### PR TITLE
Make orchestrator timeout activity-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tmux attach -t agents
 
 The background daemon runs directly as a macOS LaunchAgent, which is a per-user background service managed by launchd. It polls your configured message source, receives local terminal requests from `relaymux ask`, runs your orchestrator command, and sends replies. It does **not** run inside `tmux`.
 
-The orchestrator is just a command from your config. It receives the incoming request as prompt text, and whatever it prints to stdout becomes the reply. Use a non-interactive command whose stdout is a clean final response; if a CLI mixes logs into stdout, wrap it. If the orchestrator exits nonzero or times out, relaymux sends an error update instead.
+The orchestrator is just a command from your config. It receives the incoming request as prompt text, and whatever it prints to stdout becomes the reply. Use a non-interactive command whose stdout is a clean final response; if a CLI mixes logs into stdout, wrap it. If the orchestrator exits nonzero or times out, relaymux sends an error update instead. For orchestrators with `timeoutMs`, the default `timeoutMode` is `activity`: relaymux treats stdout/stderr and known Pi session-file writes as heartbeats, so healthy long turns are not killed by a fixed wall-clock timer.
 
 The default setup uses [Pi](https://github.com/earendil-works/pi) in non-interactive mode. Pi can use shell tools, so it can decide to run `relaymux launch` for longer work. You can replace Pi with any command that accepts a prompt and prints a reply, but that command can only launch delegated agents if it has a way to run shell commands.
 
@@ -146,7 +146,9 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
   "orchestrator": {
     "cwd": "~",
     "command": ["pi", "--print", "--continue", "--session-dir", "~/.relaymux/state/sessions", "{prompt}"],
-    "promptMode": "arg"
+    "promptMode": "arg",
+    "timeoutMs": 0,
+    "timeoutMode": "activity"
   },
   "agents": {
     "pi": {

--- a/examples/config.imsg.json
+++ b/examples/config.imsg.json
@@ -45,6 +45,8 @@
     "command": ["pi", "{prompt}"],
     "promptMode": "arg",
     "timeoutMs": 0,
+    "timeoutMode": "activity",
+    "hardTimeoutMs": 0,
     "systemPromptFile": "",
     "extraSystemPrompt": ""
   },

--- a/src/async-process.ts
+++ b/src/async-process.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { spawn } from "node:child_process";
 
 export function runCommandAsync(command: string, args: string[] = [], options: any = {}): Promise<any> {
@@ -9,31 +10,82 @@ export function runCommandAsync(command: string, args: string[] = [], options: a
     });
 
     const maxBuffer = options.maxBuffer ?? 10 * 1024 * 1024;
+    const timeoutMs = Number(options.timeoutMs || 0);
+    const hardTimeoutMs = Number(options.hardTimeoutMs || 0);
+    const timeoutMode = options.timeoutMode === "activity" ? "activity" : "wall";
+    const activityPaths = Array.isArray(options.activityPaths) ? options.activityPaths.filter(Boolean).map(String) : [];
     let stdout = "";
     let stderr = "";
     let settled = false;
     let timedOut = false;
+    let timeoutReason = "";
+    let timeoutAfterMs = timeoutMs;
+    let lastActivityAt = Date.now();
+    let lastActivityReason = "process start";
+    let lastActivityPathMtimeMs = maxActivityPathMtime(activityPaths);
+    let activityTimer = null;
+    let wallTimer = null;
+    let hardTimer = null;
+
+    const markActivity = (reason) => {
+      lastActivityAt = Date.now();
+      lastActivityReason = reason;
+    };
+
+    const clearTimers = () => {
+      if (activityTimer) clearInterval(activityTimer);
+      if (wallTimer) clearTimeout(wallTimer);
+      if (hardTimer) clearTimeout(hardTimer);
+    };
 
     const finish = (fn, value) => {
       if (settled) return;
       settled = true;
-      if (timer) clearTimeout(timer);
+      clearTimers();
       fn(value);
     };
 
-    const timer = options.timeoutMs && options.timeoutMs > 0
-      ? setTimeout(() => {
-          timedOut = true;
-          child.kill("SIGTERM");
-          setTimeout(() => {
-            if (!settled) child.kill("SIGKILL");
-          }, 1000).unref?.();
-        }, options.timeoutMs)
-      : null;
-    timer?.unref?.();
+    const killForTimeout = (reason, afterMs) => {
+      if (settled || timedOut) return;
+      timedOut = true;
+      timeoutReason = reason;
+      timeoutAfterMs = afterMs;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 1000).unref?.();
+    };
+
+    const refreshActivityPaths = () => {
+      const mtimeMs = maxActivityPathMtime(activityPaths);
+      if (mtimeMs > lastActivityPathMtimeMs) {
+        lastActivityPathMtimeMs = mtimeMs;
+        markActivity("activity file updated");
+      }
+    };
+
+    if (timeoutMs > 0 && timeoutMode === "activity") {
+      const intervalMs = Number(options.activityCheckIntervalMs || Math.max(25, Math.min(1000, Math.floor(timeoutMs / 4))));
+      activityTimer = setInterval(() => {
+        refreshActivityPaths();
+        if (Date.now() - lastActivityAt >= timeoutMs) {
+          killForTimeout("inactivity", timeoutMs);
+        }
+      }, intervalMs);
+      activityTimer.unref?.();
+    } else if (timeoutMs > 0) {
+      wallTimer = setTimeout(() => killForTimeout("wall", timeoutMs), timeoutMs);
+      wallTimer.unref?.();
+    }
+
+    if (hardTimeoutMs > 0) {
+      hardTimer = setTimeout(() => killForTimeout("hard", hardTimeoutMs), hardTimeoutMs);
+      hardTimer.unref?.();
+    }
 
     const append = (which, chunk) => {
       const text = chunk.toString("utf8");
+      markActivity(which);
       if (which === "stdout") stdout += text;
       else stderr += text;
       if (stdout.length + stderr.length > maxBuffer) {
@@ -56,15 +108,26 @@ export function runCommandAsync(command: string, args: string[] = [], options: a
 
     child.on("close", (status, signal) => {
       const code = status ?? 1;
-      const result = { status: code, signal, stdout, stderr };
+      const result = {
+        status: code,
+        signal,
+        stdout,
+        stderr,
+        timedOut,
+        timeoutReason,
+        timeoutMs: timeoutAfterMs,
+        lastActivityAt: new Date(lastActivityAt).toISOString(),
+        lastActivityReason,
+      };
       if (timedOut) {
-        const error: any = new Error(`${command} timed out after ${options.timeoutMs}ms`);
+        const detail = timeoutReason === "inactivity" ? " without output or activity" : "";
+        const error: any = new Error(`${command} timed out after ${timeoutAfterMs}ms${detail}`);
         Object.assign(error, result);
         finish(reject, error);
         return;
       }
       if (code !== 0 && !options.allowFailure) {
-        const error: any = new Error(stderr.trim() || `${command} ${args.join(" ")} exited with ${code}`);
+        const error: any = new Error(`${command} exited with ${code}`);
         Object.assign(error, result);
         finish(reject, error);
         return;
@@ -78,4 +141,14 @@ export function runCommandAsync(command: string, args: string[] = [], options: a
       child.stdin.end();
     }
   });
+}
+
+function maxActivityPathMtime(activityPaths: string[]) {
+  let max = 0;
+  for (const activityPath of activityPaths) {
+    try {
+      max = Math.max(max, fs.statSync(activityPath).mtimeMs);
+    } catch {}
+  }
+  return max;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,8 @@ export function defaultConfig(env = process.env) {
       command: ["pi", "{prompt}"],
       promptMode: "arg",
       timeoutMs: 0,
+      timeoutMode: "activity",
+      hardTimeoutMs: 0,
       maxBufferBytes: 10 * 1024 * 1024,
       systemPromptFile: "",
       extraSystemPrompt: "",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -285,8 +285,14 @@ async function closeServer(server) {
 
 function describeError(error) {
   const parts = [error?.message || String(error)];
-  if (error?.stdout?.trim()) parts.push(`stdout: ${error.stdout.trim()}`);
-  if (error?.stderr?.trim()) parts.push(`stderr: ${error.stderr.trim()}`);
+  const stdoutBytes = Buffer.byteLength(String(error?.stdout || ""));
+  const stderrBytes = Buffer.byteLength(String(error?.stderr || ""));
+  if (stdoutBytes) parts.push(`stdout captured: ${stdoutBytes} bytes`);
+  if (stderrBytes) parts.push(`stderr captured: ${stderrBytes} bytes`);
+  if (error?.lastActivityAt) {
+    parts.push(`last activity: ${error.lastActivityAt}${error.lastActivityReason ? ` (${error.lastActivityReason})` : ""}`);
+  }
+  if (error?.signal) parts.push(`signal: ${error.signal}`);
   return parts.join("\n");
 }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -106,6 +106,10 @@ export async function runOrchestrator(config, { prompt, stateDir, configPath, re
     env,
     input,
     timeoutMs: Number(orchestrator.timeoutMs || 0),
+    timeoutMode: orchestrator.timeoutMode || "activity",
+    hardTimeoutMs: Number(orchestrator.hardTimeoutMs || 0),
+    activityCheckIntervalMs: Number(orchestrator.activityCheckIntervalMs || 0),
+    activityPaths: resolveOrchestratorActivityPaths(invocation.argv),
     maxBuffer: Number(orchestrator.maxBufferBytes || 10 * 1024 * 1024),
   });
 
@@ -131,6 +135,37 @@ function sanitizeFilePart(value) {
 
 function makeRequestId() {
   return `orch-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+}
+
+function resolveOrchestratorActivityPaths(argv) {
+  const paths = [];
+  for (let index = 0; index < argv.length - 1; index += 1) {
+    const value = String(argv[index + 1] || "");
+    if (argv[index] === "--session" && (value.includes("/") || value.endsWith(".jsonl"))) {
+      paths.push(expandPath(value));
+    }
+    if (argv[index] === "--session-dir") {
+      const latest = latestJsonlFile(expandPath(value));
+      if (latest) paths.push(latest);
+    }
+  }
+  return Array.from(new Set(paths));
+}
+
+function latestJsonlFile(dir) {
+  try {
+    let latest = null;
+    for (const entry of fs.readdirSync(dir)) {
+      if (!entry.endsWith(".jsonl")) continue;
+      const file = path.join(dir, entry);
+      const stat = fs.statSync(file);
+      if (!stat.isFile()) continue;
+      if (!latest || stat.mtimeMs > latest.mtimeMs) latest = { file, mtimeMs: stat.mtimeMs };
+    }
+    return latest?.file || null;
+  } catch {
+    return null;
+  }
 }
 
 function formatHostForUrl(host) {

--- a/test/async-process.test.ts
+++ b/test/async-process.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runCommandAsync } from "../src/async-process.js";
+
+test("runCommandAsync wall timeout rejects", async () => {
+  await assert.rejects(
+    runCommandAsync(process.execPath, ["-e", "setTimeout(() => {}, 500)"], { timeoutMs: 50 }),
+    /timed out after 50ms/,
+  );
+});
+
+test("runCommandAsync activity timeout resets on stdout", async () => {
+  const script = `let n = 0;
+const timer = setInterval(() => {
+  console.log('tick');
+  n += 1;
+  if (n === 3) {
+    clearInterval(timer);
+    setTimeout(() => process.exit(0), 50);
+  }
+}, 50);`;
+
+  const result = await runCommandAsync(process.execPath, ["-e", script], {
+    timeoutMs: 200,
+    timeoutMode: "activity",
+    activityCheckIntervalMs: 20,
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /tick/);
+});
+
+test("runCommandAsync activity timeout resets on watched file changes", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-activity-"));
+  const activityFile = path.join(dir, "session.jsonl");
+  fs.writeFileSync(activityFile, "");
+  const script = `const fs = require('node:fs');
+const file = process.argv[1];
+let n = 0;
+const timer = setInterval(() => {
+  fs.appendFileSync(file, '.');
+  n += 1;
+  if (n === 4) {
+    clearInterval(timer);
+    setTimeout(() => process.exit(0), 50);
+  }
+}, 50);`;
+
+  const result = await runCommandAsync(process.execPath, ["-e", script, activityFile], {
+    timeoutMs: 200,
+    timeoutMode: "activity",
+    activityPaths: [activityFile],
+    activityCheckIntervalMs: 20,
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(fs.readFileSync(activityFile, "utf8"), "....");
+});
+
+test("runCommandAsync activity timeout rejects when idle", async () => {
+  await assert.rejects(
+    runCommandAsync(process.execPath, ["-e", "setTimeout(() => {}, 500)"], {
+      timeoutMs: 50,
+      timeoutMode: "activity",
+      activityCheckIntervalMs: 10,
+    }),
+    (error: any) => {
+      assert.match(error.message, /timed out after 50ms without output or activity/);
+      assert.equal(error.timedOut, true);
+      assert.equal(error.timeoutReason, "inactivity");
+      assert.equal(error.lastActivityReason, "process start");
+      return true;
+    },
+  );
+});
+
+test("runCommandAsync nonzero error omits command arguments", async () => {
+  await assert.rejects(
+    runCommandAsync(process.execPath, ["-e", "process.exit(7)", "secret-argument"], {}),
+    (error: any) => {
+      assert.equal(error.message, `${process.execPath} exited with 7`);
+      assert.doesNotMatch(error.message, /secret-argument/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
Fix relaymux orchestrator turns being killed while Pi is still actively working or compacting its session.

- `orchestrator.timeoutMs` now defaults to activity/inactivity semantics instead of a hard wall clock.
- Timeout diagnostics no longer dump captured stdout/stderr contents into daemon logs.

## Design
### Activity-aware subprocess timeouts
- `src/async-process.ts` — adds `timeoutMode: "activity"`, optional `hardTimeoutMs`, stdout/stderr activity tracking, watched activity-file mtimes, and richer timeout metadata.
- `src/orchestrator.ts` — runs the orchestrator with activity timeout mode by default and watches Pi session JSONL files from `--session` or the latest file in `--session-dir`.
- `src/config.ts` — adds default `orchestrator.timeoutMode: "activity"` and `hardTimeoutMs: 0`.

### Safer diagnostics and docs
- `src/daemon.ts` — changes daemon error descriptions to log captured byte counts and last activity metadata instead of full stdout/stderr contents.
- `README.md` and `examples/config.imsg.json` — document the activity-timeout behavior and example config knobs.

### Tests
- `test/async-process.test.ts` — covers wall timeouts, activity timeout resets from stdout, activity timeout resets from watched session-file changes, idle activity timeout rejection, and omitting sensitive command args from nonzero errors.

## Validation
- `npm run validate` — passed (`tsc --noEmit`, 48 node tests, `tsc` build).
