### PR TITLE
Harden relaymux iMessage bridge restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ relaymux doctor
 relaymux status
 ```
 
+`relaymux setup` is the new-user path: it creates `~/.relaymux/config.json`, discovers recent `imsg` chats when possible, installs/loads the macOS LaunchAgent, and prints next steps. A healthy install should show `ok background-service ... LaunchAgent loaded` in `relaymux doctor`. If it says the service is not loaded, run `relaymux restart-launch-agent` from a normal terminal.
+
 `relaymux setup` tries to list recent Messages chats through `imsg chats --json` and prompts you to choose one. If discovery does not work, pass the chat id or phone number yourself:
 
 ```bash
@@ -287,6 +289,17 @@ tmux kill-session -t agents
 It does not uninstall relaymux or stop the LaunchAgent.
 
 ## Troubleshooting
+
+### Background service unloaded after a restart
+
+If `relaymux status-launch-agent` says `not loaded`, reload it from a normal terminal:
+
+```bash
+relaymux restart-launch-agent
+relaymux status-launch-agent
+```
+
+relaymux protects against the common self-restart trap: when `restart-launch-agent` is invoked from inside the relaymux LaunchAgent, it now schedules a short-lived helper LaunchAgent to do the reload after the current chat turn has time to reply. Direct `launchctl bootout` from inside the daemon can kill the daemon before it marks the message seen.
 
 ### Messages permissions
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -121,6 +121,10 @@ async function handleSetup(flags, io) {
   const status = handleDoctor(configInfo, io);
   if (status === 0) {
     io.stdout.write("Setup complete. relaymux is ready.\n");
+    io.stdout.write("Next steps:\n");
+    io.stdout.write("  1. Text the configured chat; relaymux should reply from the background LaunchAgent.\n");
+    io.stdout.write("  2. Run `relaymux status` to inspect the daemon and any tmux agent tabs.\n");
+    io.stdout.write("  3. Use `relaymux launch --repo <path> --agent pi --prompt <task>` for a manual first agent.\n");
   } else {
     io.stderr.write("Setup completed, but doctor found missing requirements. Fix the missing checks above and re-run `relaymux doctor`.\n");
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export function defaultConfig(env = process.env) {
       launchAgentLabel: "com.relaymux.daemon",
       launchMode: "direct",
       supervisorPollMs: 15000,
+      selfRestartDelayMs: 30000,
       logDir,
     },
     orchestrator: {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { defaultConfigPath, legacyDefaultConfigPath, resolveLogDir, resolveStateDir } from "./config.js";
 import { runCommand } from "./process.js";
-import { launchAgentPath } from "./launch-agent.js";
+import { getLaunchAgentStatus, launchAgentPath } from "./launch-agent.js";
 import { defaultRelaymuxHome } from "./paths.js";
 import { webhookStatus } from "./webhook.js";
 
@@ -97,10 +97,16 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
     ok: !webhook.tokenFileExists || webhook.tokenFileMode === "0600",
     detail: webhook.tokenFileExists ? `${webhook.tokenFile} mode ${webhook.tokenFileMode}` : `will be created at ${webhook.tokenFile}`,
   });
+  const launchAgent: any = getLaunchAgentStatus(config);
+  const daemonEnabled = config.daemon?.enabled !== false;
   checks.push({
     name: "background-service",
-    ok: true,
-    detail: `direct/background LaunchAgent outside tmux: ${launchAgentPath(config)}`,
+    ok: !daemonEnabled || !launchAgent.supported || launchAgent.loaded,
+    detail: daemonEnabled
+      ? launchAgent.supported
+        ? `direct/background LaunchAgent ${launchAgent.loaded ? "loaded" : "not loaded"}: ${launchAgentPath(config)}${launchAgent.detail ? ` (${launchAgent.detail})` : ""}`
+        : `direct/background LaunchAgent unsupported on ${process.platform}: ${launchAgentPath(config)}`
+      : "disabled in config",
   });
 
   for (const [name, agent] of Object.entries((config.agents ?? {}) as Record<string, any>)) {

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { resolveLogDir } from "./config.js";
+import { quoteArgv } from "./command.js";
 import { expandPath, ensureDirectory } from "./paths.js";
 import { runCommand } from "./process.js";
 import { killWindowByName, validateSessionName } from "./tmux.js";
@@ -83,6 +84,11 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
 
   if (flags.load !== false) {
     const target = launchAgentTarget(config);
+    if (process.platform === "darwin" && isCurrentLaunchAgent(config, process.env) && flags.immediateSelfRestart !== true) {
+      scheduleLaunchAgentReloadHelper({ config, plistPath, io });
+      return plistPath;
+    }
+
     runCommand("launchctl", ["bootout", target], { allowFailure: true });
     if (process.platform === "darwin" && launchMode === "direct" && flags.keepTmuxDaemon !== true) {
       const windowName = String(flags.windowName || "relaymux-daemon");
@@ -195,6 +201,83 @@ export function uninstallLaunchAgent({ config, io }) {
     io.stdout.write(`No LaunchAgent found at ${plistPath}\n`);
   }
   return plistPath;
+}
+
+export function isCurrentLaunchAgent(config, env = process.env) {
+  const label = launchAgentLabel(config);
+  return env.XPC_SERVICE_NAME === label || env.LAUNCHD_JOB_LABEL === label;
+}
+
+export function scheduleLaunchAgentReloadHelper({ config, plistPath, io }) {
+  const mainLabel = launchAgentLabel(config);
+  const helperLabel = `${mainLabel}.reload.${process.pid}.${Date.now()}`;
+  const helperPlistPath = path.join(os.homedir(), "Library", "LaunchAgents", `${helperLabel}.plist`);
+  const logDir = resolveLogDir(config);
+  const scriptPath = path.join(logDir, `${helperLabel}.sh`);
+  const logPath = path.join(logDir, "launch-agent-reload.log");
+  const domain = launchAgentDomain();
+  const target = launchAgentTarget(config);
+  const helperTarget = `${domain}/${helperLabel}`;
+  const delaySeconds = Math.max(1, Math.ceil(Number(config.daemon?.selfRestartDelayMs || 30000) / 1000));
+
+  ensureDirectory(path.dirname(helperPlistPath));
+  ensureDirectory(logDir);
+  fs.writeFileSync(scriptPath, renderLaunchAgentReloadScript({
+    delaySeconds,
+    domain,
+    helperPlistPath,
+    helperTarget,
+    plistPath,
+    scriptPath,
+    target,
+  }), { mode: 0o700 });
+  try { fs.chmodSync(scriptPath, 0o700); } catch {}
+
+  const helperPlist = renderLaunchAgentPlist({
+    label: helperLabel,
+    programArguments: ["/bin/sh", scriptPath],
+    workingDirectory: os.homedir(),
+    environment: {
+      PATH: defaultLaunchPath(),
+      HOME: os.homedir(),
+    },
+    standardOutPath: logPath,
+    standardErrorPath: logPath,
+    keepAlive: false,
+  });
+  fs.writeFileSync(helperPlistPath, helperPlist, { mode: 0o644 });
+
+  runCommand("launchctl", ["bootout", helperTarget], { allowFailure: true });
+  const result = runCommand("launchctl", ["bootstrap", domain, helperPlistPath], { allowFailure: true });
+  if (result.status !== 0) {
+    throw new Error(`Could not schedule LaunchAgent reload helper (${result.status}): ${firstLine(result.stderr) || firstLine(result.stdout)}`);
+  }
+  runCommand("launchctl", ["kickstart", "-k", helperTarget], { allowFailure: true });
+  io.stdout.write(`Scheduled LaunchAgent reload helper ${helperLabel} in ${delaySeconds}s; log ${logPath}\n`);
+  return helperPlistPath;
+}
+
+export function renderLaunchAgentReloadScript({ delaySeconds, domain, helperPlistPath, helperTarget, plistPath, scriptPath, target }) {
+  return [
+    "#!/bin/sh",
+    "set -u",
+    `sleep ${Math.max(1, Number(delaySeconds) || 1)}`,
+    `printf '[%s] reloading %s from %s\\n' "$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)" ${quoteArgv([target])} ${quoteArgv([plistPath])}`,
+    `${quoteArgv(["launchctl", "bootout", target])} >/dev/null 2>&1 || true`,
+    "sleep 1",
+    `${quoteArgv(["launchctl", "enable", target])} >/dev/null 2>&1 || true`,
+    `if ${quoteArgv(["launchctl", "bootstrap", domain, plistPath])}; then`,
+    `  ${quoteArgv(["launchctl", "kickstart", "-k", target])} >/dev/null 2>&1 || true`,
+    `  ${quoteArgv(["launchctl", "print", target])} || true`,
+    "else",
+    "  status=$?",
+    "  echo \"bootstrap failed with status $status\"",
+    `  ${quoteArgv(["launchctl", "print", target])} || true`,
+    "  exit \"$status\"",
+    "fi",
+    `${quoteArgv(["rm", "-f", helperPlistPath, scriptPath])} || true`,
+    `${quoteArgv(["launchctl", "bootout", helperTarget])} >/dev/null 2>&1 || true`,
+  ].join("\n") + "\n";
 }
 
 export function launchAgentDomain() {

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -127,13 +127,21 @@ export async function sendMessage(config: any, text: string, io: any = process) 
 
   const commandConfig = send.command || {};
   for (const chunk of chunks) {
-    const argv = buildAdapterArgv(commandConfig, messageContext(config, { text: chunk }));
+    const argv = buildAdapterArgv(commandConfig, messageContext(config, { text: commandSafeMessageText(chunk) }));
     await runCommandAsync(argv[0], argv.slice(1), {
       cwd: expandPath(commandConfig.cwd || "~"),
       timeoutMs: Number(commandConfig.timeoutMs || 60000),
       maxBuffer: Number(commandConfig.maxBufferBytes || 10 * 1024 * 1024),
     });
   }
+}
+
+export function commandSafeMessageText(text) {
+  const value = String(text || "");
+  // imsg 0.8.x does not accept option values that start with "-" when they are
+  // passed as the argv element after --text. Prefix an invisible character so
+  // bullet-list replies like "- fixed X" do not get parsed as more flags.
+  return value.startsWith("-") ? `\u200B${value}` : value;
 }
 
 export function messageContext(config, extra = {}) {

--- a/test/launch-agent.test.ts
+++ b/test/launch-agent.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { defaultConfig } from "../src/config.js";
-import { installLaunchAgent, parseLaunchCtlPrint, renderLaunchAgentPlist } from "../src/launch-agent.js";
+import { installLaunchAgent, isCurrentLaunchAgent, parseLaunchCtlPrint, renderLaunchAgentPlist, renderLaunchAgentReloadScript } from "../src/launch-agent.js";
 
 
 test("renderLaunchAgentPlist escapes XML and includes daemon args", () => {
@@ -69,6 +69,36 @@ test("installLaunchAgent direct dry-run does not invoke tmux or set tmux environ
   assert.doesNotMatch(stdout, /<string>tmux<\/string>/);
   assert.doesNotMatch(stdout, /TMUX/);
   assert.doesNotMatch(stdout, /RELAYMUX_SESSION/);
+});
+
+test("isCurrentLaunchAgent detects inherited launchd service context", () => {
+  const config = {
+    ...defaultConfig(),
+    daemon: {
+      ...defaultConfig().daemon,
+      launchAgentLabel: "com.example.relaymux",
+    },
+  };
+
+  assert.equal(isCurrentLaunchAgent(config, { XPC_SERVICE_NAME: "com.example.relaymux" }), true);
+  assert.equal(isCurrentLaunchAgent(config, { XPC_SERVICE_NAME: "com.example.other" }), false);
+});
+
+test("renderLaunchAgentReloadScript bootouts and bootstraps the main service", () => {
+  const script = renderLaunchAgentReloadScript({
+    delaySeconds: 15,
+    domain: "gui/501",
+    helperPlistPath: "/tmp/helper.plist",
+    helperTarget: "gui/501/com.example.relaymux.reload.1",
+    plistPath: "/tmp/main.plist",
+    scriptPath: "/tmp/helper.sh",
+    target: "gui/501/com.example.relaymux",
+  });
+
+  assert.match(script, /sleep 15/);
+  assert.match(script, /launchctl bootout gui\/501\/com.example.relaymux/);
+  assert.match(script, /launchctl bootstrap gui\/501 \/tmp\/main.plist/);
+  assert.match(script, /com.example.relaymux.reload.1/);
 });
 
 test("parseLaunchCtlPrint extracts running status", () => {

--- a/test/message-io.test.ts
+++ b/test/message-io.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildAdapterArgv,
+  commandSafeMessageText,
   formatIncomingForPrompt,
   isIncomingUserMessage,
   normalizeMessages,
@@ -37,6 +38,11 @@ test("buildAdapterArgv renders command placeholders", () => {
     buildAdapterArgv({ argv: ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}"] }, { chatId: "1", text: "hello" }),
     ["imsg", "send", "--chat-id", "1", "--text", "hello"],
   );
+});
+
+test("commandSafeMessageText protects dash-leading replies from option parsing", () => {
+  assert.equal(commandSafeMessageText("hello"), "hello");
+  assert.equal(commandSafeMessageText("- bullet"), "\u200B- bullet");
 });
 
 test("formatIncomingForPrompt is generic", () => {


### PR DESCRIPTION
## Summary
Harden the relaymux iMessage bridge so daemon restarts and outgoing replies do not silently break the background service.

- Avoid self-terminating the LaunchAgent when restart is invoked from inside the daemon.
- Make `doctor` catch unloaded background services and improve setup/onboarding guidance.

## Design
### LaunchAgent restart safety
- `src/launch-agent.ts` — detects when reload/install is being invoked from the current LaunchAgent via launchd environment, then schedules a short-lived helper LaunchAgent instead of directly booting out itself.
- `src/launch-agent.ts` — adds the helper script/plist generation path, delayed reload, logging to `launch-agent-reload.log`, and cleanup of helper artifacts after bootstrap.
- `src/config.ts` — adds `daemon.selfRestartDelayMs` so the deferred self-restart delay is configurable.
- `test/launch-agent.test.ts` — covers LaunchAgent self-context detection and generated helper reload script shape.

### iMessage send robustness and diagnostics
- `src/message-io.ts` — prefixes dash-leading outgoing chunks with an invisible character so `imsg send --text` does not parse bullet-list replies as options.
- `src/doctor.ts` — checks actual LaunchAgent load state with `getLaunchAgentStatus` instead of reporting success when only the plist exists.
- `test/message-io.test.ts` — covers the dash-leading outgoing text regression.

### New-user onboarding
- `src/cli.ts` — prints concrete next steps after successful `relaymux setup`.
- `README.md` — documents the setup success condition and the background-service recovery/self-restart behavior.

## Validation
- `npm test` — passed, 51 tests.
- `npm run build` — passed.
- Local smoke before PR: installed the built relaymux, restarted the LaunchAgent, simulated an in-daemon restart via `XPC_SERVICE_NAME=com.avyay.relaymux-imessage relaymux restart-launch-agent`, and verified the helper reloaded the main LaunchAgent and cleaned up its helper files.
