### PR TITLE
Add guardrails for delegated agent launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
     "sessionMode": "shared",
     "sessionPrefix": "rmx"
   },
+  "launchNotifications": {
+    "onExit": "never",
+    "replyMode": "imessage",
+    "tailLines": 80,
+    "tailBytes": 4000
+  },
   "daemon": {
     "enabled": true,
     "host": "127.0.0.1",
@@ -158,7 +164,7 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
       "promptMode": "arg"
     },
     "codex": {
-      "command": ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"],
+      "command": ["codex", "--model", "gpt-5.5", "{prompt}"],
       "promptMode": "arg"
     },
     "claude": {
@@ -242,6 +248,46 @@ relaymux notify \
 `--reply-mode imessage` asks the daemon to send a user-visible text update. `--reply-mode none` still re-prompts the daemon/orchestrator path, but suppresses the outgoing iMessage. Use it for progress notes that should affect the orchestrator's context or logs without texting the user. Whether that context persists depends on your orchestrator command; the default Pi command uses `--continue` with a relaymux session directory.
 
 The idempotency key is a stable de-duplication string for one logical update. If a delegated agent retries the same completion notification, reuse the same key so relaymux does not send duplicate text messages.
+
+## Delegated-run guardrails
+
+`relaymux doctor` statically checks configured agent command templates for known stale flags before you launch. For Codex, it reports `--reasoning-effort` as an error because current Codex CLI releases reject that flag; remove the flag/value from `~/.relaymux/config.json` and rerun `relaymux doctor`. `relaymux launch` runs the same fatal validation before opening tmux, so a stale known flag fails in the caller instead of disappearing into a tmux tab.
+
+Every tmux launch records local `started` and `completed` events. For user-visible completion that does not depend on the subagent following prompt instructions, opt into wrapper-level exit notifications:
+
+```json
+{
+  "launchNotifications": {
+    "onExit": "failure",
+    "replyMode": "imessage",
+    "tailLines": 80,
+    "tailBytes": 4000
+  }
+}
+```
+
+`onExit` may be `never` (default), `failure`, or `always`. `failure` sends a relaymux notification only for nonzero exits; `always` also sends success notifications. `replyMode: "imessage"` asks the daemon to send a chat update. Nonzero auto-notifications include the run name, run id, exit code, and a bounded recent tmux output tail when available. You can also set this for one launch:
+
+```bash
+relaymux launch \
+  --repo ~/code/my-app \
+  --agent codex \
+  --name email-draft \
+  --notify-on-exit always \
+  --notify-reply-mode imessage \
+  --prompt @prompt.txt
+```
+
+Still include an explicit completion instruction in delegated prompts for richer summaries:
+
+```text
+When done or blocked, run:
+relaymux notify --from email-draft --reply-mode imessage \
+  --idempotency-key email-draft-<date>-done \
+  --message "Finished: summary, validation, blockers."
+```
+
+The wrapper-level notification is a fallback; the explicit `relaymux notify` should carry the useful human summary.
 
 ## Migrating old relaymux-managed files
 

--- a/examples/config.imsg.json
+++ b/examples/config.imsg.json
@@ -6,6 +6,12 @@
     "sessionMode": "shared",
     "sessionPrefix": "rmx"
   },
+  "launchNotifications": {
+    "onExit": "never",
+    "replyMode": "imessage",
+    "tailLines": 80,
+    "tailBytes": 4000
+  },
   "imessage": {
     "chatId": "CHAT_ID_OR_PHONE",
     "recipient": "+15555550123",
@@ -52,7 +58,7 @@
   },
   "agents": {
     "pi": { "command": ["pi", "{prompt}"], "promptMode": "arg" },
-    "codex": { "command": ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"], "promptMode": "arg" },
+    "codex": { "command": ["codex", "--model", "gpt-5.5", "{prompt}"], "promptMode": "arg" },
     "claude": { "command": ["claude", "{prompt}"], "promptMode": "arg" }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 
 import { parseArgv } from "./args.js";
 import { buildAgentInvocation, buildTmuxShellCommand, buildTmuxShellScript, quoteArgv, renderTemplate, shellExportBlock } from "./command.js";
+import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
 import { defaultConfigPath, loadConfig, resolveLogDir, resolveStateDir, writeConfig, writeDefaultConfig } from "./config.js";
 import { runDaemon } from "./daemon.js";
@@ -214,6 +215,7 @@ function handleLaunch(flags, configInfo, stateDir, io) {
   if (!agentConfig) {
     throw new Error(`Unknown agent "${agentName}". Add it to your config under agents.`);
   }
+  assertNoFatalCommandFindings(agentName, agentConfig, { location: `agents.${agentName}` });
 
   const prompt = resolvePrompt(flags);
   const runId = flags.runId || makeRunId();
@@ -222,6 +224,7 @@ function handleLaunch(flags, configInfo, stateDir, io) {
   const sessionInfo = resolveLaunchSession({ flags, config, env: io.env, repo, workdir, name });
   const session = sessionInfo.session;
   const holdOnExit = flags.hold ?? config.holdOnExit ?? false;
+  const launchNotification = resolveLaunchNotification(flags, config);
 
   if (flags.dryRun) {
     const promptFile = path.join(stateDir, "prompts", `${runId}.txt`);
@@ -231,6 +234,7 @@ function handleLaunch(flags, configInfo, stateDir, io) {
       cliPath: process.argv[1],
       configPath: configInfo.path,
       holdOnExit,
+      launchNotification,
       name,
       prompt,
       promptFile,
@@ -261,6 +265,7 @@ function handleLaunch(flags, configInfo, stateDir, io) {
     cliPath: process.argv[1],
     configPath: configInfo.path,
     holdOnExit,
+    launchNotification,
     name,
     prompt,
     promptFile,
@@ -601,6 +606,29 @@ function buildLaunchShellScript(agentName, agentConfig, context) {
   return buildTmuxShellScript(invocation, context);
 }
 
+function resolveLaunchNotification(flags, config) {
+  const configured = config.launchNotifications || {};
+  const onExit = String(flags.notifyOnExit ?? configured.onExit ?? configured.notifyOnExit ?? "never");
+  const replyMode = String(flags.notifyReplyMode ?? configured.replyMode ?? "imessage");
+  const tailLines = normalizePositiveInteger(flags.notifyTailLines ?? configured.tailLines, 80);
+  const tailBytes = normalizePositiveInteger(flags.notifyTailBytes ?? configured.tailBytes, 4000);
+
+  if (!["never", "failure", "always"].includes(onExit)) {
+    throw new Error("--notify-on-exit / launchNotifications.onExit must be never, failure, or always");
+  }
+  if (!["imessage", "none"].includes(replyMode)) {
+    throw new Error("--notify-reply-mode / launchNotifications.replyMode must be imessage or none");
+  }
+
+  return { onExit, replyMode, tailLines, tailBytes };
+}
+
+function normalizePositiveInteger(value, fallback) {
+  const number = Number(value ?? fallback);
+  if (!Number.isFinite(number) || number < 1) return fallback;
+  return Math.floor(number);
+}
+
 function handleStatus(flags, configInfo, stateDir, io) {
   const config = configInfo.config;
   const session = flags.session ? String(flags.session) : undefined;
@@ -705,9 +733,16 @@ function targetTab(target) {
 function handleDoctor(configInfo, io) {
   const checks = collectDoctorChecks(configInfo.config, configInfo, io.env);
   for (const check of checks) {
-    io.stdout.write(`${check.ok ? "ok" : "missing"}\t${check.name}\t${check.detail}\n`);
+    io.stdout.write(`${doctorStatusLabel(check)}\t${check.name}\t${check.detail}\n`);
   }
-  return checks.every((check) => check.ok || check.name.startsWith("agent:")) ? 0 : 1;
+  return checks.every((check) => check.ok || check.fatal === false || check.severity === "warning") ? 0 : 1;
+}
+
+function doctorStatusLabel(check) {
+  if (check.ok) return "ok";
+  if (check.severity === "warning") return "warning";
+  if (check.severity === "error") return "error";
+  return "missing";
 }
 
 function resolvePrompt(flags) {
@@ -860,7 +895,7 @@ Usage:
   relaymux restart-launch-agent [--dry-run] [--no-load]
   relaymux status-launch-agent [--json]
   relaymux uninstall-launch-agent
-  relaymux launch --repo <path> --agent <name> --prompt <text|@file> [--name <name>]
+  relaymux launch --repo <path> --agent <name> --prompt <text|@file> [--name <name>] [--notify-on-exit never|failure|always]
   relaymux ask <text> [--no-wait] [--reply-mode imessage|none]
   relaymux status [--json] [--session <name>]
   relaymux notify [--run-id <id>] [--reply-mode imessage|none] [--message <text>]
@@ -894,6 +929,10 @@ Launch options:
   --print-command            Print the tmux tab command before launching
   --hold                     Keep a shell open after the agent exits
   --attach                   Print attach command after launch
+  --notify-on-exit <mode>    Auto relaymux notify on agent exit: never (default), failure, or always
+  --notify-reply-mode <mode> imessage sends chat updates; none records quiet completion context
+  --notify-tail-lines <n>    Recent tmux output lines to include for nonzero auto notifications
+  --notify-tail-bytes <n>    Max bytes of recent tmux output in nonzero auto notifications
 
 Background service options:
   --no-load                  Write the LaunchAgent plist without loading it

--- a/src/command-validation.ts
+++ b/src/command-validation.ts
@@ -1,0 +1,81 @@
+import path from "node:path";
+
+const VALID_PROMPT_MODES = new Set(["arg", "env", "none", "stdin"]);
+const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function validateConfiguredAgentCommand(agentName, agentConfig, { location = `agents.${agentName}` } = {}) {
+  const findings: any[] = [];
+  if (!agentConfig || !Array.isArray(agentConfig.command) || agentConfig.command.length === 0) {
+    findings.push(errorFinding(`${location}.command must be a non-empty command array`));
+    return findings;
+  }
+
+  const promptMode = agentConfig.promptMode ?? "arg";
+  if (!VALID_PROMPT_MODES.has(promptMode)) {
+    findings.push(errorFinding(`${location}.promptMode must be one of arg, env, none, or stdin (got ${JSON.stringify(promptMode)})`));
+  }
+
+  for (const key of Object.keys(agentConfig.env ?? {})) {
+    if (!ENV_KEY.test(key)) {
+      findings.push(errorFinding(`${location}.env contains invalid environment key ${JSON.stringify(key)}`));
+    }
+  }
+
+  findings.push(...validateKnownCliCommand(agentConfig.command, { location: `${location}.command` }));
+  return findings;
+}
+
+export function validateKnownCliCommand(command, { location = "command" } = {}) {
+  if (!Array.isArray(command) || command.length === 0) return [];
+
+  const executable = executableName(command[0]);
+  if (executable === "codex") {
+    return validateCodexCommand(command, { location });
+  }
+  if (executable === "pi" || executable === "claude") {
+    return [];
+  }
+  return [];
+}
+
+export function assertNoFatalCommandFindings(agentName, agentConfig, options: any = {}) {
+  const findings = validateConfiguredAgentCommand(agentName, agentConfig, options);
+  const fatal = findings.filter((finding) => finding.severity !== "warning");
+  if (!fatal.length) return findings;
+
+  const details = fatal.map((finding) => `- ${finding.detail}`).join("\n");
+  throw new Error(`Agent "${agentName}" command failed validation:\n${details}\nRun \`relaymux doctor\` after editing your config.`);
+}
+
+function validateCodexCommand(command, { location }) {
+  const findings: any[] = [];
+  for (let index = 1; index < command.length; index += 1) {
+    const part = String(command[index]);
+    if (isReasoningEffortFlag(part)) {
+      const value = flagValue(part, command[index + 1]);
+      findings.push(errorFinding(
+        `${location} contains ${value}. Current Codex CLI rejects --reasoning-effort; remove that flag/value from your relaymux config or replace it with a Codex-supported option.`,
+      ));
+    }
+  }
+  return findings;
+}
+
+function isReasoningEffortFlag(part) {
+  return part === "--reasoning-effort" || part.startsWith("--reasoning-effort=") || /^--reasoning-effort\s+/.test(part);
+}
+
+function flagValue(part, nextPart) {
+  if (part.includes("=")) return JSON.stringify(part);
+  if (/^--reasoning-effort\s+/.test(part)) return JSON.stringify(part);
+  if (nextPart && !String(nextPart).startsWith("--")) return `${JSON.stringify(part)} ${JSON.stringify(nextPart)}`;
+  return JSON.stringify(part);
+}
+
+function executableName(value) {
+  return path.basename(String(value || ""));
+}
+
+function errorFinding(detail) {
+  return { ok: false, severity: "error", fatal: true, detail };
+}

--- a/src/command.ts
+++ b/src/command.ts
@@ -84,6 +84,7 @@ export function buildTmuxShellScript(invocation, context) {
     "--repo",
     context.repo,
   ];
+  const launchNotification = normalizeLaunchNotification(context.launchNotification);
 
   const baseEnv = {
     RELAYMUX_AGENT: context.agent,
@@ -103,7 +104,8 @@ export function buildTmuxShellScript(invocation, context) {
     (invocation.stdinFile ? ` < ${shellQuote(invocation.stdinFile)}` : "");
 
   const startedNotify = quoteArgv([...notifyBase, "--event", "started", "--message", "started"]);
-  const completedNotify = `${quoteArgv([...notifyBase, "--event", "completed", "--exit-code"])} "$status"`;
+  const completedNotify = `${quoteArgv([...notifyBase, "--event", "completed", "--exit-code"])} "$status" --message "$completion_message"`;
+  const exitNotificationBlock = buildExitNotificationBlock(notifyBase, launchNotification);
   const holdOrExit = context.holdOnExit
     ? 'printf "\\nrelaymux: holding shell open after exit %s\\n" "$status"; exec "${SHELL:-/bin/sh}"'
     : 'exit "$status"';
@@ -116,8 +118,14 @@ export function buildTmuxShellScript(invocation, context) {
     `${startedNotify} >/dev/null 2>&1 || true`,
     agentCommand,
     "status=$?",
+    'if [ "$status" -eq 0 ]; then',
+    '  completion_message="relaymux run $RELAYMUX_NAME ($RELAYMUX_RUN_ID) completed with exit 0"',
+    "else",
+    '  completion_message="relaymux run $RELAYMUX_NAME ($RELAYMUX_RUN_ID) failed with exit $status"',
+    "fi",
     `${completedNotify} >/dev/null 2>&1 || true`,
-    'printf "\\nrelaymux: completed %s with exit %s\\n" "$RELAYMUX_RUN_ID" "$status"',
+    ...exitNotificationBlock,
+    'printf "\\nrelaymux: completed %s (%s) with exit %s\\n" "$RELAYMUX_RUN_ID" "$RELAYMUX_NAME" "$status"',
     holdOrExit,
   ].join("\n");
 }
@@ -135,4 +143,57 @@ export function shellExportBlock(env) {
       return `${key}=${shellQuote(value)}; export ${key}`;
     })
     .join("\n");
+}
+
+function buildExitNotificationBlock(notifyBase, notification) {
+  if (notification.onExit === "never") return [];
+
+  const shouldNotifyLines = notification.onExit === "always"
+    ? ["relaymux_should_notify=1"]
+    : [
+        "relaymux_should_notify=0",
+        'if [ "$status" -ne 0 ]; then relaymux_should_notify=1; fi',
+      ];
+  const notifyCommand = `${quoteArgv([...notifyBase, "--event", "completed", "--exit-code"])} "$status" --reply-mode ${shellQuote(notification.replyMode)} --idempotency-key "$relaymux_idempotency_key" --message "$relaymux_auto_message"`;
+
+  return [
+    ...shouldNotifyLines,
+    'if [ "$relaymux_should_notify" = "1" ]; then',
+    "  relaymux_tail=",
+    '  if [ "$status" -ne 0 ] && command -v tmux >/dev/null 2>&1 && [ -n "${TMUX_PANE:-}" ]; then',
+    `    relaymux_tail="$(tmux capture-pane -pt "$TMUX_PANE" -S -${notification.tailLines} 2>/dev/null | tail -n ${notification.tailLines} | tail -c ${notification.tailBytes})"`,
+    "  fi",
+    '  if [ -n "$relaymux_tail" ]; then',
+    `    relaymux_auto_message="$(printf "%s\\n\\nRecent tmux output (last ${notification.tailLines} lines, ${notification.tailBytes} bytes max):\\n%s" "$completion_message" "$relaymux_tail")"`,
+    "  else",
+    '    relaymux_auto_message="$completion_message"',
+    "  fi",
+    '  relaymux_idempotency_key="$RELAYMUX_RUN_ID-exit-$status"',
+    `  if ! ${notifyCommand} >/dev/null; then`,
+    '    printf "relaymux: exit notification failed for %s (%s) with exit %s\\n" "$RELAYMUX_RUN_ID" "$RELAYMUX_NAME" "$status" >&2',
+    "  fi",
+    "fi",
+  ];
+}
+
+function normalizeLaunchNotification(notification: any = {}) {
+  const onExit = notification.onExit || "never";
+  const replyMode = notification.replyMode || "imessage";
+  const tailLines = normalizePositiveInteger(notification.tailLines, 80);
+  const tailBytes = normalizePositiveInteger(notification.tailBytes, 4000);
+
+  if (!["never", "failure", "always"].includes(onExit)) {
+    throw new Error(`launchNotifications.onExit must be never, failure, or always (got ${JSON.stringify(onExit)})`);
+  }
+  if (!["imessage", "none"].includes(replyMode)) {
+    throw new Error(`launchNotifications.replyMode must be imessage or none (got ${JSON.stringify(replyMode)})`);
+  }
+
+  return { onExit, replyMode, tailLines, tailBytes };
+}
+
+function normalizePositiveInteger(value, fallback) {
+  const number = Number(value ?? fallback);
+  if (!Number.isFinite(number) || number < 1) return fallback;
+  return Math.floor(number);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,12 @@ export function defaultConfig(env = process.env) {
       sessionPrefix: "rmx",
       extraWindows: [],
     },
+    launchNotifications: {
+      onExit: "never",
+      replyMode: "imessage",
+      tailLines: 80,
+      tailBytes: 4000,
+    },
     imessage: {
       chatId: "CHAT_ID_OR_PHONE",
       recipient: "+15555550123",
@@ -76,8 +82,8 @@ export function defaultConfig(env = process.env) {
         promptMode: "arg",
       },
       codex: {
-        description: "Codex CLI template with model/effort flags. Edit flags to match your local install.",
-        command: ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"],
+        description: "Codex CLI template. Edit flags to match your local install.",
+        command: ["codex", "--model", "gpt-5.5", "{prompt}"],
         promptMode: "arg",
       },
       claude: {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { defaultConfigPath, legacyDefaultConfigPath, resolveLogDir, resolveStateDir } from "./config.js";
+import { validateConfiguredAgentCommand } from "./command-validation.js";
 import { runCommand } from "./process.js";
 import { getLaunchAgentStatus, launchAgentPath } from "./launch-agent.js";
 import { defaultRelaymuxHome } from "./paths.js";
@@ -115,8 +116,28 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
     checks.push({
       name: `agent:${name}`,
       ok: Boolean(executable),
+      fatal: false,
       detail: executable || `${command || "missing command"} not found on PATH`,
     });
+
+    const findings = validateConfiguredAgentCommand(name, agent, { location: `agents.${name}` });
+    if (findings.length === 0) {
+      checks.push({
+        name: `agent:${name}-command`,
+        ok: true,
+        detail: "command template passed static checks",
+      });
+    } else {
+      for (const finding of findings) {
+        checks.push({
+          name: `agent:${name}-command`,
+          ok: false,
+          severity: finding.severity,
+          fatal: finding.fatal,
+          detail: finding.detail,
+        });
+      }
+    }
   }
 
   return checks;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -20,6 +20,7 @@ Delegating with relaymux:
 - Ask subagents to report meaningful completion or blockers with relaymux notify.
 - Use --reply-mode imessage for user-visible completion updates and --reply-mode none for quiet context-only updates.
 - Include an idempotency key when asking a subagent to notify, so retries do not duplicate chat updates.
+- When a delegated run must notify even if the model forgets, add relaymux launch --notify-on-exit failure or --notify-on-exit always with --notify-reply-mode imessage. Use this deliberately to avoid spam.
 
 Example completion command for a subagent:
 relaymux notify --from <subagent-name> --reply-mode imessage --idempotency-key <stable-key> --message "Finished: summary, validation, blockers."
@@ -52,5 +53,6 @@ export function buildRuntimePromptContext({ configPath, homeDir, stateDir, sessi
 - default launch behavior: ${defaultLaunchBehavior}
 - separate session escape hatch: add --session <name> only when the user explicitly asks for a separate/new/named tmux session
 - per-worktree escape hatch: add --session-mode per-worktree only when the user explicitly asks for per-worktree sessions
-- completion helper shape: relaymux notify --from <name> --reply-mode imessage --idempotency-key <stable-key> --message <summary>`;
+- completion helper shape: relaymux notify --from <name> --reply-mode imessage --idempotency-key <stable-key> --message <summary>
+- launch notification fallback: add --notify-on-exit failure|always --notify-reply-mode imessage when the wrapper itself should notify on exit`;
 }

--- a/src/setup-imsg.ts
+++ b/src/setup-imsg.ts
@@ -68,7 +68,7 @@ export function buildImsgConfig(options: any = {}, env = process.env) {
       },
       codex: {
         description: "Codex subagent. Edit flags to match your local install.",
-        command: [codex, "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"],
+        command: [codex, "--model", "gpt-5.5", "{prompt}"],
         promptMode: "arg",
       },
       claude: {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -154,6 +154,34 @@ test("launch dry-run honors explicit session grouping", async () => {
   assert.match(harness.stdout, /# tmux session: task-group \(explicit; --session\)/);
 });
 
+test("launch dry-run includes opt-in exit notification wrapper", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-repo-"));
+  const harness = makeIo();
+  const code = await main([
+    "--config",
+    writeTempConfig("launch-notify-on-exit"),
+    "launch",
+    "--repo",
+    dir,
+    "--agent",
+    "custom",
+    "--name",
+    "api-fix",
+    "--prompt",
+    "noop",
+    "--notify-on-exit",
+    "failure",
+    "--notify-reply-mode",
+    "imessage",
+    "--dry-run",
+  ], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /relaymux_should_notify=0/);
+  assert.match(harness.stdout, /--reply-mode imessage/);
+  assert.match(harness.stdout, /--idempotency-key "\$relaymux_idempotency_key"/);
+});
+
 test("install-launch-agent dry-run runs the daemon directly by default", async () => {
   const harness = makeIo();
   const code = await main([

--- a/test/command-validation.test.ts
+++ b/test/command-validation.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { main } from "../src/cli.js";
+import { defaultConfig, writeConfig } from "../src/config.js";
+import { validateConfiguredAgentCommand } from "../src/command-validation.js";
+
+function makeIo(env: Record<string, string> = {}) {
+  let stdout = "";
+  let stderr = "";
+  return {
+    io: {
+      env: { ...process.env, ...env },
+      stdin: { isTTY: false },
+      stdout: { isTTY: false, write: (chunk) => { stdout += String(chunk); } },
+      stderr: { write: (chunk) => { stderr += String(chunk); } },
+    },
+    get stdout() { return stdout; },
+    get stderr() { return stderr; },
+  };
+}
+
+function writeStaleCodexConfig() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-stale-codex-"));
+  const configPath = path.join(dir, "config.json");
+  const config = defaultConfig();
+  config.agents.codex.command = ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"];
+  writeConfig(configPath, config, { force: true });
+  return { dir, configPath };
+}
+
+test("Codex command validation rejects stale --reasoning-effort", () => {
+  const findings = validateConfiguredAgentCommand("codex", {
+    command: ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"],
+    promptMode: "arg",
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, "error");
+  assert.match(findings[0].detail, /--reasoning-effort/);
+  assert.match(findings[0].detail, /Current Codex CLI rejects/);
+});
+
+test("doctor reports stale Codex flags", async () => {
+  const { configPath } = writeStaleCodexConfig();
+  const harness = makeIo();
+  const code = await main(["--config", configPath, "doctor"], harness.io);
+
+  assert.equal(code, 1);
+  assert.match(harness.stdout, /error\tagent:codex-command\t.*--reasoning-effort/);
+  assert.match(harness.stdout, /Current Codex CLI rejects/);
+});
+
+test("launch fails before tmux for stale Codex flags", async () => {
+  const { dir, configPath } = writeStaleCodexConfig();
+  const harness = makeIo();
+  const code = await main([
+    "--config",
+    configPath,
+    "launch",
+    "--repo",
+    dir,
+    "--agent",
+    "codex",
+    "--name",
+    "bad-codex",
+    "--prompt",
+    "noop",
+    "--dry-run",
+  ], harness.io);
+
+  assert.equal(code, 1);
+  assert.match(harness.stderr, /Agent "codex" command failed validation/);
+  assert.match(harness.stderr, /--reasoning-effort/);
+  assert.doesNotMatch(harness.stdout, /tmux session/);
+});

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 import {
   buildAgentInvocation,
+  buildTmuxShellScript,
   quoteArgv,
   renderTemplate,
   shellExportBlock,
@@ -52,4 +57,45 @@ test("buildAgentInvocation supports stdin prompt mode", () => {
 
 test("shellExportBlock rejects invalid env keys", () => {
   assert.throws(() => shellExportBlock({ "BAD-KEY": "value" }), /Invalid environment/);
+});
+
+test("tmux shell script can auto notify on nonzero exit", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-script-"));
+  const notifyLog = path.join(dir, "notify.log");
+  const fakeCli = path.join(dir, "relaymux-fake.js");
+  const scriptFile = path.join(dir, "run.sh");
+  fs.writeFileSync(fakeCli, `import fs from "node:fs";\nfs.appendFileSync(${JSON.stringify(notifyLog)}, JSON.stringify(process.argv.slice(2)) + "\\n");\n`);
+
+  const script = buildTmuxShellScript({
+    argv: ["sh", "-c", "printf 'bad flag\\n' >&2; exit 7"],
+    env: {},
+    stdinFile: null,
+  }, {
+    agent: "codex",
+    cliPath: fakeCli,
+    configPath: path.join(dir, "config.json"),
+    holdOnExit: false,
+    launchNotification: { onExit: "failure", replyMode: "imessage", tailLines: 20, tailBytes: 1000 },
+    name: "bad-codex",
+    promptFile: path.join(dir, "prompt.txt"),
+    repo: dir,
+    runId: "run-test",
+    session: "agents",
+    workdir: dir,
+  });
+  fs.writeFileSync(scriptFile, script, { mode: 0o700 });
+
+  const result = spawnSync("/bin/sh", [scriptFile], { encoding: "utf8", env: { ...process.env, TMUX_PANE: "" } });
+  assert.equal(result.status, 7);
+  assert.match(result.stderr, /bad flag/);
+
+  const calls = fs.readFileSync(notifyLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls[0].slice(2, 5), ["notify", "--run-id", "run-test"]);
+  assert.ok(calls[1].includes("--message"));
+  assert.ok(calls[2].includes("--reply-mode"));
+  assert.ok(calls[2].includes("imessage"));
+  assert.ok(calls[2].includes("--idempotency-key"));
+  assert.ok(calls[2].includes("run-test-exit-7"));
+  assert.ok(calls[2].includes("relaymux run bad-codex (run-test) failed with exit 7"));
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -21,6 +21,8 @@ test("writeDefaultConfig creates a loadable config", () => {
   assert.equal(config.tmux.sessionMode, "shared");
   assert.ok(config.orchestrator.command);
   assert.ok(config.agents.codex);
+  assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);
+  assert.equal(config.launchNotifications.onExit, "never");
 });
 
 test("default paths live under RELAYMUX_HOME when provided", () => {

--- a/test/setup-imsg.test.ts
+++ b/test/setup-imsg.test.ts
@@ -41,6 +41,7 @@ test("buildImsgConfig creates usable imsg defaults", () => {
   ]);
   assert.equal(config.daemon.tokenFile, "~/.state/relaymux-test/webhook-token");
   assert.equal(config.daemon.port, 49999);
+  assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);
 });
 
 test("formatChat shows id and label", () => {


### PR DESCRIPTION
## Summary
Adds guardrails so broken delegated-agent commands fail earlier and delegated tmux runs can notify on exit without relying on the agent prompt.

- `relaymux doctor` and `relaymux launch` now reject stale Codex `--reasoning-effort` config before opening tmux.
- Adds opt-in `launchNotifications` / `--notify-on-exit` wrapper notifications for failure or all exits.
- Updates defaults/docs to remove the stale Codex flag and document the safer prompt pattern.

## Design
### Command validation
- `src/command-validation.ts` — new static command-template validator for agent configs, including prompt/env shape checks and a Codex-specific fatal finding for `--reasoning-effort`.
- `src/doctor.ts` / `src/cli.ts` — doctor reports command-template validation as `agent:<name>-command`, and launch runs fatal validation before resolving prompts or creating tmux windows.
- `src/config.ts`, `src/setup-imsg.ts`, `examples/config.imsg.json` — generated/default Codex templates no longer include the stale `--reasoning-effort xhigh` flag.

### Exit notifications
- `src/command.ts` — tmux wrapper still records local started/completed events, now with a completion message including run id/name/exit code; when configured, it calls `relaymux notify` after exit with idempotency and a bounded recent tmux output tail for nonzero exits.
- `src/cli.ts` — adds `launchNotifications` resolution and launch flags: `--notify-on-exit never|failure|always`, `--notify-reply-mode`, `--notify-tail-lines`, and `--notify-tail-bytes`. Defaults remain quiet/backwards-compatible (`never`).
- `src/prompt.ts` / `README.md` — documents explicit subagent `relaymux notify` as the rich-summary path and wrapper-level exit notifications as the fallback.

### Tests
- `test/command-validation.test.ts` — covers stale Codex validation in the validator, doctor output, and pre-tmux launch failure.
- `test/command.test.ts` / `test/cli.test.ts` — cover wrapper notification-on-exit behavior and dry-run rendering.
- `test/config.test.ts` / `test/setup-imsg.test.ts` — assert generated configs omit the stale Codex flag.

## Validation
- `npm run validate` — passes (`tsc --noEmit`, 56 node tests, `tsc` build).
