### PR TITLE
Polish README for HN launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,61 @@
 # relaymux
 
-Text your Mac to launch coding agents in `tmux` windows.
+`relaymux` launches local CLI agents in `tmux` windows and gives them a small, local completion path back to a daemon or run log.
 
-`relaymux` is a small local dispatcher for coding agents. You send a request over iMessage/SMS or from a terminal, a local orchestrator decides what to do, and delegated work runs as visible `tmux` windows you can attach to, inspect, and kill with normal terminal commands.
+```bash
+# Start a visible agent window in the shared tmux session.
+relaymux launch --repo ~/code/my-app --agent pi --name fix-tests \
+  --prompt "Fix the failing tests, then report back with relaymux notify."
 
-It is intentionally thin: relaymux does not try to be a model provider, agent runtime, IDE, or full agent platform. Your agents are just commands such as `pi`, `codex`, `claude`, or any custom shell command.
-
-```text
-iMessage/SMS or terminal
-        │
-        ▼
-relaymux background daemon ──▶ orchestrator command stdout becomes the reply
-        │                              │
-        │                              ▼
-        │                     relaymux launch
-        │                              │
-        ▼                              ▼
-notify updates ◀────────── tmux window running Pi/Codex/Claude/etc.
+# From inside an agent when the work is done or blocked.
+relaymux notify --from fix-tests --reply-mode imessage \
+  --idempotency-key fix-tests-20260614-done \
+  --message "Done: fixed the tests. Validation: npm test passed."
 ```
 
-## Quick start
+`--reply-mode imessage` is for machines with the optional daemon configured through `relaymux setup`. The iMessage/SMS path uses your configured `imsg` command; relaymux does not talk to Messages.app directly. Without the daemon, relaymux still launches local tmux agent windows and records run state, but it will not send text-message completions.
 
-Install from GitHub:
+relaymux is not a model provider, coding agent, IDE, or cloud runtime. It is a thin local coordinator for tools you already run in a terminal: `pi`, `codex`, `claude`, `aider`, shell scripts, or any command you add to your config.
+
+## Why relaymux exists
+
+Coding agents are useful, but running more than one usually turns into a pile of terminal tabs, forgotten prompts, and "did that finish?" checks. relaymux keeps the work visible in `tmux`, gives every delegated run a name and local state record, and provides one completion path: `relaymux notify`.
+
+The optional iMessage/SMS daemon lets you ask your Mac to start or coordinate agent work while you are away from the keyboard. Text the configured chat, the daemon runs your orchestrator command, and the orchestrator can either answer directly or launch longer work into `tmux`.
+
+## Core ideas
+
+An **agent** is just a command template in `~/.relaymux/config.json`. If you configure `pi`, relaymux runs `pi ...`; if you configure `codex`, it runs `codex ...`; if you configure `custom`, it can be any shell command.
+
+A **run** is one `relaymux launch`. By default, relaymux creates a new `tmux` window in one shared session named `agents`. tmux calls these windows; many terminal apps display them like tabs. relaymux does not create panes or splits for agent runs.
+
+The **daemon** is optional. On macOS, `relaymux setup` can install it as a per-user LaunchAgent. The daemon stays outside `tmux`, polls your configured message source, accepts local `relaymux ask` and `relaymux notify` requests, and runs your orchestrator command.
+
+The **orchestrator** is also just a command, but it has a different job from an agent. The orchestrator handles inbound requests from iMessage/SMS or `relaymux ask`; agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply. The default iMessage setup uses Pi in non-interactive mode, but you can replace it with any command that accepts a prompt and writes a clean final response to stdout.
+
+relaymux stores its private config, token, run records, prompts, and logs under `~/.relaymux` by default:
+
+```text
+~/.relaymux/
+  config.json     # private config, written mode 0600
+  state/          # daemon state, run records, prompts, scripts, webhook token
+  logs/           # LaunchAgent stdout/stderr logs
+  tasks/          # optional task scratch space
+  reports/        # optional reports
+  research/       # optional research notes
+```
+
+## Install
+
+Requirements for local agent launches are Node.js 20+, npm, git, and `tmux`. tmux is the terminal multiplexer relaymux uses to keep agent runs visible as attachable sessions and windows.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/avyayv/relaymux/main/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
+relaymux --version
 ```
 
-Set up the iMessage/SMS adapter and background service:
-
-```bash
-relaymux setup
-relaymux doctor
-relaymux status
-```
-
-`relaymux setup` is the new-user path: it creates `~/.relaymux/config.json`, discovers recent `imsg` chats when possible, installs/loads the macOS LaunchAgent, and prints next steps. A healthy install should show `ok background-service ... LaunchAgent loaded` in `relaymux doctor`. If it says the service is not loaded, run `relaymux restart-launch-agent` from a normal terminal.
-
-`relaymux setup` tries to list recent Messages chats through `imsg chats --json` and prompts you to choose one. If discovery does not work, pass the chat id or phone number yourself:
-
-```bash
-relaymux setup --chat-id +15555550123
-```
-
-Launch a first agent window manually:
-
-```bash
-relaymux launch \
-  --repo ~/code/my-app \
-  --agent pi \
-  --name fix-api \
-  --prompt "Fix the API bug, run tests, and report back with relaymux notify."
-```
-
-Attach to the shared `tmux` session shown by `relaymux status`. tmux calls these “windows”; many terminal UIs display them like tabs.
-
-```bash
-tmux attach -t agents
-```
-
-## Mental model
-
-The background daemon runs directly as a macOS LaunchAgent, which is a per-user background service managed by launchd. It polls your configured message source, receives local terminal requests from `relaymux ask`, runs your orchestrator command, and sends replies. It does **not** run inside `tmux`.
-
-The orchestrator is just a command from your config. It receives the incoming request as prompt text, and whatever it prints to stdout becomes the reply. Use a non-interactive command whose stdout is a clean final response; if a CLI mixes logs into stdout, wrap it. If the orchestrator exits nonzero or times out, relaymux sends an error update instead. For orchestrators with `timeoutMs`, the default `timeoutMode` is `activity`: relaymux treats stdout/stderr and known Pi session-file writes as heartbeats, so healthy long turns are not killed by a fixed wall-clock timer.
-
-The default setup uses [Pi](https://github.com/earendil-works/pi) in non-interactive mode. Pi can use shell tools, so it can decide to run `relaymux launch` for longer work. You can replace Pi with any command that accepts a prompt and prints a reply, but that command can only launch delegated agents if it has a way to run shell commands.
-
-relaymux adds its runtime instructions directly to the prompt text passed to the orchestrator. Those instructions tell the orchestrator how to launch delegated work with `relaymux launch` and how delegated agents should report back with `relaymux notify`. You can extend them with `orchestrator.systemPromptFile` or `orchestrator.extraSystemPrompt` in config.
-
-Incoming messages do not need special chat syntax. The daemon polls every few seconds, ignores messages sent by you, and remembers seen message ids so it does not process the same inbound text repeatedly. The orchestrator can answer directly, or it can run `relaymux launch` when the work should happen in a separate terminal.
-
-Agent work runs in `tmux`. By default, every `relaymux launch` creates a new tmux window in one shared session named `agents`. relaymux does not create panes or splits. If you kill the tmux session, you kill those agent windows, but the background daemon keeps running.
-
-Subagents report progress or completion explicitly with `relaymux notify`. That command talks to a localhost-only HTTP endpoint protected by a random token stored in the token file. You normally do not call the endpoint yourself; use `relaymux notify`. Delegated agents should not send iMessages directly.
-
-## Requirements
-
-- macOS for the iMessage/SMS LaunchAgent flow. The Mac must be signed into Messages; SMS also depends on your normal iPhone/Mac SMS forwarding setup.
-- Node.js 20+, npm, and git.
-- `tmux` for agent windows.
-- An external `imsg` CLI installed as `imsg` that supports `chats`, `history`, and `send` commands with JSON output. relaymux does not install or vendor `imsg`; use the Messages.app CLI you already trust, then verify it with `imsg chats --limit 5 --json`.
-- At least one local agent/orchestrator command. The generated config assumes `pi` from [Pi](https://github.com/earendil-works/pi), and includes editable templates for `codex` and `claude`; install and authenticate those CLIs separately.
-
-If you only want terminal-launched tmux agents, you can still use `relaymux launch` without the iMessage flow after writing a config.
-
-## Install from a clone
+Or install from a clone:
 
 ```bash
 git clone https://github.com/avyayv/relaymux.git
@@ -95,22 +64,88 @@ cd relaymux
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-## Configuration
+For iMessage/SMS control you also need macOS, Messages signed in on that Mac, normal SMS forwarding if you want SMS, and an `imsg` CLI available as `imsg`. relaymux does not vendor or install `imsg`; it shells out to the message tool you configure. The expected commands are `imsg chats --limit <n> --json`, `imsg history --chat-id <id> --limit <n> --json`, and `imsg send --chat-id <id> --text <text> --json`.
 
-`relaymux setup` writes a private config file and managed data under `~/.relaymux`:
+## Try it in two minutes without iMessage
 
-```text
-~/.relaymux/
-  config.json          # private config, mode 0600
-  state/               # daemon state, run records, prompts, scripts, webhook token
-  logs/                # LaunchAgent stdout/stderr logs
-  tasks/               # default generated task scratch
-  reports/             # optional generated reports
-  research/            # optional generated research notes
-  workouts/            # optional generated workout logs
+This starts a harmless local run using the built-in default config, which includes a `custom` agent that just prints the prompt. You do not need to run `relaymux setup` first. `--repo` is the working directory for the command; it does not have to be a Git repository unless you use Git-specific features such as `--session-mode per-worktree`. `--hold` keeps the tmux window open after the command exits so you can inspect it.
+
+```bash
+mkdir -p /tmp/relaymux-demo
+relaymux launch \
+  --repo /tmp/relaymux-demo \
+  --agent custom \
+  --name hello-relaymux \
+  --hold \
+  --prompt "hello from relaymux"
 ```
 
-New relaymux-managed prompts, run records, completion notes, logs, and generated scratch/research/workout files should live under this home unless you pass an explicit path. The important config parts are the shared tmux session, the background daemon, the message adapters, the orchestrator command, and the agent command templates:
+Attach to the shared session:
+
+```bash
+tmux attach -t agents
+```
+
+In tmux, you should see a window named `hello-relaymux`. Detach with `Ctrl-b d`. Back in your shell:
+
+```bash
+relaymux status --history
+```
+
+Once that shape makes sense, replace `custom` with a real local agent from your config:
+
+```bash
+relaymux launch --repo ~/code/my-app --agent pi --name investigate-api \
+  --prompt "Investigate the API failure. When done or blocked, run relaymux notify with a concise summary."
+```
+
+## Optional iMessage/SMS setup
+
+The message flow is intentionally local:
+
+```text
+iMessage/SMS or relaymux ask
+        │
+        ▼
+relaymux daemon on your Mac ──▶ orchestrator command
+        │                              │
+        │                              └── may run relaymux launch
+        ▼
+reply text ◀──────────── relaymux notify from tmux agent windows
+```
+
+Run setup on the Mac that will receive and send messages:
+
+```bash
+relaymux setup
+relaymux doctor
+relaymux status
+```
+
+`relaymux setup` creates `~/.relaymux/config.json`, tries to discover recent `imsg` chats, installs the LaunchAgent, and prints next steps. The target can be an individual chat, group chat, or phone number understood by your `imsg` tool. If chat discovery is not available or you already know the target chat, pass it explicitly:
+
+```bash
+relaymux setup --chat-id <chat-id-or-phone-number>
+```
+
+After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies. The daemon remembers message ids it has already seen, runs the orchestrator, and sends back the orchestrator's stdout as the reply.
+
+You can also send a request to the same daemon from a terminal:
+
+```bash
+relaymux ask "Launch an agent in ~/code/my-app to inspect the failing test"
+relaymux ask --no-wait --reply-mode imessage "Start a longer refactor and text me when it is delegated"
+```
+
+If you do not want a LaunchAgent, you can run the daemon in the foreground for debugging:
+
+```bash
+relaymux daemon
+```
+
+## Configuration
+
+`relaymux setup` writes a full config, but the important shape is small. Command arrays are argv templates; `{prompt}` and `{promptFile}` are substituted at launch time. The Pi commands below are examples, not requirements; edit them to match the agent CLIs you actually use.
 
 ```json
 {
@@ -118,14 +153,7 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
   "session": "agents",
   "stateDir": "~/.relaymux/state",
   "tmux": {
-    "sessionMode": "shared",
-    "sessionPrefix": "rmx"
-  },
-  "launchNotifications": {
-    "onExit": "never",
-    "replyMode": "imessage",
-    "tailLines": 80,
-    "tailBytes": 4000
+    "sessionMode": "shared"
   },
   "daemon": {
     "enabled": true,
@@ -133,15 +161,15 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
     "port": 47761,
     "tokenFile": "~/.relaymux/state/webhook-token",
     "launchAgentLabel": "com.relaymux.daemon",
-    "launchMode": "direct",
     "logDir": "~/.relaymux/logs"
   },
   "imessage": {
-    "chatId": "CHAT_ID_OR_PHONE",
+    "chatId": "<chat-id-or-phone-number>",
+    "pollMs": 3000,
     "receive": {
       "backend": "command",
       "command": {
-        "argv": ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--attachments", "--convert-attachments", "--json"]
+        "argv": ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"]
       }
     },
     "send": {
@@ -154,9 +182,7 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
   "orchestrator": {
     "cwd": "~",
     "command": ["pi", "--print", "--continue", "--session-dir", "~/.relaymux/state/sessions", "{prompt}"],
-    "promptMode": "arg",
-    "timeoutMs": 0,
-    "timeoutMode": "activity"
+    "promptMode": "arg"
   },
   "agents": {
     "pi": {
@@ -164,261 +190,144 @@ New relaymux-managed prompts, run records, completion notes, logs, and generated
       "promptMode": "arg"
     },
     "codex": {
-      "command": ["codex", "--model", "gpt-5.5", "{prompt}"],
+      "command": ["codex", "{prompt}"],
       "promptMode": "arg"
     },
-    "claude": {
-      "command": ["claude", "{prompt}"],
-      "promptMode": "arg"
+    "custom": {
+      "command": ["sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""],
+      "promptMode": "env"
     }
   }
 }
 ```
 
-Agent commands are templates. If the command contains `{prompt}` or `{promptFile}`, relaymux substitutes those values. If it does not, `promptMode` decides what to do with the prompt. Valid values are `arg`, `env`, `stdin`, and `none`.
+Prompt passing modes are:
 
-Prompts can be passed inline or read from a file. `--prompt @prompt.txt` means “read the prompt text from `prompt.txt`.” You can also use `--prompt-file prompt.txt`.
+| `promptMode` | Behavior |
+| --- | --- |
+| `arg` | Append the prompt as a command-line argument unless `{prompt}` is already present. |
+| `env` | Put the prompt in `RELAYMUX_PROMPT`. |
+| `stdin` | Write the prompt under `~/.relaymux/state/prompts` and pipe that file to stdin. |
+| `none` | Do not pass the prompt automatically. |
 
-## Session behavior
+Use `--prompt @prompt.txt` or `--prompt-file prompt.txt` for longer prompts. The orchestrator follows the same command-template rules as agents: relaymux passes it a prompt, expects a useful final reply on stdout, and treats a nonzero exit as an error to report.
 
-The default is one shared tmux session:
+## Common workflows
 
-```json
-{
-  "session": "agents",
-  "tmux": { "sessionMode": "shared" }
-}
-```
-
-That means work from different repos and worktrees appears as windows in the same session unless you ask for a different shape.
-
-Use an explicit session when you want a separate group of windows:
+Launch a named agent in the default shared session:
 
 ```bash
-relaymux launch --session my-task --repo ~/code/app --agent pi --prompt @prompt.txt
+relaymux launch --repo ~/code/my-app --agent pi --name fix-api --prompt @prompt.txt
 ```
 
-Use per-worktree sessions when you want deterministic isolation by Git worktree or branch. relaymux derives the session name from the repo/worktree/branch plus a short hash, so repeated launches for the same worktree land in the same named session. If you do not use Git worktrees, you can ignore this mode.
+Launch into a separate tmux session when you want an isolated group of windows:
 
 ```bash
-relaymux launch --session-mode per-worktree --repo ~/code/app --agent pi --prompt @prompt.txt
+relaymux launch --session release-fix --repo ~/code/my-app --agent codex --prompt @prompt.txt
 ```
 
-Or make per-worktree sessions the default:
-
-```json
-{
-  "tmux": {
-    "sessionMode": "per-worktree",
-    "sessionPrefix": "rmx"
-  }
-}
-```
-
-relaymux-managed panes/splits are not used.
-
-## Common commands
+Use per-worktree sessions when each Git worktree should get a stable session name. In this mode, relaymux derives the session from the repo/worktree/branch plus a short hash:
 
 ```bash
-relaymux doctor                 # check config, home layout, commands, token permissions, and background mode
-relaymux status                 # show background service and relaymux-managed tmux windows
-relaymux status --session NAME  # filter status to one tmux session
-relaymux status --history       # include old run records whose windows are gone
-relaymux status-launch-agent    # show launchd status for the background service
-relaymux restart-launch-agent   # regenerate and reload the LaunchAgent
-relaymux migrate-home --dry-run # inventory old relaymux-owned paths before copying into ~/.relaymux
+relaymux launch --session-mode per-worktree --repo ~/code/my-app --agent pi --prompt @prompt.txt
 ```
 
-Ask the orchestrator from a terminal:
-
-```bash
-relaymux ask "open a subagent in ~/code/my-app to fix the failing test"
-```
-
-Notify from a delegated agent:
+Send a completion from a delegated agent. Manual notifications with `--reply-mode` require the daemon; local runs still record automatic `started` and `completed` events even without it:
 
 ```bash
 relaymux notify \
   --from fix-api \
   --reply-mode imessage \
-  --idempotency-key fix-api-done \
-  --message "Finished: fixed the API bug and tests pass."
+  --idempotency-key fix-api-20260614-done \
+  --message "Finished: fixed the API bug. Validation: npm test passed."
 ```
 
-`--reply-mode imessage` asks the daemon to send a user-visible text update. `--reply-mode none` still re-prompts the daemon/orchestrator path, but suppresses the outgoing iMessage. Use it for progress notes that should affect the orchestrator's context or logs without texting the user. Whether that context persists depends on your orchestrator command; the default Pi command uses `--continue` with a relaymux session directory.
+`--reply-mode imessage` asks the daemon to send a user-visible update to the configured chat. `--reply-mode none` posts the completion to the daemon so the orchestrator can observe it, but suppresses the outgoing text. Use a stable `--idempotency-key` for one logical update so retries do not send duplicates.
 
-The idempotency key is a stable de-duplication string for one logical update. If a delegated agent retries the same completion notification, reuse the same key so relaymux does not send duplicate text messages.
-
-## Delegated-run guardrails
-
-`relaymux doctor` statically checks configured agent command templates for known stale flags before you launch. For Codex, it reports `--reasoning-effort` as an error because current Codex CLI releases reject that flag; remove the flag/value from `~/.relaymux/config.json` and rerun `relaymux doctor`. `relaymux launch` runs the same fatal validation before opening tmux, so a stale known flag fails in the caller instead of disappearing into a tmux tab.
-
-Every tmux launch records local `started` and `completed` events. For user-visible completion that does not depend on the subagent following prompt instructions, opt into wrapper-level exit notifications:
-
-```json
-{
-  "launchNotifications": {
-    "onExit": "failure",
-    "replyMode": "imessage",
-    "tailLines": 80,
-    "tailBytes": 4000
-  }
-}
-```
-
-`onExit` may be `never` (default), `failure`, or `always`. `failure` sends a relaymux notification only for nonzero exits; `always` also sends success notifications. `replyMode: "imessage"` asks the daemon to send a chat update. Nonzero auto-notifications include the run name, run id, exit code, and a bounded recent tmux output tail when available. You can also set this for one launch:
+Turn on wrapper-level exit notifications if you want a fallback even when the agent forgets to call `relaymux notify`. `failure` means only nonzero exits notify; `always` also notifies on success; `never` is the default:
 
 ```bash
-relaymux launch \
-  --repo ~/code/my-app \
-  --agent codex \
-  --name email-draft \
-  --notify-on-exit always \
-  --notify-reply-mode imessage \
+relaymux launch --repo ~/code/my-app --agent pi --name risky-task \
+  --notify-on-exit failure --notify-reply-mode imessage \
   --prompt @prompt.txt
 ```
 
-Still include an explicit completion instruction in delegated prompts for richer summaries:
-
-```text
-When done or blocked, run:
-relaymux notify --from email-draft --reply-mode imessage \
-  --idempotency-key email-draft-<date>-done \
-  --message "Finished: summary, validation, blockers."
-```
-
-The wrapper-level notification is a fallback; the explicit `relaymux notify` should carry the useful human summary.
-
-## Migrating old relaymux-managed files
-
-New installs use `~/.relaymux`, but older local setups may still have relaymux-owned config/state under `~/.config/relaymux`, `~/.local/state/relaymux`, old `agentmux` paths, `~/.pi/agent/orchestrator-imessage`, or prompt scratch like `~/research/orchestrator-prompts-*`.
-
-Start with an inventory; it prints paths only, never token contents:
+Inspect local state. `--history` includes old run records whose tmux windows have already exited:
 
 ```bash
-relaymux migrate-home --dry-run
-```
-
-If the plan looks right, copy only those relaymux-owned files into `~/.relaymux`:
-
-```bash
-relaymux migrate-home --apply
+relaymux status
+relaymux status --history
 relaymux doctor
+relaymux status-launch-agent
+```
+
+Manage the background service:
+
+```bash
 relaymux restart-launch-agent
-```
-
-`--apply` copies and leaves the original files in place for backcompat. Add `--symlink` only if you want migrated source paths replaced by symlinks after copying. relaymux intentionally does **not** blindly move all of `~/research`, `~/personal`, or other canonical personal directories.
-
-## Cleanup
-
-Stop the background service and remove the installed binary:
-
-```bash
 relaymux uninstall-launch-agent
-rm -rf ~/.local/lib/relaymux ~/.local/bin/relaymux
 ```
 
-Optionally remove local state and config after checking for data you want to keep:
+## Safety model and limitations
 
-```bash
-rm -rf ~/.relaymux
-# Legacy installs may also have:
-# rm -rf ~/.local/state/relaymux ~/.config/relaymux
-```
+relaymux is designed for a single user's local machine. The daemon binds to `127.0.0.1` and `relaymux notify` authenticates to it with a random token stored under `~/.relaymux/state`. The config file is written with private file permissions.
 
-Killing a tmux session only kills the windows in that session:
+That does not make arbitrary agents safe. If an incoming message causes your orchestrator to launch `pi`, `codex`, `claude`, or a shell script, that command has the same local permissions it would have if you ran it yourself. Configure relaymux only with chats and agents you trust, review your agent prompts, and assume prompts, logs, tmux scrollback, and run records may contain sensitive project context.
 
-```bash
-tmux kill-session -t agents
-```
-
-It does not uninstall relaymux or stop the LaunchAgent.
+relaymux is probably the wrong tool if you need a sandbox, a multi-tenant service, durable distributed jobs, a cron/scheduler, hosted model inference, or a web UI. It is also not a general iMessage library; iMessage/SMS support depends on macOS, Messages.app, and the external `imsg` command you choose.
 
 ## Troubleshooting
 
-### Background service unloaded after a restart
-
-If `relaymux status-launch-agent` says `not loaded`, reload it from a normal terminal:
+If setup says the LaunchAgent is not loaded, reload it from a normal terminal:
 
 ```bash
 relaymux restart-launch-agent
 relaymux status-launch-agent
 ```
 
-relaymux protects against the common self-restart trap: when `restart-launch-agent` is invoked from inside the relaymux LaunchAgent, it now schedules a short-lived helper LaunchAgent to do the reload after the current chat turn has time to reply. Direct `launchctl bootout` from inside the daemon can kill the daemon before it marks the message seen.
-
-### Messages permissions
-
-If receive/send fails, grant the terminal or automation host Full Disk Access and Messages Automation permissions required by your `imsg` tool. Then run:
+If Messages send/receive fails, verify your `imsg` CLI first:
 
 ```bash
-relaymux doctor
-relaymux restart-launch-agent
-```
-
-### LaunchAgent status and logs
-
-```bash
-relaymux status-launch-agent
-launchctl print gui/$(id -u)/com.relaymux.daemon
-ls ~/.relaymux/logs
-```
-
-The generated LaunchAgent should run `node ... relaymux ... daemon` directly. It should not contain `tmux`, `supervise-tmux`, `TMUX_TMPDIR`, or `RELAYMUX_SESSION`.
-
-### Token file permissions
-
-The local token file stores the random secret used by `relaymux notify` to reach the localhost HTTP endpoint. It must not be group/world-readable:
-
-```bash
-chmod 600 ~/.relaymux/state/webhook-token
+imsg chats --limit 5 --json
 relaymux doctor
 ```
 
-### tmux not found
+You may need to grant the terminal or automation host the macOS permissions required by your message tool, such as Full Disk Access or Messages automation permission.
 
-Install tmux and make sure it is on the PATH seen by your shell:
+If tmux is missing:
 
 ```bash
 brew install tmux
 relaymux doctor
 ```
 
-The background service can run without tmux, but agent windows need it.
-
-### Config errors
-
-Check that the config exists and is private:
+If the notify token has loose permissions:
 
 ```bash
-ls -l ~/.relaymux/config.json
+chmod 600 ~/.relaymux/state/webhook-token
 relaymux doctor
 ```
 
-Use `relaymux setup --force` only if you intentionally want to rewrite the config.
-
-## Test without real iMessage
-
-The mock config uses fake receive/send commands, so you can test the daemon and tmux launch path without touching Messages.app:
+For a no-Messages smoke test from a clone:
 
 ```bash
 npm run build
 rm -rf /tmp/relaymux-mock
 node ./dist/bin/relaymux.js --config examples/config.mock.json daemon --once
+node ./dist/bin/relaymux.js --config examples/config.mock.json launch \
+  --repo /tmp/relaymux-mock/repo --agent custom --name smoke --prompt "smoke"
+node ./dist/bin/relaymux.js --config examples/config.mock.json status --history
 ```
 
-Launch a harmless mock agent window:
+## Development
 
 ```bash
-mkdir -p /tmp/relaymux-mock/repo
-node ./dist/bin/relaymux.js --config examples/config.mock.json launch \
-  --repo /tmp/relaymux-mock/repo \
-  --agent custom \
-  --name smoke \
-  --prompt "smoke"
-node ./dist/bin/relaymux.js --config examples/config.mock.json status
+npm ci
+npm run validate
 ```
 
-## Notes
+Issues and pull requests are welcome. Please keep public examples free of private paths, phone numbers, chat ids, and secrets.
 
-relaymux does not include private prompts, phone numbers, secrets, or repo-specific context. The notify endpoint binds to localhost and requires the token file.
+## License
+
+MIT

--- a/examples/config.imsg.json
+++ b/examples/config.imsg.json
@@ -58,7 +58,7 @@
   },
   "agents": {
     "pi": { "command": ["pi", "{prompt}"], "promptMode": "arg" },
-    "codex": { "command": ["codex", "--model", "gpt-5.5", "{prompt}"], "promptMode": "arg" },
+    "codex": { "command": ["codex", "{prompt}"], "promptMode": "arg" },
     "claude": { "command": ["claude", "{prompt}"], "promptMode": "arg" }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -375,9 +375,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -483,32 +483,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relaymux",
   "version": "0.1.0",
-  "description": "Talk to a local Pi orchestrator over iMessage/SMS and delegate coding agents into tmux tabs.",
+  "description": "Orchestrate local CLI agents in tmux and receive async iMessage/SMS completions.",
   "type": "module",
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('dist/bin/relaymux.js', 0o755)\"",

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,7 +83,7 @@ export function defaultConfig(env = process.env) {
       },
       codex: {
         description: "Codex CLI template. Edit flags to match your local install.",
-        command: ["codex", "--model", "gpt-5.5", "{prompt}"],
+        command: ["codex", "{prompt}"],
         promptMode: "arg",
       },
       claude: {

--- a/src/setup-imsg.ts
+++ b/src/setup-imsg.ts
@@ -68,7 +68,7 @@ export function buildImsgConfig(options: any = {}, env = process.env) {
       },
       codex: {
         description: "Codex subagent. Edit flags to match your local install.",
-        command: [codex, "--model", "gpt-5.5", "{prompt}"],
+        command: [codex, "{prompt}"],
         promptMode: "arg",
       },
       claude: {

--- a/test/command-validation.test.ts
+++ b/test/command-validation.test.ts
@@ -27,14 +27,14 @@ function writeStaleCodexConfig() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-stale-codex-"));
   const configPath = path.join(dir, "config.json");
   const config = defaultConfig();
-  config.agents.codex.command = ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"];
+  config.agents.codex.command = ["codex", "--reasoning-effort", "xhigh", "{prompt}"];
   writeConfig(configPath, config, { force: true });
   return { dir, configPath };
 }
 
 test("Codex command validation rejects stale --reasoning-effort", () => {
   const findings = validateConfiguredAgentCommand("codex", {
-    command: ["codex", "--model", "gpt-5.5", "--reasoning-effort", "xhigh", "{prompt}"],
+    command: ["codex", "--reasoning-effort", "xhigh", "{prompt}"],
     promptMode: "arg",
   });
 


### PR DESCRIPTION
## Summary
Rewrite the README for a first-time Hacker News reader: clear identity, immediate usage shape, local quickstart, optional iMessage setup, config, workflows, and safety boundaries.

- Keeps relaymux positioned as a local tmux/notification coordinator, not a model provider.
- Removes launch-readme distractions like migration history and hardcoded private-ish examples.
- Cleans Codex defaults to avoid documenting a hardcoded model flag.

## Design
### Public README
- `README.md` — restructures the launch README around what relaymux is, why it exists, a two-minute local tmux demo, optional iMessage/SMS setup, safe config placeholders, common workflows, safety/limitations, troubleshooting, and development.
- `README.md` — clarifies shared tmux session/window behavior, daemon/orchestrator/agent roles, `relaymux notify` reply modes, `~/.relaymux` state, and when not to use relaymux.

### CLI defaults and examples
- `src/config.ts` — changes the default Codex agent template to `codex {prompt}` instead of baking in a model flag.
- `src/setup-imsg.ts` — applies the same Codex template cleanup to generated iMessage configs.
- `examples/config.imsg.json` — keeps the public example aligned with the safer Codex default.
- `package.json` — updates the package description to describe arbitrary local CLI-agent orchestration.

### Validation/dependency cleanup
- `test/command-validation.test.ts` — updates stale Codex validation fixtures so they test the rejected flag without relying on a model flag.
- `package-lock.json` — updates esbuild transitive packages via `npm audit fix` so the lockfile audits cleanly.

## Validation
- `npm run validate` — passed (`tsc --noEmit`, 56 node:test tests, build).
- `npm audit --audit-level=high` — passed, 0 vulnerabilities.
- `node ./dist/bin/relaymux.js --help` — verified documented command names/options against local build.
- First-reader review with `pi --print --no-tools --no-context-files --no-skills --no-prompt-templates --no-extensions --no-session` over only the README content — fixed flagged confusion around pre-setup `custom`, `--repo`, `reply-mode`, `imsg`, and orchestrator vs agent roles.
