### PR TITLE
Make message adapters optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # relaymux
 
-`relaymux` launches local CLI agents in `tmux` windows and gives them a small, local completion path back to a daemon or run log.
+`relaymux` coordinates local CLI agents in `tmux` windows and gives them a small local API for status, requests, and completion notifications.
 
 ```bash
 # Start a visible agent window in the shared tmux session.
@@ -8,20 +8,19 @@ relaymux launch --repo ~/code/my-app --agent pi --name fix-tests \
   --prompt "Fix the failing tests, then report back with relaymux notify."
 
 # From inside an agent when the work is done or blocked.
-relaymux notify --from fix-tests --reply-mode imessage \
-  --idempotency-key fix-tests-20260614-done \
+relaymux notify --from fix-tests \
   --message "Done: fixed the tests. Validation: npm test passed."
 ```
 
-`--reply-mode imessage` is for machines with the optional daemon configured through `relaymux setup`. The iMessage/SMS path uses your configured `imsg` command; relaymux does not talk to Messages.app directly. Without the daemon, relaymux still launches local tmux agent windows and records run state, but it will not send text-message completions.
+The core product is local: CLI + `tmux` + run state + a loopback HTTP API/webhook. Notification adapters are optional. iMessage/SMS via `imsg` and Telegram via the Bot API are supported as add-ons; neither is required to launch agents, inspect status, or record local notifications.
 
-relaymux is not a model provider, coding agent, IDE, or cloud runtime. It is a thin local coordinator for tools you already run in a terminal: `pi`, `codex`, `claude`, `aider`, shell scripts, or any command you add to your config.
+relaymux is not a model provider, coding agent, IDE, cloud runtime, or general messaging SDK. It is a thin local coordinator for tools you already run in a terminal: `pi`, `codex`, `claude`, `aider`, shell scripts, or any command you add to your config.
 
 ## Why relaymux exists
 
 Coding agents are useful, but running more than one usually turns into a pile of terminal tabs, forgotten prompts, and "did that finish?" checks. relaymux keeps the work visible in `tmux`, gives every delegated run a name and local state record, and provides one completion path: `relaymux notify`.
 
-The optional iMessage/SMS daemon lets you ask your Mac to start or coordinate agent work while you are away from the keyboard. Text the configured chat, the daemon runs your orchestrator command, and the orchestrator can either answer directly or launch longer work into `tmux`.
+Optional adapters can make those completions user-visible away from the keyboard. iMessage/SMS and Telegram are sibling integrations: configure one, both, or neither.
 
 ## Core ideas
 
@@ -29,11 +28,11 @@ An **agent** is just a command template in `~/.relaymux/config.json`. If you con
 
 A **run** is one `relaymux launch`. By default, relaymux creates a new `tmux` window in one shared session named `agents`. tmux calls these windows; many terminal apps display them like tabs. relaymux does not create panes or splits for agent runs.
 
-The **daemon** is optional. On macOS, `relaymux setup` can install it as a per-user LaunchAgent. The daemon stays outside `tmux`, polls your configured message source, accepts local `relaymux ask` and `relaymux notify` requests, and runs your orchestrator command.
+The **daemon** is optional for local launches, but useful for the local API and adapter delivery. On macOS, `relaymux setup` can install it as a per-user LaunchAgent. The daemon stays outside `tmux`, accepts local `relaymux ask` and `relaymux notify` requests, and runs your orchestrator command. If the iMessage/SMS adapter is enabled, it also polls the configured `imsg` chat.
 
-The **orchestrator** is also just a command, but it has a different job from an agent. The orchestrator handles inbound requests from iMessage/SMS or `relaymux ask`; agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply. The default iMessage setup uses Pi in non-interactive mode, but you can replace it with any command that accepts a prompt and writes a clean final response to stdout.
+The **orchestrator** is also just a command, but it has a different job from an agent. The orchestrator handles inbound requests from the local API or optional adapters; agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply.
 
-relaymux stores its private config, token, run records, prompts, and logs under `~/.relaymux` by default:
+relaymux stores private config, token, run records, prompts, and logs under `~/.relaymux` by default:
 
 ```text
 ~/.relaymux/
@@ -64,9 +63,12 @@ cd relaymux
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-For iMessage/SMS control you also need macOS, Messages signed in on that Mac, normal SMS forwarding if you want SMS, and an `imsg` CLI available as `imsg`. relaymux does not vendor or install `imsg`; it shells out to the message tool you configure. The expected commands are `imsg chats --limit <n> --json`, `imsg history --chat-id <id> --limit <n> --json`, and `imsg send --chat-id <id> --text <text> --json`.
+Optional adapter requirements:
 
-## Try it in two minutes without iMessage
+- iMessage/SMS: macOS, Messages signed in on that Mac, SMS forwarding if you want SMS, and an external `imsg` CLI. relaymux shells out to the command you configure; it does not vendor `imsg` or talk to Messages.app directly.
+- Telegram: a Telegram bot token and chat id. relaymux sends through the Telegram Bot API and reads the token from an environment variable or token file.
+
+## Try it in two minutes without message adapters
 
 This starts a harmless local run using the built-in default config, which includes a `custom` agent that just prints the prompt. You do not need to run `relaymux setup` first. `--repo` is the working directory for the command; it does not have to be a Git repository unless you use Git-specific features such as `--session-mode per-worktree`. `--hold` keeps the tmux window open after the command exits so you can inspect it.
 
@@ -99,53 +101,104 @@ relaymux launch --repo ~/code/my-app --agent pi --name investigate-api \
   --prompt "Investigate the API failure. When done or blocked, run relaymux notify with a concise summary."
 ```
 
-## Optional iMessage/SMS setup
+## Local API/webhook
 
-The message flow is intentionally local:
+The daemon exposes the core integration point on loopback only. `relaymux ask` and `relaymux notify --reply-mode ...` are CLI wrappers over this API.
 
-```text
-iMessage/SMS or relaymux ask
-        │
-        ▼
-relaymux daemon on your Mac ──▶ orchestrator command
-        │                              │
-        │                              └── may run relaymux launch
-        ▼
-reply text ◀──────────── relaymux notify from tmux agent windows
-```
+Default endpoints:
 
-Run setup on the Mac that will receive and send messages:
+- `GET /health` returns daemon, queue, and webhook status.
+- `POST /request` submits a terminal/local request to the orchestrator.
+- `POST /message` or `POST /agent-message` submits a subagent completion/update.
+
+Requests to `POST` endpoints require `Authorization: Bearer <token>`, where the token is stored in `~/.relaymux/state/webhook-token` by default. For foreground debugging instead of LaunchAgent, run `relaymux daemon`.
 
 ```bash
-relaymux setup
+TOKEN="$(cat ~/.relaymux/state/webhook-token)"
+curl -sS -X POST http://127.0.0.1:47761/message \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"from":"build-agent","replyMode":"none","idempotencyKey":"build-agent:job-123:done","text":"Finished; tests passed."}'
+```
+
+`replyMode` can be:
+
+| `replyMode` | Behavior |
+| --- | --- |
+| `none` | Quiet/local context update; no adapter message is sent. |
+| `imessage` | Send the orchestrator's user-visible reply through the optional iMessage/SMS adapter. |
+| `telegram` | Send the orchestrator's user-visible reply through the optional Telegram adapter. |
+
+## Optional iMessage/SMS adapter
+
+The iMessage/SMS adapter is one optional integration. It uses your configured `imsg` command for both inbound polling and outbound replies. The expected command shapes are `imsg chats --limit <n> --json`, `imsg history --chat-id <id> --limit <n> --json`, and `imsg send --chat-id <id> --text <text> --json`.
+
+```bash
+relaymux setup --imsg --chat-id <chat-id-or-phone-number>
 relaymux doctor
 relaymux status
 ```
 
-`relaymux setup` creates `~/.relaymux/config.json`, tries to discover recent `imsg` chats, installs the LaunchAgent, and prints next steps. The target can be an individual chat, group chat, or phone number understood by your `imsg` tool. If chat discovery is not available or you already know the target chat, pass it explicitly:
+`relaymux setup --imsg` creates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps.
+
+After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
+
+Manual user-visible completion:
 
 ```bash
-relaymux setup --chat-id <chat-id-or-phone-number>
+relaymux notify \
+  --from fix-api \
+  --reply-mode imessage \
+  --idempotency-key fix-api-20260614-done \
+  --message "Finished: fixed the API bug. Validation: npm test passed."
 ```
 
-After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies. The daemon remembers message ids it has already seen, runs the orchestrator, and sends back the orchestrator's stdout as the reply.
+## Optional Telegram adapter
 
-You can also send a request to the same daemon from a terminal:
+The Telegram adapter is outbound notification support through `sendMessage`. It does not poll Telegram for inbound messages.
+
+Create a bot with BotFather, get a chat id for the chat you want to notify, and store the token outside the public config. A token file works well with LaunchAgent because it does not depend on your interactive shell environment:
 
 ```bash
-relaymux ask "Launch an agent in ~/code/my-app to inspect the failing test"
-relaymux ask --no-wait --reply-mode imessage "Start a longer refactor and text me when it is delegated"
+mkdir -p ~/.relaymux/secrets
+printf '%s\n' '<telegram-bot-token>' > ~/.relaymux/secrets/telegram-bot-token
+chmod 600 ~/.relaymux/secrets/telegram-bot-token
+
+relaymux setup --telegram \
+  --telegram-chat-id <telegram-chat-id> \
+  --telegram-bot-token-file ~/.relaymux/secrets/telegram-bot-token
+relaymux doctor
+relaymux status
 ```
 
-If you do not want a LaunchAgent, you can run the daemon in the foreground for debugging:
+You can also use an environment variable instead of a file:
+
+```json
+{
+  "integrations": {
+    "telegram": {
+      "enabled": true,
+      "chatId": "<telegram-chat-id>",
+      "botTokenEnv": "TELEGRAM_BOT_TOKEN",
+      "parseMode": ""
+    }
+  }
+}
+```
+
+Manual Telegram completion:
 
 ```bash
-relaymux daemon
+relaymux notify \
+  --from fix-api \
+  --reply-mode telegram \
+  --idempotency-key fix-api-20260614-done \
+  --message "Finished: fixed the API bug. Validation: npm test passed."
 ```
 
 ## Configuration
 
-`relaymux setup` writes a full config, but the important shape is small. Command arrays are argv templates; `{prompt}` and `{promptFile}` are substituted at launch time. The Pi commands below are examples, not requirements; edit them to match the agent CLIs you actually use.
+`relaymux init` writes a core config with no message adapters. Command arrays are argv templates; `{prompt}` and `{promptFile}` are substituted at launch time. The Pi commands below are examples, not requirements; edit them to match the agent CLIs you actually use.
 
 ```json
 {
@@ -163,43 +216,49 @@ relaymux daemon
     "launchAgentLabel": "com.relaymux.daemon",
     "logDir": "~/.relaymux/logs"
   },
-  "imessage": {
-    "chatId": "<chat-id-or-phone-number>",
-    "pollMs": 3000,
-    "receive": {
-      "backend": "command",
-      "command": {
-        "argv": ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"]
-      }
-    },
-    "send": {
-      "backend": "command",
-      "command": {
-        "argv": ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"]
-      }
-    }
-  },
+  "integrations": {},
   "orchestrator": {
     "cwd": "~",
     "command": ["pi", "--print", "--continue", "--session-dir", "~/.relaymux/state/sessions", "{prompt}"],
     "promptMode": "arg"
   },
   "agents": {
-    "pi": {
-      "command": ["pi", "{prompt}"],
-      "promptMode": "arg"
+    "pi": { "command": ["pi", "{prompt}"], "promptMode": "arg" },
+    "codex": { "command": ["codex", "{prompt}"], "promptMode": "arg" },
+    "custom": { "command": ["sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""], "promptMode": "env" }
+  }
+}
+```
+
+Optional adapter config lives under `integrations`:
+
+```json
+{
+  "integrations": {
+    "imessage": {
+      "enabled": true,
+      "chatId": "<chat-id-or-phone-number>",
+      "pollMs": 3000,
+      "receive": {
+        "backend": "command",
+        "command": { "argv": ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"] }
+      },
+      "send": {
+        "backend": "command",
+        "command": { "argv": ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"] }
+      }
     },
-    "codex": {
-      "command": ["codex", "{prompt}"],
-      "promptMode": "arg"
-    },
-    "custom": {
-      "command": ["sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""],
-      "promptMode": "env"
+    "telegram": {
+      "enabled": true,
+      "chatId": "<telegram-chat-id>",
+      "botTokenFile": "~/.relaymux/secrets/telegram-bot-token",
+      "parseMode": ""
     }
   }
 }
 ```
+
+Legacy top-level `imessage` config is still accepted and normalized as `integrations.imessage` at load time.
 
 Prompt passing modes are:
 
@@ -232,23 +291,21 @@ Use per-worktree sessions when each Git worktree should get a stable session nam
 relaymux launch --session-mode per-worktree --repo ~/code/my-app --agent pi --prompt @prompt.txt
 ```
 
-Send a completion from a delegated agent. Manual notifications with `--reply-mode` require the daemon; local runs still record automatic `started` and `completed` events even without it:
+Send a local run-log completion from a delegated agent. Local runs still record automatic `started` and `completed` events even without the daemon:
 
 ```bash
 relaymux notify \
   --from fix-api \
-  --reply-mode imessage \
-  --idempotency-key fix-api-20260614-done \
   --message "Finished: fixed the API bug. Validation: npm test passed."
 ```
 
-`--reply-mode imessage` asks the daemon to send a user-visible update to the configured chat. `--reply-mode none` posts the completion to the daemon so the orchestrator can observe it, but suppresses the outgoing text. Use a stable `--idempotency-key` for one logical update so retries do not send duplicates.
+Add `--reply-mode none` when the daemon should receive quiet context but no adapter message should be sent. Use `--reply-mode imessage` or `--reply-mode telegram` only when that adapter is configured and you want a user-visible update. Use a stable `--idempotency-key` for one logical update so retries do not send duplicates.
 
 Turn on wrapper-level exit notifications if you want a fallback even when the agent forgets to call `relaymux notify`. `failure` means only nonzero exits notify; `always` also notifies on success; `never` is the default:
 
 ```bash
 relaymux launch --repo ~/code/my-app --agent pi --name risky-task \
-  --notify-on-exit failure --notify-reply-mode imessage \
+  --notify-on-exit failure --notify-reply-mode telegram \
   --prompt @prompt.txt
 ```
 
@@ -270,11 +327,11 @@ relaymux uninstall-launch-agent
 
 ## Safety model and limitations
 
-relaymux is designed for a single user's local machine. The daemon binds to `127.0.0.1` and `relaymux notify` authenticates to it with a random token stored under `~/.relaymux/state`. The config file is written with private file permissions.
+relaymux is designed for a single user's local machine. The daemon binds to `127.0.0.1` and API requests authenticate with a random token stored under `~/.relaymux/state`. The config file is written with private file permissions.
 
-That does not make arbitrary agents safe. If an incoming message causes your orchestrator to launch `pi`, `codex`, `claude`, or a shell script, that command has the same local permissions it would have if you ran it yourself. Configure relaymux only with chats and agents you trust, review your agent prompts, and assume prompts, logs, tmux scrollback, and run records may contain sensitive project context.
+That does not make arbitrary agents safe. If a local request or adapter message causes your orchestrator to launch `pi`, `codex`, `claude`, or a shell script, that command has the same local permissions it would have if you ran it yourself. Configure relaymux only with adapters and agents you trust, review your agent prompts, and assume prompts, logs, tmux scrollback, and run records may contain sensitive project context.
 
-relaymux is probably the wrong tool if you need a sandbox, a multi-tenant service, durable distributed jobs, a cron/scheduler, hosted model inference, or a web UI. It is also not a general iMessage library; iMessage/SMS support depends on macOS, Messages.app, and the external `imsg` command you choose.
+relaymux is probably the wrong tool if you need a sandbox, a multi-tenant service, durable distributed jobs, a cron/scheduler, hosted model inference, or a web UI. It is also not a general iMessage, SMS, or Telegram library.
 
 ## Troubleshooting
 
@@ -285,7 +342,7 @@ relaymux restart-launch-agent
 relaymux status-launch-agent
 ```
 
-If Messages send/receive fails, verify your `imsg` CLI first:
+If iMessage/SMS send/receive fails, verify your `imsg` CLI first:
 
 ```bash
 imsg chats --limit 5 --json
@@ -293,6 +350,13 @@ relaymux doctor
 ```
 
 You may need to grant the terminal or automation host the macOS permissions required by your message tool, such as Full Disk Access or Messages automation permission.
+
+If Telegram sending fails, verify the chat id, token source, and token file permissions:
+
+```bash
+chmod 600 ~/.relaymux/secrets/telegram-bot-token
+relaymux doctor
+```
 
 If tmux is missing:
 
@@ -308,7 +372,7 @@ chmod 600 ~/.relaymux/state/webhook-token
 relaymux doctor
 ```
 
-For a no-Messages smoke test from a clone:
+For a no-adapter smoke test from a clone:
 
 ```bash
 npm run build
@@ -326,7 +390,7 @@ npm ci
 npm run validate
 ```
 
-Issues and pull requests are welcome. Please keep public examples free of private paths, phone numbers, chat ids, and secrets.
+Issues and pull requests are welcome. Please keep public examples free of private paths, phone numbers, chat ids, tokens, and secrets.
 
 ## License
 

--- a/examples/config.mock.json
+++ b/examples/config.mock.json
@@ -6,29 +6,7 @@
     "sessionMode": "shared",
     "sessionPrefix": "rmx"
   },
-  "imessage": {
-    "chatId": "mock-chat",
-    "recipient": "+15555550123",
-    "pollMs": 1000,
-    "syncLimit": 5,
-    "maxReplyChars": 1400,
-    "receive": {
-      "backend": "command",
-      "command": {
-        "argv": ["sh", "-lc", "printf '%s\\n' '[]'"],
-        "cwd": "/tmp",
-        "timeoutMs": 5000
-      }
-    },
-    "send": {
-      "backend": "command",
-      "command": {
-        "argv": ["sh", "-lc", "printf '%s\\n' \"$1\" >> /tmp/relaymux-mock/outbox.txt", "sh", "{text}"],
-        "cwd": "/tmp",
-        "timeoutMs": 5000
-      }
-    }
-  },
+  "integrations": {},
   "daemon": {
     "enabled": true,
     "host": "127.0.0.1",

--- a/examples/config.telegram.json
+++ b/examples/config.telegram.json
@@ -8,34 +8,17 @@
   },
   "launchNotifications": {
     "onExit": "never",
-    "replyMode": "imessage",
+    "replyMode": "telegram",
     "tailLines": 80,
     "tailBytes": 4000
   },
   "integrations": {
-    "imessage": {
+    "telegram": {
       "enabled": true,
-      "chatId": "CHAT_ID_OR_PHONE",
-      "recipient": "",
-      "pollMs": 3000,
-      "syncLimit": 5,
-      "maxReplyChars": 1400,
-      "receive": {
-        "backend": "command",
-        "command": {
-          "argv": ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"],
-          "cwd": "~",
-          "timeoutMs": 30000
-        }
-      },
-      "send": {
-        "backend": "command",
-        "command": {
-          "argv": ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"],
-          "cwd": "~",
-          "timeoutMs": 60000
-        }
-      }
+      "chatId": "TELEGRAM_CHAT_ID",
+      "botTokenFile": "~/.relaymux/secrets/telegram-bot-token",
+      "parseMode": "",
+      "timeoutMs": 30000
     }
   },
   "daemon": {

--- a/examples/subagent-completion.md
+++ b/examples/subagent-completion.md
@@ -1,18 +1,8 @@
 # Subagent completion examples
 
-Ask delegated agents to report completion through `relaymux notify` instead of sending iMessages directly.
+Ask delegated agents to report completion through `relaymux notify` instead of sending adapter messages directly.
 
-User-visible completion:
-
-```bash
-relaymux notify \
-  --from build-agent \
-  --reply-mode imessage \
-  --idempotency-key "build-agent:job-123:done" \
-  --message "Finished the build fix. Validation: npm test passed. No blockers."
-```
-
-Quiet context-only update:
+Quiet context-only update (works without any message adapter):
 
 ```bash
 relaymux notify \
@@ -22,6 +12,22 @@ relaymux notify \
   --message "Still running tests; no user-visible update needed yet."
 ```
 
+User-visible completion through an optional adapter:
+
+```bash
+relaymux notify \
+  --from build-agent \
+  --reply-mode imessage \
+  --idempotency-key "build-agent:job-123:done" \
+  --message "Finished the build fix. Validation: npm test passed. No blockers."
+
+relaymux notify \
+  --from build-agent \
+  --reply-mode telegram \
+  --idempotency-key "build-agent:job-123:done-telegram" \
+  --message "Finished the build fix. Validation: npm test passed. No blockers."
+```
+
 Direct HTTP shape, if you cannot use the CLI helper:
 
 ```bash
@@ -29,5 +35,5 @@ TOKEN="$(cat ~/.relaymux/state/webhook-token)"
 curl -sS -X POST http://127.0.0.1:47761/message \
   -H "authorization: Bearer $TOKEN" \
   -H "content-type: application/json" \
-  -d '{"from":"build-agent","replyMode":"imessage","idempotencyKey":"build-agent:job-123:done","text":"Finished; tests passed."}'
+  -d '{"from":"build-agent","replyMode":"none","idempotencyKey":"build-agent:job-123:done","text":"Finished; tests passed."}'
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relaymux",
   "version": "0.1.0",
-  "description": "Orchestrate local CLI agents in tmux and receive async iMessage/SMS completions.",
+  "description": "Coordinate local CLI agents in tmux with a local API and optional notification adapters.",
   "type": "module",
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('dist/bin/relaymux.js', 0o755)\"",
@@ -11,8 +11,10 @@
   },
   "keywords": [
     "agents",
-    "imessage",
     "tmux",
+    "webhook",
+    "telegram",
+    "imessage",
     "orchestration",
     "cli"
   ],

--- a/src/args.ts
+++ b/src/args.ts
@@ -19,6 +19,7 @@ const BOOLEAN_FLAGS = new Set([
   "print-command",
   "restart",
   "symlink",
+  "telegram",
   "version",
   "wait",
 ]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { parseArgv } from "./args.js";
 import { buildAgentInvocation, buildTmuxShellCommand, buildTmuxShellScript, quoteArgv, renderTemplate, shellExportBlock } from "./command.js";
 import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
-import { defaultConfigPath, loadConfig, resolveLogDir, resolveStateDir, writeConfig, writeDefaultConfig } from "./config.js";
+import { defaultConfig, defaultConfigPath, isIntegrationEnabled, loadConfig, resolveLogDir, resolveStateDir, writeConfig } from "./config.js";
 import { runDaemon } from "./daemon.js";
 import { getLaunchAgentStatus, installLaunchAgent, launchAgentPath, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
 import { handleNotify } from "./notify.js";
@@ -15,10 +15,12 @@ import { webhookConfig, webhookStatus } from "./webhook.js";
 import { expandPath, ensureDirectory, pathExists, readTextFile } from "./paths.js";
 import { applyHomeMigration, buildHomeMigrationInventory, ensureRelaymuxHomeLayout, formatHomeMigrationInventory, formatHomeMigrationResults } from "./migration.js";
 import { buildImsgConfig, initOptionsFromFlags, resolveImsgChatId } from "./setup-imsg.js";
+import { buildTelegramConfig, initTelegramOptionsFromFlags, withTelegramIntegration } from "./setup-telegram.js";
 import { latestEventsByRun, readRuns, recordRun, writePromptFile, writeScriptFile } from "./state.js";
 import { resolveLaunchSession, resolveTmuxSessionMode } from "./session.js";
 import { createAgentWindow, createCommandWindow, killWindowByName, listAgentWindows, sendShellCommand, setWindowMetadata, validateSessionName } from "./tmux.js";
 import { createWorktree, resolveRepoAndWorkdir } from "./worktree.js";
+import { isReplyMode, replyModesText } from "./reply-modes.js";
 
 export async function main(argv, io = defaultIo()) {
   try {
@@ -100,7 +102,6 @@ async function handleSetup(flags, io) {
   if (!configInfo.exists || flags.force) {
     await handleInit({
       ...flags,
-      imsg: flags.imsg ?? true,
       installLaunchAgent: shouldInstallLaunchAgent,
     }, io);
     configInfo = loadConfig({ configPath, env: io.env });
@@ -123,7 +124,13 @@ async function handleSetup(flags, io) {
   if (status === 0) {
     io.stdout.write("Setup complete. relaymux is ready.\n");
     io.stdout.write("Next steps:\n");
-    io.stdout.write("  1. Text the configured chat; relaymux should reply from the background LaunchAgent.\n");
+    if (isIntegrationEnabled(configInfo.config, "imessage")) {
+      io.stdout.write("  1. Text the configured iMessage/SMS chat; relaymux should reply from the background LaunchAgent.\n");
+    } else if (isIntegrationEnabled(configInfo.config, "telegram")) {
+      io.stdout.write("  1. Send a Telegram-mode request with `relaymux ask --reply-mode telegram <text>` after setting the bot token.\n");
+    } else {
+      io.stdout.write("  1. Use the local CLI/API path: `relaymux ask <text>` or `relaymux notify --reply-mode none ...`.\n");
+    }
     io.stdout.write("  2. Run `relaymux status` to inspect the daemon and any tmux agent tabs.\n");
     io.stdout.write("  3. Use `relaymux launch --repo <path> --agent pi --prompt <task>` for a manual first agent.\n");
   } else {
@@ -133,34 +140,47 @@ async function handleSetup(flags, io) {
 }
 
 async function handleInit(flags, io) {
-  if (flags.imsg || flags.preset === "imsg") {
+  const wantsImsg = Boolean(flags.imsg || flags.preset === "imsg");
+  const wantsTelegram = Boolean(flags.telegram || flags.preset === "telegram");
+  const labels = [];
+  let config;
+
+  if (wantsImsg) {
     const chatId = await resolveImsgChatId(flags, io, io.env);
-    const config = buildImsgConfig({
+    config = buildImsgConfig({
       ...initOptionsFromFlags(flags),
       chatId,
     }, io.env);
-    const target = writeConfig(flags.config || defaultConfigPath(io.env), config, { force: Boolean(flags.force), env: io.env });
-    const homeDir = ensureRelaymuxHomeLayout(path.dirname(defaultConfigPath(io.env)));
-    io.stdout.write(`Created ${target} with imsg defaults\n`);
-    io.stdout.write(`relaymux home: ${homeDir} (state ${resolveStateDir(config, io.env)}, logs ${resolveLogDir(config, io.env)})\n`);
-    io.stdout.write("Next: relaymux doctor && relaymux restart-launch-agent && relaymux status\n");
-    if (flags.installLaunchAgent) {
-      installLaunchAgent({
-        flags: { load: flags.load },
-        configInfo: { config, path: target, exists: true },
-        binPath: process.argv[1],
-        io,
-      });
-    }
-    return 0;
+    labels.push("iMessage/SMS adapter");
+  } else if (wantsTelegram) {
+    config = buildTelegramConfig(initTelegramOptionsFromFlags(flags), io.env);
+    labels.push("Telegram adapter");
+  } else {
+    config = defaultConfig(io.env);
   }
 
-  const target = writeDefaultConfig(flags.config || defaultConfigPath(io.env), { force: Boolean(flags.force), env: io.env });
-  const config = loadConfig({ configPath: target, env: io.env }).config;
+  if (wantsTelegram && wantsImsg) {
+    config = withTelegramIntegration(config, initTelegramOptionsFromFlags(flags));
+    labels.push("Telegram adapter");
+  }
+
+  const target = writeConfig(flags.config || defaultConfigPath(io.env), config, { force: Boolean(flags.force), env: io.env });
   const homeDir = ensureRelaymuxHomeLayout(path.dirname(defaultConfigPath(io.env)));
-  io.stdout.write(`Created ${target}\n`);
+  io.stdout.write(`Created ${target}${labels.length ? ` with ${labels.join(" and ")} defaults` : " with core defaults"}\n`);
   io.stdout.write(`relaymux home: ${homeDir} (state ${resolveStateDir(config, io.env)}, logs ${resolveLogDir(config, io.env)})\n`);
-  io.stdout.write("Tip: use `relaymux init --imsg` for an imsg-based setup wizard.\n");
+  if (labels.length) {
+    io.stdout.write("Next: relaymux doctor && relaymux restart-launch-agent && relaymux status\n");
+  } else {
+    io.stdout.write("Tip: add optional adapters later with `relaymux init --imsg` or `relaymux init --telegram` into a new config.\n");
+  }
+  if (flags.installLaunchAgent) {
+    installLaunchAgent({
+      flags: { load: flags.load },
+      configInfo: { config, path: target, exists: true },
+      binPath: process.argv[1],
+      io,
+    });
+  }
   return 0;
 }
 
@@ -328,8 +348,8 @@ function handleLaunch(flags, configInfo, stateDir, io) {
 async function handleAsk(flags, positionals, configInfo, io) {
   const text = resolveRequestText(flags, positionals);
   const replyMode = flags.replyMode || "none";
-  if (!["imessage", "none"].includes(replyMode)) {
-    throw new Error("--reply-mode must be imessage or none");
+  if (!isReplyMode(replyMode)) {
+    throw new Error(`--reply-mode must be ${replyModesText()}`);
   }
 
   const metadata = flags.metadataJson ? parseMetadataJson(flags.metadataJson) : {};
@@ -357,7 +377,7 @@ async function handleAsk(flags, positionals, configInfo, io) {
 
 function handleStartTmux(flags, configInfo, stateDir, io) {
   if (!flags.allowTmuxDaemon) {
-    throw new Error("start-tmux daemon mode is retired: iMessage/background/orchestrator must run as a direct LaunchAgent outside tmux. Use `relaymux restart-launch-agent` for the background service and `relaymux launch` for agent tmux tabs.");
+    throw new Error("start-tmux daemon mode is retired: the relaymux background service must run as a direct LaunchAgent outside tmux. Use `relaymux restart-launch-agent` for the background service and `relaymux launch` for agent tmux tabs.");
   }
   if (!flags.session) {
     throw new Error("Missing --session <name> for start-tmux");
@@ -475,7 +495,7 @@ function handleStartTmux(flags, configInfo, stateDir, io) {
 
 async function handleSuperviseTmux(flags, configInfo, stateDir, io) {
   if (!flags.allowTmuxDaemon) {
-    throw new Error("supervise-tmux daemon mode is retired: the background iMessage/orchestrator service must run direct outside tmux.");
+    throw new Error("supervise-tmux daemon mode is retired: the relaymux background service must run direct outside tmux.");
   }
   const config = configInfo.config;
   const session = String(flags.session || io.env.RELAYMUX_SESSION || config.session || "agents");
@@ -616,8 +636,8 @@ function resolveLaunchNotification(flags, config) {
   if (!["never", "failure", "always"].includes(onExit)) {
     throw new Error("--notify-on-exit / launchNotifications.onExit must be never, failure, or always");
   }
-  if (!["imessage", "none"].includes(replyMode)) {
-    throw new Error("--notify-reply-mode / launchNotifications.replyMode must be imessage or none");
+  if (!isReplyMode(replyMode)) {
+    throw new Error(`--notify-reply-mode / launchNotifications.replyMode must be ${replyModesText()}`);
   }
 
   return { onExit, replyMode, tailLines, tailBytes };
@@ -874,10 +894,10 @@ function defaultIo() {
 }
 
 function helpText() {
-  return `relaymux - relay iMessage/SMS requests to local coding agents
+  return `relaymux - coordinate local CLI agents in tmux with optional notification adapters
 
 Mental model:
-  - iMessage/background/orchestrator runs as a direct macOS LaunchAgent outside tmux.
+  - The background daemon/local API runs as a direct macOS LaunchAgent outside tmux when installed.
   - By default, all agents open as tmux tabs/windows in one shared session.
   - Managed config/state/logs/prompts/scratch live under ~/.relaymux by default.
   - Use --session only when you explicitly want a separate/new/named tmux session; panes/splits are never used.
@@ -888,23 +908,30 @@ Start here:
   relaymux status
 
 Usage:
-  relaymux setup [--imsg] [--chat-id <id>] [--no-launch-agent]
+  relaymux setup [--imsg|--telegram] [--chat-id <id>] [--telegram-chat-id <id>] [--no-launch-agent]
   relaymux init [--force] [--config <path>]
   relaymux init --imsg [--chat-id <id>] [--install-launch-agent]
+  relaymux init --telegram [--telegram-chat-id <id>] [--install-launch-agent]
   relaymux install-launch-agent [--dry-run] [--no-load]
   relaymux restart-launch-agent [--dry-run] [--no-load]
   relaymux status-launch-agent [--json]
   relaymux uninstall-launch-agent
   relaymux launch --repo <path> --agent <name> --prompt <text|@file> [--name <name>] [--notify-on-exit never|failure|always]
-  relaymux ask <text> [--no-wait] [--reply-mode imessage|none]
+  relaymux ask <text> [--no-wait] [--reply-mode imessage|telegram|none]
   relaymux status [--json] [--session <name>]
-  relaymux notify [--run-id <id>] [--reply-mode imessage|none] [--message <text>]
+  relaymux notify [--run-id <id>] [--reply-mode imessage|telegram|none] [--message <text>]
   relaymux migrate-home [--dry-run] [--apply] [--symlink]
   relaymux doctor
 
 Setup/init options:
-  --imsg                    Create an imsg-based config and prompt for a chat when possible
+  --imsg                    Enable the optional iMessage/SMS adapter and prompt for a chat when possible
+  --telegram                Enable the optional Telegram adapter
   --chat-id <id>            Messages chat id/phone for imsg history/send
+  --telegram-chat-id <id>   Telegram chat id for Bot API sendMessage
+  --telegram-bot-token-env <name>   Env var that contains the Telegram bot token (default TELEGRAM_BOT_TOKEN)
+  --telegram-bot-token-file <path>  File that contains the Telegram bot token (contents are never printed)
+  --telegram-parse-mode <mode>      Optional Telegram parse_mode such as MarkdownV2 or HTML
+  --telegram-timeout-ms <ms>        Telegram sendMessage timeout (default 30000)
   --cwd <path>              Working directory for Pi and message commands
   --state-dir <path>        State/token/log directory
   --install-launch-agent    Install the direct/background LaunchAgent after writing config
@@ -930,7 +957,7 @@ Launch options:
   --hold                     Keep a shell open after the agent exits
   --attach                   Print attach command after launch
   --notify-on-exit <mode>    Auto relaymux notify on agent exit: never (default), failure, or always
-  --notify-reply-mode <mode> imessage sends chat updates; none records quiet completion context
+  --notify-reply-mode <mode> imessage/telegram sends adapter updates; none records quiet completion context
   --notify-tail-lines <n>    Recent tmux output lines to include for nonzero auto notifications
   --notify-tail-bytes <n>    Max bytes of recent tmux output in nonzero auto notifications
 
@@ -942,7 +969,7 @@ Request/notify/status options:
   --message <text>           Request/notify message text
   --no-wait                  For ask/request: enqueue and return immediately
   --timeout-ms <ms>          For ask/request: client-side wait timeout
-  --reply-mode <mode>        imessage sends a concise chat update; none is quiet/no text
+  --reply-mode <mode>        imessage/telegram sends an adapter update; none is quiet/no text
   --from <name>              For notify: source/subagent name
   --idempotency-key <key>    For notify: suppress duplicate completion webhook retries
   --metadata-json <json>     For notify: optional metadata object
@@ -950,7 +977,7 @@ Request/notify/status options:
 
 Useful commands:
   tmux attach -t <session>       attach to the shared or named agent session
-  tmux kill-session -t <session> kill only that tmux session; background iMessage keeps running
+  tmux kill-session -t <session> kill only that tmux session; background daemon/adapters keep running
 
 Default home layout: ~/.relaymux/{config.json,state,logs,tasks,reports,research,workouts}.
 Config defaults to ${defaultConfigPath()} (legacy ~/.config/relaymux/config.json is still read if the new config does not exist).

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,3 +1,5 @@
+import { isReplyMode, replyModesText } from "./reply-modes.js";
+
 const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const SAFE_SHELL_TOKEN = /^[A-Za-z0-9_/:=@%+.,-]+$/;
 
@@ -178,15 +180,15 @@ function buildExitNotificationBlock(notifyBase, notification) {
 
 function normalizeLaunchNotification(notification: any = {}) {
   const onExit = notification.onExit || "never";
-  const replyMode = notification.replyMode || "imessage";
+  const replyMode = notification.replyMode || "none";
   const tailLines = normalizePositiveInteger(notification.tailLines, 80);
   const tailBytes = normalizePositiveInteger(notification.tailBytes, 4000);
 
   if (!["never", "failure", "always"].includes(onExit)) {
     throw new Error(`launchNotifications.onExit must be never, failure, or always (got ${JSON.stringify(onExit)})`);
   }
-  if (!["imessage", "none"].includes(replyMode)) {
-    throw new Error(`launchNotifications.replyMode must be imessage or none (got ${JSON.stringify(replyMode)})`);
+  if (!isReplyMode(replyMode)) {
+    throw new Error(`launchNotifications.replyMode must be ${replyModesText()} (got ${JSON.stringify(replyMode)})`);
   }
 
   return { onExit, replyMode, tailLines, tailBytes };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,48 @@ import path from "node:path";
 
 import { defaultRelaymuxHome, defaultRelaymuxHomeConfigValue, expandPath } from "./paths.js";
 
+export function defaultImessageIntegration() {
+  return {
+    enabled: false,
+    chatId: "",
+    recipient: "",
+    pollMs: 3000,
+    syncLimit: 5,
+    maxReplyChars: 1400,
+    receive: {
+      backend: "command",
+      command: {
+        description: "Command must print recent messages as JSON/JSONL. This imsg example is a placeholder.",
+        argv: ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"],
+        cwd: "~",
+        timeoutMs: 30000,
+      },
+    },
+    send: {
+      backend: "command",
+      command: {
+        description: "Command sends one text chunk. This imsg example is a placeholder.",
+        argv: ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"],
+        cwd: "~",
+        timeoutMs: 60000,
+      },
+    },
+  };
+}
+
+export function defaultTelegramIntegration() {
+  return {
+    enabled: false,
+    chatId: "",
+    botTokenEnv: "TELEGRAM_BOT_TOKEN",
+    botTokenFile: "",
+    parseMode: "",
+    apiBaseUrl: "https://api.telegram.org",
+    timeoutMs: 30000,
+    maxMessageChars: 3900,
+  };
+}
+
 export function defaultConfig(env = process.env) {
   const homeDir = defaultRelaymuxHomeConfigValue(env);
   const stateDir = path.posix.join(homeDir, "state");
@@ -22,35 +64,11 @@ export function defaultConfig(env = process.env) {
     },
     launchNotifications: {
       onExit: "never",
-      replyMode: "imessage",
+      replyMode: "none",
       tailLines: 80,
       tailBytes: 4000,
     },
-    imessage: {
-      chatId: "CHAT_ID_OR_PHONE",
-      recipient: "+15555550123",
-      pollMs: 3000,
-      syncLimit: 5,
-      maxReplyChars: 1400,
-      receive: {
-        backend: "command",
-        command: {
-          description: "Command must print recent messages as JSON/JSONL. This imsg example is a placeholder.",
-          argv: ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"],
-          cwd: "~",
-          timeoutMs: 30000,
-        },
-      },
-      send: {
-        backend: "command",
-        command: {
-          description: "Command sends one text chunk. This imsg example is a placeholder.",
-          argv: ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"],
-          cwd: "~",
-          timeoutMs: 60000,
-        },
-      },
-    },
+    integrations: {},
     daemon: {
       enabled: true,
       host: "127.0.0.1",
@@ -184,6 +202,30 @@ export function resolveTokenFile(config, env = process.env) {
   return expandPath(config.daemon?.tokenFile || defaultConfig(env).daemon.tokenFile);
 }
 
+export function getIntegration(config, name) {
+  const raw = integrationOverride(config, name);
+  const defaults = name === "imessage"
+    ? defaultImessageIntegration()
+    : name === "telegram"
+      ? defaultTelegramIntegration()
+      : { enabled: false };
+  const merged = mergeConfig(defaults, raw || {});
+  if (raw && !Object.prototype.hasOwnProperty.call(raw, "enabled")) {
+    merged.enabled = true;
+  }
+  return merged;
+}
+
+export function isIntegrationEnabled(config, name) {
+  return getIntegration(config, name).enabled === true;
+}
+
+export function defaultReplyModeForConfig(config) {
+  if (isIntegrationEnabled(config, "imessage")) return "imessage";
+  if (isIntegrationEnabled(config, "telegram")) return "telegram";
+  return "none";
+}
+
 function normalizeConfig(config, override) {
   if (!isPlainObject(override)) {
     return config;
@@ -199,7 +241,42 @@ function normalizeConfig(config, override) {
     }
   }
 
+  config.integrations = config.integrations || {};
+
+  if (hasOwnPath(override, ["integrations", "imessage"])) {
+    config.integrations.imessage = normalizeIntegration(defaultImessageIntegration(), override.integrations.imessage);
+  } else if (hasOwnPath(override, ["imessage"])) {
+    config.integrations.imessage = normalizeIntegration(defaultImessageIntegration(), override.imessage);
+  }
+
+  if (hasOwnPath(override, ["integrations", "telegram"])) {
+    config.integrations.telegram = normalizeIntegration(defaultTelegramIntegration(), override.integrations.telegram);
+  }
+
+  if (hasOwnPath(override, ["imessage"]) && config.integrations.imessage?.enabled && !hasOwnPath(override, ["launchNotifications", "replyMode"])) {
+    config.launchNotifications = config.launchNotifications || {};
+    config.launchNotifications.replyMode = "imessage";
+  }
+
   return config;
+}
+
+function normalizeIntegration(defaults, override) {
+  if (override === false) return { ...defaults, enabled: false };
+  const raw = isPlainObject(override) ? override : {};
+  const normalized = mergeConfig(defaults, raw);
+  if (!Object.prototype.hasOwnProperty.call(raw, "enabled")) {
+    normalized.enabled = true;
+  } else {
+    normalized.enabled = raw.enabled === true;
+  }
+  return normalized;
+}
+
+function integrationOverride(config, name) {
+  if (hasOwnPath(config, ["integrations", name])) return config.integrations[name];
+  if (name === "imessage" && hasOwnPath(config, ["imessage"])) return config.imessage;
+  return null;
 }
 
 function mergeConfig(base, override) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 
 import { createCompletionWebhookServer } from "./webhook.js";
 import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorPrompt, runOrchestrator } from "./orchestrator.js";
-import { formatIncomingForPrompt, isIncomingUserMessage, receiveMessages, sendMessage } from "./message-io.js";
+import { formatIncomingForPrompt, isImessageReceiveEnabled, isIncomingUserMessage, receiveMessages, sendMessage } from "./message-io.js";
+import { sendTelegramMessage } from "./telegram.js";
 import { ensureDirectory } from "./paths.js";
 import { validateSessionName } from "./tmux.js";
 
@@ -112,17 +113,17 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     try {
       const prompt = buildWebhookOrchestratorPrompt({ config, configPath: configInfo.path, job });
       const reply = await runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId });
-      if (job.replyMode === "imessage") {
-        await sendMessage(config, reply, io);
-        log(`sent completion reply for ${job.requestId}`);
-      } else {
+      if (job.replyMode === "none") {
         log(`processed quiet completion ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
+      } else {
+        await sendReply(config, job.replyMode, reply, io);
+        log(`sent ${job.replyMode} completion reply for ${job.requestId}`);
       }
     } catch (error) {
       warn(`failed processing local completion ${job.requestId}:`, describeError(error));
-      if (job.replyMode === "imessage") {
+      if (job.replyMode !== "none") {
         try {
-          await sendMessage(config, `relaymux orchestrator hit an error processing ${job.source}: ${error.message || String(error)}`, io);
+          await sendReply(config, job.replyMode, `relaymux orchestrator hit an error processing ${job.source}: ${error.message || String(error)}`, io);
         } catch (sendError) {
           warn("also failed to send completion error message:", describeError(sendError));
         }
@@ -135,19 +136,19 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     try {
       const prompt = buildTerminalOrchestratorPrompt({ config, configPath: configInfo.path, job });
       const reply = await runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId });
-      if (job.replyMode === "imessage") {
-        await sendMessage(config, reply, io);
-        log(`sent terminal request reply for ${job.requestId}`);
-      } else {
+      if (job.replyMode === "none") {
         log(`processed terminal request ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
+      } else {
+        await sendReply(config, job.replyMode, reply, io);
+        log(`sent ${job.replyMode} terminal request reply for ${job.requestId}`);
       }
       job.deferred?.resolve({ ok: true, queued: false, reply });
     } catch (error) {
       const message = `relaymux orchestrator hit an error processing ${job.source}: ${error.message || String(error)}`;
       warn(`failed processing terminal request ${job.requestId}:`, describeError(error));
-      if (job.replyMode === "imessage") {
+      if (job.replyMode !== "none") {
         try {
-          await sendMessage(config, message, io);
+          await sendReply(config, job.replyMode, message, io);
         } catch (sendError) {
           warn("also failed to send terminal request error message:", describeError(sendError));
         }
@@ -184,8 +185,12 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     if (fresh.length) enqueueIncoming(fresh);
   }
 
-  log("starting relaymux iMessage orchestrator daemon");
-  if (!state.initialized) {
+  const inboundImessageEnabled = isImessageReceiveEnabled(config);
+  log("starting relaymux background daemon");
+  if (inboundImessageEnabled) log("iMessage/SMS adapter enabled for inbound polling");
+  else log("no inbound message adapter enabled; serving local API/webhook only");
+
+  if (inboundImessageEnabled && !state.initialized) {
     try {
       const recent = await receiveMessages(config);
       const initialIds = recent.filter(isIncomingUserMessage).map((message) => String(message.id));
@@ -212,7 +217,9 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
       });
   if (webhookServer) log(`local completion webhook listening on ${config.daemon?.host || "127.0.0.1"}:${Number(config.daemon?.port || 47761)}`);
 
-  await pollOnce().catch((error) => warn("initial poll failed:", describeError(error)));
+  if (inboundImessageEnabled) {
+    await pollOnce().catch((error) => warn("initial poll failed:", describeError(error)));
+  }
   await drainIfOnce(flags, processQueue);
 
   if (flags.once) {
@@ -221,14 +228,16 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     return 0;
   }
 
-  const interval = setInterval(() => {
-    pollOnce().catch((error) => warn("poll failed:", describeError(error)));
-  }, Number(config.imessage?.pollMs || 3000));
+  const interval = inboundImessageEnabled
+    ? setInterval(() => {
+        pollOnce().catch((error) => warn("poll failed:", describeError(error)));
+      }, Number(config.integrations?.imessage?.pollMs || config.imessage?.pollMs || 3000))
+    : null;
 
   await new Promise<void>((resolve) => {
     const shutdown = async (signal) => {
       log(`shutting down (${signal})`);
-      clearInterval(interval);
+      if (interval) clearInterval(interval);
       if (webhookServer) await closeServer(webhookServer);
       resolve();
     };
@@ -277,6 +286,12 @@ function compareMessages(a, b) {
 async function drainIfOnce(flags, processQueue) {
   if (!flags.once) return;
   await processQueue();
+}
+
+async function sendReply(config, replyMode, text, io) {
+  if (replyMode === "imessage") return sendMessage(config, text, io);
+  if (replyMode === "telegram") return sendTelegramMessage(config, text, io, io.env || process.env);
+  throw new Error(`unsupported reply mode: ${replyMode}`);
 }
 
 async function closeServer(server) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
-import { defaultConfigPath, legacyDefaultConfigPath, resolveLogDir, resolveStateDir } from "./config.js";
+import { defaultConfigPath, getIntegration, isIntegrationEnabled, legacyDefaultConfigPath, resolveLogDir, resolveStateDir } from "./config.js";
 import { validateConfiguredAgentCommand } from "./command-validation.js";
 import { runCommand } from "./process.js";
 import { getLaunchAgentStatus, launchAgentPath } from "./launch-agent.js";
@@ -85,11 +86,25 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
   }
 
   checks.push(commandCheck("orchestrator", config.orchestrator?.command?.[0], env));
-  if (config.imessage?.receive?.backend === "command") {
-    checks.push(commandCheck("message-receive", config.imessage.receive.command?.argv?.[0], env));
+
+  const imessage = getIntegration(config, "imessage");
+  if (isIntegrationEnabled(config, "imessage")) {
+    if (imessage.receive?.backend === "command" && imessage.receive?.enabled !== false) {
+      checks.push(commandCheck("imessage-receive", imessage.receive.command?.argv?.[0], env));
+    }
+    if (imessage.send?.backend === "command" && imessage.send?.enabled !== false) {
+      checks.push(commandCheck("imessage-send", imessage.send.command?.argv?.[0], env));
+    }
   }
-  if (config.imessage?.send?.backend === "command") {
-    checks.push(commandCheck("message-send", config.imessage.send.command?.argv?.[0], env));
+
+  const telegram = getIntegration(config, "telegram");
+  if (isIntegrationEnabled(config, "telegram")) {
+    checks.push({
+      name: "telegram-chat-id",
+      ok: Boolean(String(telegram.chatId || "").trim()) && telegram.chatId !== "TELEGRAM_CHAT_ID",
+      detail: telegram.chatId && telegram.chatId !== "TELEGRAM_CHAT_ID" ? "configured" : "missing config.integrations.telegram.chatId",
+    });
+    checks.push(telegramTokenCheck(telegram, env));
   }
 
   const webhook = webhookStatus(config);
@@ -150,4 +165,42 @@ function commandCheck(name, command, env) {
     ok: Boolean(executable),
     detail: executable || `${command || "missing command"} not found on PATH`,
   };
+}
+
+function telegramTokenCheck(telegram, env) {
+  const tokenEnv = String(telegram.botTokenEnv || "").trim();
+  if (tokenEnv && env[tokenEnv]) {
+    return { name: "telegram-token", ok: true, detail: `env ${tokenEnv} is set` };
+  }
+
+  const tokenFile = String(telegram.botTokenFile || "").trim();
+  if (tokenFile) {
+    const file = expandHome(tokenFile, env);
+    try {
+      const stat = fs.statSync(file);
+      const mode = stat.mode & 0o777;
+      const hasToken = Boolean(fs.readFileSync(file, "utf8").trim());
+      return {
+        name: "telegram-token",
+        ok: stat.isFile() && hasToken && (mode & 0o077) === 0,
+        detail: `${file} mode 0${mode.toString(8)}${hasToken ? "" : " (empty)"}`,
+      };
+    } catch {
+      return { name: "telegram-token", ok: false, detail: `token file missing: ${file}` };
+    }
+  }
+
+  return {
+    name: "telegram-token",
+    ok: false,
+    detail: tokenEnv ? `env ${tokenEnv} is not set` : "missing botTokenEnv or botTokenFile",
+  };
+}
+
+function expandHome(value, env) {
+  const text = String(value || "");
+  const home = env.HOME || process.env.HOME || os.homedir();
+  if (text === "~") return home;
+  if (text.startsWith("~/")) return path.join(home, text.slice(2));
+  return text;
 }

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -297,7 +297,7 @@ function resolveLaunchMode(flags, config) {
   const rawMode = String(explicitMode || config.daemon?.launchMode || "direct");
   const mode = rawMode === "background" ? "direct" : rawMode;
   if (explicitMode && !["direct", "background"].includes(String(explicitMode))) {
-    throw new Error("LaunchAgent tmux mode has been removed. The background iMessage/orchestrator service must run direct; use start-tmux only for legacy manual debugging.");
+    throw new Error("LaunchAgent tmux mode has been removed. The relaymux background service must run direct; use start-tmux only for legacy manual debugging.");
   }
   if (["direct", "tmux", "supervised-tmux"].includes(mode)) {
     return "direct";

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { renderTemplate } from "./command.js";
+import { getIntegration, isIntegrationEnabled } from "./config.js";
 import { expandPath } from "./paths.js";
 import { runCommandAsync } from "./async-process.js";
 
@@ -59,7 +60,7 @@ export function formatIncomingForPrompt(messages) {
   if (normalized.length === 1) {
     const message = normalized[0];
     const attachments = formatAttachments(message.attachments);
-    return `New incoming iMessage/SMS from the configured chat (${message.createdAt || "unknown time"}, message id ${message.id}).\n\n${message.text || "[no text]"}${attachments}\n\nReply directly and concisely as a text message. Do not mention daemon internals.`;
+    return `New incoming message from the configured iMessage/SMS adapter chat (${message.createdAt || "unknown time"}, message id ${message.id}).\n\n${message.text || "[no text]"}${attachments}\n\nReply directly and concisely. Do not mention daemon internals.`;
   }
 
   const body = normalized
@@ -68,7 +69,7 @@ export function formatIncomingForPrompt(messages) {
       return `- ${message.createdAt || "unknown time"} id=${message.id}: ${message.text || "[no text]"}${attachments}`;
     })
     .join("\n");
-  return `The configured iMessage/SMS chat sent these new messages, in order:\n${body}\n\nRespond once, directly and concisely as a text message. Do not mention daemon internals.`;
+  return `The configured iMessage/SMS adapter chat sent these new messages, in order:\n${body}\n\nRespond once, directly and concisely. Do not mention daemon internals.`;
 }
 
 export function splitMessage(text, maxChars = 1400) {
@@ -95,11 +96,17 @@ export function buildAdapterArgv(commandConfig, context) {
   return commandConfig.argv.map((part) => renderTemplate(part, context));
 }
 
-export async function receiveMessages(config) {
-  const imessage = config.imessage || {};
+export function isImessageReceiveEnabled(config) {
+  const imessage = getIntegration(config, "imessage");
   const receive = imessage.receive || {};
-  if (receive.backend === "none" || receive.enabled === false) return [];
-  if (receive.backend !== "command") throw new Error(`unsupported receive backend: ${receive.backend || "missing"}`);
+  return imessage.enabled === true && receive.enabled !== false && receive.backend !== "none";
+}
+
+export async function receiveMessages(config) {
+  const imessage = getIntegration(config, "imessage");
+  const receive = imessage.receive || {};
+  if (!isImessageReceiveEnabled(config)) return [];
+  if (receive.backend !== "command") throw new Error(`unsupported iMessage receive backend: ${receive.backend || "missing"}`);
 
   const commandConfig = receive.command || {};
   const argv = buildAdapterArgv(commandConfig, messageContext(config, { limit: imessage.syncLimit || 5 }));
@@ -112,7 +119,10 @@ export async function receiveMessages(config) {
 }
 
 export async function sendMessage(config: any, text: string, io: any = process) {
-  const imessage = config.imessage || {};
+  const imessage = getIntegration(config, "imessage");
+  if (!isIntegrationEnabled(config, "imessage")) {
+    throw new Error("iMessage/SMS adapter is not enabled in config.integrations.imessage");
+  }
   const send = imessage.send || {};
   const maxReplyChars = Number(imessage.maxReplyChars || 1400);
   const chunks = splitMessage(text, maxReplyChars);
@@ -123,7 +133,7 @@ export async function sendMessage(config: any, text: string, io: any = process) 
     }
     return;
   }
-  if (send.backend !== "command") throw new Error(`unsupported send backend: ${send.backend || "missing"}`);
+  if (send.backend !== "command") throw new Error(`unsupported iMessage send backend: ${send.backend || "missing"}`);
 
   const commandConfig = send.command || {};
   for (const chunk of chunks) {
@@ -145,7 +155,7 @@ export function commandSafeMessageText(text) {
 }
 
 export function messageContext(config, extra = {}) {
-  const imessage = config.imessage || {};
+  const imessage = getIntegration(config, "imessage");
   return {
     chatId: imessage.chatId || "",
     recipient: imessage.recipient || "",

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -5,6 +5,7 @@ import { renderTemplate } from "./command.js";
 import { runCommand } from "./process.js";
 import { formatHostForUrl, webhookConfig } from "./webhook.js";
 import { expandPath } from "./paths.js";
+import { isReplyMode, replyModesText } from "./reply-modes.js";
 
 export async function handleNotify({ flags, positionals, config, stateDir, io }) {
   const runId = flags.runId || process.env.RELAYMUX_RUN_ID;
@@ -89,8 +90,8 @@ async function postCompletionWebhook(config, flags, event) {
   if (!event.message?.trim()) {
     throw new Error("Missing --message/--text for daemon completion webhook");
   }
-  if (!["imessage", "none"].includes(event.replyMode)) {
-    throw new Error("--reply-mode must be imessage or none");
+  if (!isReplyMode(event.replyMode)) {
+    throw new Error(`--reply-mode must be ${replyModesText()}`);
   }
 
   const resolved = webhookConfig(config);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -12,7 +12,7 @@ export function buildIncomingOrchestratorPrompt({ config, configPath, incomingTe
   return buildFullPrompt({
     config,
     configPath,
-    title: "Incoming iMessage/SMS turn",
+    title: "Incoming iMessage/SMS adapter turn",
     body: incomingText,
   });
 }
@@ -22,9 +22,9 @@ export function buildWebhookOrchestratorPrompt({ config, configPath, job }) {
     ? `\nMetadata JSON:\n${JSON.stringify(job.metadata, null, 2)}`
     : "";
   const idempotencyText = job.idempotencyKey ? `\nIdempotency key: ${job.idempotencyKey}` : "";
-  const replyInstruction = job.replyMode === "imessage"
-    ? "Reply mode is imessage: produce one concise user-visible text-message update. Avoid spam and mention only meaningful completion, failure, or blockers."
-    : "Reply mode is none: process this local update as context only. The daemon will not text the user, so return a short internal acknowledgement.";
+  const replyInstruction = job.replyMode === "none"
+    ? "Reply mode is none: process this local update as context only. The daemon will not send a user-visible adapter message, so return a short internal acknowledgement."
+    : `Reply mode is ${job.replyMode}: produce one concise user-visible adapter update. Avoid spam and mention only meaningful completion, failure, or blockers.`;
 
   return buildFullPrompt({
     config,
@@ -38,9 +38,9 @@ export function buildTerminalOrchestratorPrompt({ config, configPath, job }) {
   const metadataText = Object.keys(job.metadata || {}).length
     ? `\nMetadata JSON:\n${JSON.stringify(job.metadata, null, 2)}`
     : "";
-  const replyInstruction = job.replyMode === "imessage"
-    ? "Reply mode is imessage: do the requested work, then produce one concise user-visible text-message status. The daemon will also return the same text to the terminal command."
-    : "Reply mode is none: do the requested work and return one concise terminal-visible status. The daemon will not text the user.";
+  const replyInstruction = job.replyMode === "none"
+    ? "Reply mode is none: do the requested work and return one concise terminal-visible status. The daemon will not send an adapter message."
+    : `Reply mode is ${job.replyMode}: do the requested work, then produce one concise user-visible adapter status. The daemon will also return the same text to the terminal command.`;
 
   return buildFullPrompt({
     config,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,10 +1,10 @@
-export const DEFAULT_ORCHESTRATOR_SYSTEM_PROMPT = `You are a local Pi orchestrator reachable through a private iMessage/SMS chat.
+export const DEFAULT_ORCHESTRATOR_SYSTEM_PROMPT = `You are a local relaymux orchestrator reachable through a private local daemon. Optional adapters such as iMessage/SMS or Telegram may deliver user-visible replies, but relaymux itself is a local CLI, tmux, and webhook coordinator.
 
 Your job:
-- Understand the user's short text-message requests.
-- Reply concisely in a text-message-friendly style.
-- For coding work that may take more than a short moment, delegate to tmux subagents instead of blocking the chat turn.
-- Stay repo-agnostic: ask for a repo/path when needed, and never assume company, project, identity, phone, or secret context.
+- Understand short requests from local CLI/API calls or optional message adapters.
+- Reply concisely in a terminal/message-friendly style.
+- For coding work that may take more than a short moment, delegate to tmux subagents instead of blocking the current turn.
+- Stay repo-agnostic: ask for a repo/path when needed, and never assume company, project, identity, phone, chat, or secret context.
 
 Delegating with relaymux:
 - Launch subagents with relaymux launch, choosing an agent configured in the user's relaymux config.
@@ -18,19 +18,19 @@ Delegating with relaymux:
 - Do not move or rewrite existing personal canonical files just because they look related; inventory and ask before migrating them.
 - Give each subagent exact scope, files or areas to inspect first when known, acceptance criteria, and validation commands.
 - Ask subagents to report meaningful completion or blockers with relaymux notify.
-- Use --reply-mode imessage for user-visible completion updates and --reply-mode none for quiet context-only updates.
-- Include an idempotency key when asking a subagent to notify, so retries do not duplicate chat updates.
-- When a delegated run must notify even if the model forgets, add relaymux launch --notify-on-exit failure or --notify-on-exit always with --notify-reply-mode imessage. Use this deliberately to avoid spam.
+- Use --reply-mode none for quiet context-only updates. Use --reply-mode imessage or --reply-mode telegram only when that adapter is configured and a user-visible update is appropriate.
+- Include an idempotency key when asking a subagent to notify, so retries do not duplicate adapter updates.
+- When a delegated run must notify even if the model forgets, add relaymux launch --notify-on-exit failure or --notify-on-exit always with --notify-reply-mode <mode>. Use this deliberately to avoid spam.
 
 Example completion command for a subagent:
-relaymux notify --from <subagent-name> --reply-mode imessage --idempotency-key <stable-key> --message "Finished: summary, validation, blockers."
+relaymux notify --from <subagent-name> --reply-mode <imessage|telegram|none> --idempotency-key <stable-key> --message "Finished: summary, validation, blockers."
 
 Operational rules:
-- The background daemon sends your final answer over iMessage/SMS and runs outside tmux under launchd. Do not call the send-message command yourself unless the user explicitly asks and it is safe.
-- Do not mention daemon internals unless debugging the daemon itself.
+- The background daemon sends final answers over the selected optional adapter when replyMode is imessage or telegram. Do not call adapter send commands yourself unless the user explicitly asks and it is safe.
+- Do not mention daemon internals unless debugging relaymux itself.
 - Inspect real tmux/repo/test state before claiming delegated work is complete.
 - Do not close or kill long-running code-task tmux tabs or sessions unless the user explicitly asks.
-- Never include secrets, tokens, private keys, or full credentials in prompts, logs, PRs, or chat replies.
+- Never include secrets, tokens, private keys, or full credentials in prompts, logs, PRs, or adapter replies.
 - If the request is vague or unsafe, ask one concise clarifying question instead of opening a swarm.
 - There is no durable /loop feature in relaymux; do not promise scheduled looping.`;
 
@@ -45,7 +45,7 @@ export function buildRuntimePromptContext({ configPath, homeDir, stateDir, sessi
   return `Runtime context:
 - relaymux config: ${configPath}
 - relaymux managed home: ${homeDir} (state ${stateDir}; logs ${homeDir}/logs; task scratch ${homeDir}/tasks; research ${homeDir}/research; workouts ${homeDir}/workouts)
-- background service: launchd direct/background process outside tmux
+- background service: direct/background process outside tmux when installed
 - tmux model: ${grouping}; agents appear as tabs/windows, never panes/splits
 - local completion webhook: ${webhookUrl}
 - webhook token file for helpers: ${tokenFile}
@@ -53,6 +53,6 @@ export function buildRuntimePromptContext({ configPath, homeDir, stateDir, sessi
 - default launch behavior: ${defaultLaunchBehavior}
 - separate session escape hatch: add --session <name> only when the user explicitly asks for a separate/new/named tmux session
 - per-worktree escape hatch: add --session-mode per-worktree only when the user explicitly asks for per-worktree sessions
-- completion helper shape: relaymux notify --from <name> --reply-mode imessage --idempotency-key <stable-key> --message <summary>
-- launch notification fallback: add --notify-on-exit failure|always --notify-reply-mode imessage when the wrapper itself should notify on exit`;
+- completion helper shape: relaymux notify --from <name> --reply-mode <imessage|telegram|none> --idempotency-key <stable-key> --message <summary>
+- launch notification fallback: add --notify-on-exit failure|always --notify-reply-mode <imessage|telegram|none> when the wrapper itself should notify on exit`;
 }

--- a/src/reply-modes.ts
+++ b/src/reply-modes.ts
@@ -1,0 +1,9 @@
+export const REPLY_MODES = ["imessage", "telegram", "none"];
+
+export function isReplyMode(value) {
+  return REPLY_MODES.includes(String(value));
+}
+
+export function replyModesText() {
+  return "imessage, telegram, or none";
+}

--- a/src/setup-imsg.ts
+++ b/src/setup-imsg.ts
@@ -1,7 +1,7 @@
 import readline from "node:readline/promises";
 import path from "node:path";
 
-import { defaultConfig } from "./config.js";
+import { defaultConfig, defaultImessageIntegration } from "./config.js";
 import { findExecutable } from "./doctor.js";
 import { expandPath } from "./paths.js";
 import { runCommand } from "./process.js";
@@ -22,30 +22,38 @@ export function buildImsgConfig(options: any = {}, env = process.env) {
     ...base,
     session: options.session || base.session,
     stateDir,
-    imessage: {
-      ...base.imessage,
-      chatId,
-      recipient: options.recipient || "",
-      pollMs: Number(options.pollMs || base.imessage.pollMs),
-      syncLimit: Number(options.syncLimit || 10),
-      receive: {
-        backend: "command",
-        command: {
-          description: "Read recent Messages.app chat history through imsg.",
-          argv: [imsg, "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--attachments", "--convert-attachments", "--json"],
-          cwd,
-          timeoutMs: 30000,
+    integrations: {
+      ...base.integrations,
+      imessage: {
+        ...defaultImessageIntegration(),
+        enabled: true,
+        chatId,
+        recipient: options.recipient || "",
+        pollMs: Number(options.pollMs || 3000),
+        syncLimit: Number(options.syncLimit || 10),
+        receive: {
+          backend: "command",
+          command: {
+            description: "Read recent Messages.app chat history through imsg.",
+            argv: [imsg, "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--attachments", "--convert-attachments", "--json"],
+            cwd,
+            timeoutMs: 30000,
+          },
+        },
+        send: {
+          backend: "command",
+          command: {
+            description: "Send one reply chunk through imsg.",
+            argv: [imsg, "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"],
+            cwd,
+            timeoutMs: 60000,
+          },
         },
       },
-      send: {
-        backend: "command",
-        command: {
-          description: "Send one reply chunk through imsg.",
-          argv: [imsg, "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"],
-          cwd,
-          timeoutMs: 60000,
-        },
-      },
+    },
+    launchNotifications: {
+      ...base.launchNotifications,
+      replyMode: "imessage",
     },
     daemon: {
       ...base.daemon,

--- a/src/setup-telegram.ts
+++ b/src/setup-telegram.ts
@@ -1,0 +1,101 @@
+import path from "node:path";
+
+import { defaultConfig, defaultTelegramIntegration } from "./config.js";
+import { findExecutable } from "./doctor.js";
+import { expandPath } from "./paths.js";
+
+export function buildTelegramIntegration(options: any = {}) {
+  const defaults = defaultTelegramIntegration();
+  return {
+    ...defaults,
+    enabled: true,
+    chatId: options.telegramChatId || options.chatId || "TELEGRAM_CHAT_ID",
+    botTokenEnv: options.telegramBotTokenEnv || (options.telegramBotTokenFile ? "" : defaults.botTokenEnv),
+    botTokenFile: options.telegramBotTokenFile || "",
+    parseMode: options.telegramParseMode || options.parseMode || "",
+    apiBaseUrl: options.telegramApiBaseUrl || options.apiBaseUrl || defaults.apiBaseUrl,
+    timeoutMs: Number(options.telegramTimeoutMs || options.timeoutMs || defaults.timeoutMs),
+    maxMessageChars: Number(options.telegramMaxMessageChars || options.maxMessageChars || defaults.maxMessageChars),
+  };
+}
+
+export function withTelegramIntegration(config, options: any = {}) {
+  return {
+    ...config,
+    integrations: {
+      ...(config.integrations || {}),
+      telegram: buildTelegramIntegration(options),
+    },
+    launchNotifications: {
+      ...(config.launchNotifications || {}),
+      replyMode: options.defaultReplyMode || config.launchNotifications?.replyMode || "telegram",
+    },
+  };
+}
+
+export function buildTelegramConfig(options: any = {}, env = process.env) {
+  const base = defaultConfig(env);
+  const stateDir = options.stateDir || base.stateDir;
+  const sessionDir = path.posix.join(stateDir, "sessions");
+  const logDir = options.logDir || (options.stateDir ? path.posix.join(stateDir, "logs") : base.daemon.logDir);
+  const pi = options.piPath || findExecutable("pi", env) || "pi";
+  const codex = options.codexPath || findExecutable("codex", env) || "codex";
+  const claude = options.claudePath || findExecutable("claude", env) || "claude";
+  const cwd = options.cwd || "~";
+
+  return withTelegramIntegration({
+    ...base,
+    session: options.session || base.session,
+    stateDir,
+    daemon: {
+      ...base.daemon,
+      port: Number(options.port || base.daemon.port),
+      tokenFile: path.posix.join(stateDir, "webhook-token"),
+      launchAgentLabel: options.launchAgentLabel || base.daemon.launchAgentLabel,
+      logDir,
+    },
+    orchestrator: {
+      ...base.orchestrator,
+      cwd,
+      command: [pi, "--print", "--continue", "--session-dir", sessionDir, "{prompt}"],
+      promptMode: "arg",
+    },
+    agents: {
+      pi: {
+        description: "Default Pi subagent launched in tmux.",
+        command: [pi, "{prompt}"],
+        promptMode: "arg",
+      },
+      codex: {
+        description: "Codex subagent. Edit flags to match your local install.",
+        command: [codex, "{prompt}"],
+        promptMode: "arg",
+      },
+      claude: {
+        description: "Claude subagent.",
+        command: [claude, "{prompt}"],
+        promptMode: "arg",
+      },
+    },
+  }, { ...options, defaultReplyMode: options.defaultReplyMode || "telegram" });
+}
+
+export function initTelegramOptionsFromFlags(flags) {
+  return {
+    telegramChatId: flags.telegramChatId,
+    telegramBotTokenEnv: flags.telegramBotTokenEnv,
+    telegramBotTokenFile: flags.telegramBotTokenFile,
+    telegramParseMode: flags.telegramParseMode,
+    telegramTimeoutMs: flags.telegramTimeoutMs,
+    telegramApiBaseUrl: flags.telegramApiBaseUrl,
+    telegramMaxMessageChars: flags.telegramMaxMessageChars,
+    cwd: flags.cwd ? expandPath(flags.cwd) : undefined,
+    stateDir: flags.stateDir,
+    session: flags.session,
+    port: flags.port,
+    launchAgentLabel: flags.launchAgentLabel,
+    piPath: flags.piPath,
+    codexPath: flags.codexPath,
+    claudePath: flags.claudePath,
+  };
+}

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+
+import { getIntegration, isIntegrationEnabled } from "./config.js";
+import { expandPath } from "./paths.js";
+import { splitMessage } from "./message-io.js";
+
+export function resolveTelegramToken(config, env = process.env) {
+  const telegram = getIntegration(config, "telegram");
+  const tokenEnv = String(telegram.botTokenEnv || "").trim();
+  if (tokenEnv && env[tokenEnv]) {
+    return { token: String(env[tokenEnv]).trim(), source: `env:${tokenEnv}` };
+  }
+
+  const tokenFile = String(telegram.botTokenFile || "").trim();
+  if (tokenFile) {
+    const resolved = expandPath(tokenFile);
+    const token = fs.readFileSync(resolved, "utf8").trim();
+    return { token, source: `file:${resolved}` };
+  }
+
+  return { token: "", source: tokenEnv ? `env:${tokenEnv}` : "missing" };
+}
+
+export async function sendTelegramMessage(config, text, io: any = process, env = io.env || process.env) {
+  const telegram = getIntegration(config, "telegram");
+  if (!isIntegrationEnabled(config, "telegram")) {
+    throw new Error("Telegram adapter is not enabled in config.integrations.telegram");
+  }
+
+  const chatId = String(telegram.chatId || "").trim();
+  if (!chatId || chatId === "TELEGRAM_CHAT_ID") {
+    throw new Error("Telegram adapter requires config.integrations.telegram.chatId");
+  }
+
+  const { token, source } = resolveTelegramToken(config, env);
+  if (!token) {
+    throw new Error(`Telegram adapter token is missing (${source})`);
+  }
+
+  const maxChars = normalizeMaxMessageChars(telegram.maxMessageChars);
+  const chunks = splitMessage(text, maxChars);
+  for (const chunk of chunks) {
+    await postTelegramSendMessage(telegram, token, {
+      chat_id: chatId,
+      text: chunk,
+      ...(telegram.parseMode ? { parse_mode: String(telegram.parseMode) } : {}),
+    });
+  }
+}
+
+async function postTelegramSendMessage(telegram, token, body) {
+  const apiBaseUrl = String(telegram.apiBaseUrl || "https://api.telegram.org").replace(/\/+$/, "");
+  const timeoutMs = Number(telegram.timeoutMs || 30000);
+  const controller = timeoutMs > 0 ? new AbortController() : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller?.signal,
+    });
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(`Telegram send failed with HTTP ${response.status}: ${responseText.slice(0, 500)}`);
+    }
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error(`Telegram send timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function normalizeMaxMessageChars(value) {
+  const number = Number(value || 3900);
+  if (!Number.isFinite(number) || number < 1) return 3900;
+  return Math.min(Math.floor(number), 4096);
+}

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -4,7 +4,8 @@ import http from "node:http";
 import path from "node:path";
 
 import { ensureDirectory } from "./paths.js";
-import { resolveTokenFile } from "./config.js";
+import { defaultReplyModeForConfig, resolveTokenFile } from "./config.js";
+import { isReplyMode, replyModesText } from "./reply-modes.js";
 
 export function webhookConfig(config) {
   const daemon = config.daemon || {};
@@ -57,7 +58,7 @@ export function ensureWebhookToken(tokenFile) {
   return token;
 }
 
-export function normalizeCompletionBody(body, requestId, receivedAt = new Date().toISOString()) {
+export function normalizeCompletionBody(body, requestId, receivedAt = new Date().toISOString(), defaultReplyMode = "imessage") {
   if (!body || typeof body !== "object" || Array.isArray(body)) throw httpError(400, "JSON object body is required");
 
   const rawText = body.text ?? body.message;
@@ -66,8 +67,8 @@ export function normalizeCompletionBody(body, requestId, receivedAt = new Date()
   const metadata = body.metadata === undefined ? {} : body.metadata;
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) throw httpError(400, "metadata must be an object when provided");
 
-  const replyMode = body.replyMode === undefined ? "imessage" : String(body.replyMode);
-  if (!["imessage", "none"].includes(replyMode)) throw httpError(400, "replyMode must be imessage or none");
+  const replyMode = body.replyMode === undefined ? defaultReplyMode : String(body.replyMode);
+  if (!isReplyMode(replyMode)) throw httpError(400, `replyMode must be ${replyModesText()}`);
 
   const rawSource = body.from ?? body.source ?? "local-subagent";
   const source = String(rawSource || "local-subagent").slice(0, 200);
@@ -98,7 +99,7 @@ export function normalizeTerminalRequestBody(body, requestId, receivedAt = new D
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) throw httpError(400, "metadata must be an object when provided");
 
   const replyMode = body.replyMode === undefined ? "none" : String(body.replyMode);
-  if (!["imessage", "none"].includes(replyMode)) throw httpError(400, "replyMode must be imessage or none");
+  if (!isReplyMode(replyMode)) throw httpError(400, `replyMode must be ${replyModesText()}`);
 
   const rawSource = body.from ?? body.source ?? "terminal";
   const source = String(rawSource || "terminal").slice(0, 200);
@@ -189,7 +190,7 @@ export async function createCompletionWebhookServer({ config, state, saveState, 
         }
 
         const requestId = makeRequestId("wh");
-        const job = normalizeCompletionBody(body, requestId);
+        const job = normalizeCompletionBody(body, requestId, new Date().toISOString(), defaultReplyModeForConfig(config));
         if (job.idempotencyKey) {
           const result = rememberWebhookIdempotencyKey(state, job.idempotencyKey);
           if (result.duplicate) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -15,7 +15,8 @@ test("writeDefaultConfig creates a loadable config", () => {
 
   assert.equal(exists, true);
   assert.equal(config.session, "agents");
-  assert.equal(config.imessage.receive.backend, "command");
+  assert.equal(config.integrations.imessage, undefined);
+  assert.equal(config.launchNotifications.replyMode, "none");
   assert.equal(config.daemon.host, "127.0.0.1");
   assert.equal(config.daemon.launchMode, "direct");
   assert.equal(config.tmux.sessionMode, "shared");
@@ -23,6 +24,23 @@ test("writeDefaultConfig creates a loadable config", () => {
   assert.ok(config.agents.codex);
   assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);
   assert.equal(config.launchNotifications.onExit, "never");
+});
+
+test("loadConfig treats legacy top-level imessage as enabled integration", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-imsg-alias-"));
+  const configPath = path.join(dir, "config.json");
+  fs.writeFileSync(configPath, JSON.stringify({
+    imessage: {
+      chatId: "chat-1",
+      send: { command: { argv: ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}"] } },
+    },
+  }));
+
+  const { config } = loadConfig({ configPath });
+
+  assert.equal(config.integrations.imessage.enabled, true);
+  assert.equal(config.integrations.imessage.chatId, "chat-1");
+  assert.equal(config.launchNotifications.replyMode, "imessage");
 });
 
 test("default paths live under RELAYMUX_HOME when provided", () => {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { defaultConfig } from "../src/config.js";
+import { collectDoctorChecks } from "../src/doctor.js";
+
+test("doctor does not check optional message adapters by default", () => {
+  const config = defaultConfig({ PATH: "" });
+  const checks = collectDoctorChecks(config, { exists: false, path: "/tmp/relaymux-config.json" }, { PATH: "" });
+  const names = checks.map((check) => check.name);
+
+  assert.equal(names.includes("imessage-receive"), false);
+  assert.equal(names.includes("imessage-send"), false);
+  assert.equal(names.includes("telegram-token"), false);
+});
+
+test("doctor checks Telegram only when enabled without printing token contents", () => {
+  const config = {
+    ...defaultConfig({ PATH: "" }),
+    integrations: {
+      telegram: {
+        enabled: true,
+        chatId: "12345",
+        botTokenEnv: "RELAYMUX_TEST_TELEGRAM_TOKEN",
+      },
+    },
+  };
+  const checks = collectDoctorChecks(config, { exists: false, path: "/tmp/relaymux-config.json" }, {
+    PATH: "",
+    RELAYMUX_TEST_TELEGRAM_TOKEN: "test-bot-token-value",
+  });
+  const tokenCheck = checks.find((check) => check.name === "telegram-token");
+  const chatCheck = checks.find((check) => check.name === "telegram-chat-id");
+
+  assert.equal(chatCheck?.ok, true);
+  assert.equal(tokenCheck?.ok, true);
+  assert.match(tokenCheck?.detail || "", /RELAYMUX_TEST_TELEGRAM_TOKEN/);
+  assert.doesNotMatch(tokenCheck?.detail || "", /test-bot-token-value/);
+});

--- a/test/message-io.test.ts
+++ b/test/message-io.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { defaultConfig } from "../src/config.js";
 import {
   buildAdapterArgv,
   commandSafeMessageText,
@@ -8,6 +9,7 @@ import {
   isIncomingUserMessage,
   normalizeMessages,
   parseMessageOutput,
+  receiveMessages,
   splitMessage,
 } from "../src/message-io.js";
 
@@ -47,8 +49,12 @@ test("commandSafeMessageText protects dash-leading replies from option parsing",
 
 test("formatIncomingForPrompt is generic", () => {
   const text = formatIncomingForPrompt([{ id: "m1", text: "do the thing", isFromMe: false }]);
-  assert.match(text, /configured chat/);
+  assert.match(text, /configured iMessage\/SMS adapter chat/);
   assert.doesNotMatch(text, /Avyay|Dari/);
+});
+
+test("receiveMessages is a no-op when iMessage adapter is disabled", async () => {
+  assert.deepEqual(await receiveMessages(defaultConfig({ PATH: "" })), []);
 });
 
 test("splitMessage chunks long text", () => {

--- a/test/setup-imsg.test.ts
+++ b/test/setup-imsg.test.ts
@@ -16,14 +16,15 @@ test("buildImsgConfig creates usable imsg defaults", () => {
   }, { PATH: "" });
 
   assert.equal(config.session, "work");
-  assert.equal(config.imessage.chatId, "chat-1");
-  assert.deepEqual(config.imessage.receive.command.argv.slice(0, 4), [
+  assert.equal(config.integrations.imessage.enabled, true);
+  assert.equal(config.integrations.imessage.chatId, "chat-1");
+  assert.deepEqual(config.integrations.imessage.receive.command.argv.slice(0, 4), [
     "/usr/local/bin/imsg",
     "history",
     "--chat-id",
     "{chatId}",
   ]);
-  assert.deepEqual(config.imessage.send.command.argv.slice(0, 6), [
+  assert.deepEqual(config.integrations.imessage.send.command.argv.slice(0, 6), [
     "/usr/local/bin/imsg",
     "send",
     "--chat-id",

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import { sendTelegramMessage } from "../src/telegram.js";
+
+test("sendTelegramMessage posts to Telegram Bot API shape", async () => {
+  const requests: any[] = [];
+  const server = http.createServer(async (req, res) => {
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    requests.push({ method: req.method, url: req.url, body: JSON.parse(raw) });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  await listen(server);
+  const address: any = server.address();
+
+  try {
+    await sendTelegramMessage({
+      integrations: {
+        telegram: {
+          enabled: true,
+          chatId: "chat-123",
+          botTokenEnv: "RELAYMUX_TEST_TELEGRAM_TOKEN",
+          apiBaseUrl: `http://127.0.0.1:${address.port}`,
+          timeoutMs: 1000,
+        },
+      },
+    }, "hello", { env: { RELAYMUX_TEST_TELEGRAM_TOKEN: "test-bot-token" } });
+  } finally {
+    await close(server);
+  }
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].method, "POST");
+  assert.equal(requests[0].url, "/bottest-bot-token/sendMessage");
+  assert.deepEqual(requests[0].body, { chat_id: "chat-123", text: "hello" });
+});
+
+test("sendTelegramMessage reports missing token without token contents", async () => {
+  await assert.rejects(
+    sendTelegramMessage({
+      integrations: {
+        telegram: {
+          enabled: true,
+          chatId: "chat-123",
+          botTokenEnv: "RELAYMUX_TEST_TELEGRAM_TOKEN",
+        },
+      },
+    }, "hello", { env: {} }),
+    /RELAYMUX_TEST_TELEGRAM_TOKEN/,
+  );
+});
+
+function listen(server) {
+  return new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+}
+
+function close(server) {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -24,7 +24,9 @@ test("normalizeCompletionBody accepts message aliases", () => {
   assert.equal(job.metadata.runId, "r1");
 });
 
-test("normalizeCompletionBody rejects invalid reply mode", () => {
+test("normalizeCompletionBody accepts telegram reply mode and rejects invalid modes", () => {
+  const job = normalizeCompletionBody({ text: "x", replyMode: "telegram" }, "req");
+  assert.equal(job.replyMode, "telegram");
   assert.throws(() => normalizeCompletionBody({ text: "x", replyMode: "loud" }, "req"), /replyMode/);
 });
 


### PR DESCRIPTION
## Summary
Makes relaymux's core product read as CLI + tmux + local API/webhook, with message delivery moved behind optional adapters.

- iMessage/SMS now lives under `integrations.imessage` with legacy top-level `imessage` configs still accepted.
- Adds a sibling Telegram adapter with `replyMode: "telegram"`, token env/file config, and mocked HTTP coverage.
- Default config/docs no longer require `imsg`; doctor skips optional adapter checks unless enabled.

## Design
### Config, setup, and reply modes
- `src/config.ts` — removes iMessage from core defaults, adds `integrations` helpers/defaults, normalizes legacy top-level `imessage` into `integrations.imessage`, and chooses a safe default reply mode based on enabled adapters.
- `src/reply-modes.ts` — centralizes supported modes: `imessage`, `telegram`, and `none`.
- `src/cli.ts`, `src/args.ts` — makes `relaymux setup` core by default, keeps `--imsg` opt-in, adds `--telegram` setup/init flags, and updates help/error text away from iMessage-first wording.
- `src/setup-imsg.ts`, `src/setup-telegram.ts` — writes new adapter configs under `integrations.*`; Telegram supports chat id, token env/file, parse mode, timeout, API base URL, and max chunk size.

### Daemon, webhook, and notification adapters
- `src/daemon.ts` — runs local API/webhook without polling `imsg` unless the iMessage adapter is enabled; dispatches user-visible replies through iMessage or Telegram by `replyMode`.
- `src/message-io.ts` — gates iMessage receive/send through `integrations.imessage` and keeps disabled iMessage a no-op for receive.
- `src/telegram.ts` — implements minimal Telegram Bot API `sendMessage` delivery with token resolution from env or file and chunking.
- `src/webhook.ts`, `src/notify.ts`, `src/command.ts` — accepts `replyMode: "telegram"`, keeps `none`, preserves iMessage behavior for enabled/legacy configs, and defaults launch notification reply mode to quiet `none` for core configs.

### Doctor, docs, and examples
- `src/doctor.ts` — only checks `imsg` commands when iMessage is enabled; only checks Telegram chat/token when Telegram is enabled and never prints token contents.
- `README.md`, `examples/config.imsg.json`, `examples/config.telegram.json`, `examples/config.mock.json`, `examples/subagent-completion.md` — documents the local API as the core integration point and presents iMessage/SMS and Telegram as optional sibling adapters with safe placeholders.
- `test/config.test.ts`, `test/doctor.test.ts`, `test/message-io.test.ts`, `test/setup-imsg.test.ts`, `test/telegram.test.ts`, `test/webhook.test.ts` — covers legacy config aliasing, doctor gating, disabled iMessage receive, iMessage setup shape, Telegram HTTP send, and Telegram reply mode parsing.

## Validation
- `npm run validate` — passed (`tsc --noEmit`, `tsx --test test/*.test.ts` with 62 passing tests, and `tsc` build).
- `git diff --check` — passed.
