### PR TITLE
Add LaunchAgent watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ relaymux notify \
     "port": 47761,
     "tokenFile": "~/.relaymux/state/webhook-token",
     "launchAgentLabel": "com.relaymux.daemon",
+    "watchdog": {
+      "enabled": true,
+      "intervalSeconds": 60
+    },
     "logDir": "~/.relaymux/logs"
   },
   "integrations": {},
@@ -322,8 +326,11 @@ Manage the background service:
 
 ```bash
 relaymux restart-launch-agent
+relaymux status-launch-agent
 relaymux uninstall-launch-agent
 ```
+
+`restart-launch-agent` writes two LaunchAgents on macOS: the main relaymux daemon and a small watchdog. The watchdog runs once a minute, checks the daemon's launchd state plus `/health` on the local API, and bootstraps/kickstarts the daemon if it was killed or left unloaded. Use `--no-watchdog` only when you intentionally want to manage recovery yourself.
 
 ## Safety model and limitations
 
@@ -341,6 +348,8 @@ If setup says the LaunchAgent is not loaded, reload it from a normal terminal:
 relaymux restart-launch-agent
 relaymux status-launch-agent
 ```
+
+A healthy install should show both the main LaunchAgent and `Watchdog ... loaded`. The checked-in watchdog script is copied to `~/.relaymux/bin/<launch-agent-label>-watchdog.sh`, and its plist lives at `~/Library/LaunchAgents/<launch-agent-label>.watchdog.plist`. Watchdog activity is logged under `~/.relaymux/logs/launch-agent-watchdog.log`.
 
 If iMessage/SMS send/receive fails, verify your `imsg` CLI first:
 

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ npm run build
 
 rm -rf "$install_dir"
 mkdir -p "$install_dir" "$bin_dir"
-cp -R dist package.json README.md LICENSE examples "$install_dir/"
+cp -R dist package.json README.md LICENSE examples scripts "$install_dir/"
 
 cat > "$bin_dir/relaymux" <<SHIM
 #!/usr/bin/env sh

--- a/scripts/relaymux-launch-agent-watchdog.sh
+++ b/scripts/relaymux-launch-agent-watchdog.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -u
+
+PATH="${PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
+MAIN_LABEL="${RELAYMUX_MAIN_LABEL:-com.relaymux.daemon}"
+DOMAIN="${RELAYMUX_LAUNCH_DOMAIN:-gui/$(/usr/bin/id -u)}"
+TARGET="${DOMAIN}/${MAIN_LABEL}"
+PLIST="${RELAYMUX_MAIN_PLIST:-${HOME}/Library/LaunchAgents/${MAIN_LABEL}.plist}"
+HEALTH_URL="${RELAYMUX_HEALTH_URL:-http://127.0.0.1:47761/health}"
+LOG="${RELAYMUX_WATCHDOG_LOG:-${HOME}/.relaymux/logs/launch-agent-watchdog.log}"
+
+mkdir -p "$(/usr/bin/dirname "$LOG")"
+
+stamp() {
+  /bin/date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+log() {
+  printf '[%s] %s\n' "$(stamp)" "$*" >> "$LOG"
+}
+
+is_launchd_running() {
+  /bin/launchctl print "$TARGET" 2>/dev/null | /usr/bin/grep -q 'state = running'
+}
+
+is_webhook_healthy() {
+  /usr/bin/curl -fsS --max-time 2 "$HEALTH_URL" >/dev/null 2>&1
+}
+
+if is_launchd_running && is_webhook_healthy; then
+  exit 0
+fi
+
+if ! /bin/test -f "$PLIST"; then
+  log "missing plist: $PLIST"
+  exit 1
+fi
+
+log "relaymux unhealthy or unloaded; restarting ${TARGET}"
+/bin/launchctl bootout "$TARGET" >> "$LOG" 2>&1 || true
+/bin/sleep 1
+/bin/launchctl enable "$TARGET" >> "$LOG" 2>&1 || true
+
+attempt=1
+while [ "$attempt" -le 3 ]; do
+  if /bin/launchctl print "$TARGET" >/dev/null 2>&1; then
+    /bin/launchctl kickstart -k "$TARGET" >> "$LOG" 2>&1 || true
+  else
+    /bin/launchctl bootstrap "$DOMAIN" "$PLIST" >> "$LOG" 2>&1 || true
+    /bin/launchctl kickstart -k "$TARGET" >> "$LOG" 2>&1 || true
+  fi
+
+  /bin/sleep 3
+  if is_launchd_running && is_webhook_healthy; then
+    log "relaymux healthy after restart attempt ${attempt}"
+    exit 0
+  fi
+
+  log "restart attempt ${attempt} did not become healthy; retrying"
+  /bin/launchctl bootout "$TARGET" >> "$LOG" 2>&1 || true
+  /bin/sleep 1
+  attempt=$((attempt + 1))
+done
+
+log "failed to restore relaymux after 3 attempts"
+exit 1

--- a/src/args.ts
+++ b/src/args.ts
@@ -22,6 +22,7 @@ const BOOLEAN_FLAGS = new Set([
   "telegram",
   "version",
   "wait",
+  "watchdog",
 ]);
 
 export function parseArgv(argv) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
 import { defaultConfig, defaultConfigPath, isIntegrationEnabled, loadConfig, resolveLogDir, resolveStateDir, writeConfig } from "./config.js";
 import { runDaemon } from "./daemon.js";
-import { getLaunchAgentStatus, installLaunchAgent, launchAgentPath, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
+import { getLaunchAgentStatus, getLaunchAgentWatchdogStatus, installLaunchAgent, launchAgentPath, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
 import { handleNotify } from "./notify.js";
 import { webhookConfig, webhookStatus } from "./webhook.js";
 import { expandPath, ensureDirectory, pathExists, readTextFile } from "./paths.js";
@@ -687,7 +687,13 @@ function handleStatus(flags, configInfo, stateDir, io) {
       : `LaunchAgent ${launchAgent.label} not loaded`
     : `LaunchAgent unsupported on ${process.platform}`;
   io.stdout.write(`Home: ${daemon.homeDir}; config ${daemon.configPath}; state ${daemon.stateDir}; logs ${daemon.logDir}\n`);
-  io.stdout.write(`Background service: ${daemon.enabled ? "enabled" : "disabled"}; mode ${daemon.launchMode}/background (no tmux); ${launchAgentText}; webhook ${daemon.webhook.endpoints.message}; token ${daemon.webhook.tokenFileExists ? daemon.webhook.tokenFileMode : "missing"}\n`);
+  const watchdog: any = daemon.launchAgentWatchdog;
+  const watchdogText = watchdog?.enabled
+    ? watchdog.loaded
+      ? `watchdog ${watchdog.label} loaded every ${watchdog.intervalSeconds}s`
+      : `watchdog ${watchdog.label} not loaded`
+    : "watchdog disabled";
+  io.stdout.write(`Background service: ${daemon.enabled ? "enabled" : "disabled"}; mode ${daemon.launchMode}/background (no tmux); ${launchAgentText}; ${watchdogText}; webhook ${daemon.webhook.endpoints.message}; token ${daemon.webhook.tokenFileExists ? daemon.webhook.tokenFileMode : "missing"}\n`);
   io.stdout.write(`Agent tmux: session mode ${daemon.agentSessionMode}; ${session ? `filter session ${session}` : "showing all relaymux-managed sessions"}; tabs are tmux windows, never panes/splits.\n`);
 
   if (rows.length === 0) {
@@ -713,6 +719,7 @@ function daemonStatus(config, configPath, env = process.env) {
     webhook: webhookStatus(config),
     launchAgentPath: launchAgentPath(config),
     launchAgent: getLaunchAgentStatus(config),
+    launchAgentWatchdog: getLaunchAgentWatchdogStatus(config),
   };
 }
 
@@ -912,8 +919,8 @@ Usage:
   relaymux init [--force] [--config <path>]
   relaymux init --imsg [--chat-id <id>] [--install-launch-agent]
   relaymux init --telegram [--telegram-chat-id <id>] [--install-launch-agent]
-  relaymux install-launch-agent [--dry-run] [--no-load]
-  relaymux restart-launch-agent [--dry-run] [--no-load]
+  relaymux install-launch-agent [--dry-run] [--no-load] [--no-watchdog]
+  relaymux restart-launch-agent [--dry-run] [--no-load] [--no-watchdog]
   relaymux status-launch-agent [--json]
   relaymux uninstall-launch-agent
   relaymux launch --repo <path> --agent <name> --prompt <text|@file> [--name <name>] [--notify-on-exit never|failure|always]
@@ -963,6 +970,7 @@ Launch options:
 
 Background service options:
   --no-load                  Write the LaunchAgent plist without loading it
+  --no-watchdog              Skip installing the periodic LaunchAgent health watchdog
   --keep-tmux-daemon         During migration, do not stop an old relaymux-daemon tmux tab
 
 Request/notify/status options:

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,10 @@ export function defaultConfig(env = process.env) {
       launchMode: "direct",
       supervisorPollMs: 15000,
       selfRestartDelayMs: 30000,
+      watchdog: {
+        enabled: true,
+        intervalSeconds: 60,
+      },
       logDir,
     },
     orchestrator: {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { defaultConfigPath, getIntegration, isIntegrationEnabled, legacyDefaultConfigPath, resolveLogDir, resolveStateDir } from "./config.js";
 import { validateConfiguredAgentCommand } from "./command-validation.js";
 import { runCommand } from "./process.js";
-import { getLaunchAgentStatus, launchAgentPath } from "./launch-agent.js";
+import { getLaunchAgentStatus, getLaunchAgentWatchdogStatus, launchAgentPath, launchAgentWatchdogPath } from "./launch-agent.js";
 import { defaultRelaymuxHome } from "./paths.js";
 import { webhookStatus } from "./webhook.js";
 
@@ -124,6 +124,18 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
         : `direct/background LaunchAgent unsupported on ${process.platform}: ${launchAgentPath(config)}`
       : "disabled in config",
   });
+
+  const watchdog: any = getLaunchAgentWatchdogStatus(config);
+  if (daemonEnabled && watchdog.enabled) {
+    checks.push({
+      name: "background-watchdog",
+      ok: !watchdog.supported || watchdog.loaded,
+      fatal: false,
+      detail: watchdog.supported
+        ? `watchdog LaunchAgent ${watchdog.loaded ? "loaded" : "not loaded"}: ${launchAgentWatchdogPath(config)}; interval ${watchdog.intervalSeconds}s`
+        : `watchdog LaunchAgent unsupported on ${process.platform}: ${launchAgentWatchdogPath(config)}`,
+    });
+  }
 
   for (const [name, agent] of Object.entries((config.agents ?? {}) as Record<string, any>)) {
     const command = Array.isArray(agent.command) ? agent.command[0] : "";

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -13,13 +13,23 @@ export function launchAgentPath(config) {
   return path.join(os.homedir(), "Library", "LaunchAgents", `${label}.plist`);
 }
 
+export function launchAgentWatchdogPath(config) {
+  const label = launchAgentWatchdogLabel(config);
+  return path.join(os.homedir(), "Library", "LaunchAgents", `${label}.plist`);
+}
+
 export function launchAgentLabel(config) {
   return config.daemon?.launchAgentLabel || "com.relaymux.daemon";
 }
 
-export function renderLaunchAgentPlist({ label, programArguments, workingDirectory, standardOutPath, standardErrorPath, environment = {}, keepAlive = true }) {
+export function launchAgentWatchdogLabel(config) {
+  return `${launchAgentLabel(config)}.watchdog`;
+}
+
+export function renderLaunchAgentPlist({ label, programArguments, workingDirectory, standardOutPath, standardErrorPath, environment = {}, keepAlive = true, startInterval = 0 }) {
   const args = programArguments.map((arg) => `    <string>${xmlEscape(arg)}</string>`).join("\n");
   const env = renderEnvironment(environment);
+  const interval = renderStartInterval(startInterval);
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -35,7 +45,7 @@ ${args}
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
-  ${keepAlive ? "<true/>" : "<false/>"}
+  ${keepAlive ? "<true/>" : "<false/>"}${interval}
   <key>StandardOutPath</key>
   <string>${xmlEscape(standardOutPath)}</string>
   <key>StandardErrorPath</key>
@@ -82,6 +92,16 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
   io.stdout.write(`Wrote ${plistPath}\n`);
   io.stdout.write(`LaunchAgent ${label} mode: ${launchMode}/background (no tmux)\n`);
 
+  if (shouldInstallWatchdog(config, flags)) {
+    installLaunchAgentWatchdog({
+      config,
+      configPath: configInfo.path,
+      binPath,
+      io,
+      load: flags.load !== false,
+    });
+  }
+
   if (flags.load !== false) {
     const target = launchAgentTarget(config);
     if (process.platform === "darwin" && isCurrentLaunchAgent(config, process.env) && flags.immediateSelfRestart !== true) {
@@ -90,6 +110,7 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
     }
 
     runCommand("launchctl", ["bootout", target], { allowFailure: true });
+    runCommand("/bin/sleep", ["1"], { allowFailure: true });
     if (process.platform === "darwin" && launchMode === "direct" && flags.keepTmuxDaemon !== true) {
       const windowName = String(flags.windowName || "relaymux-daemon");
       try {
@@ -101,15 +122,66 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
         io.stderr.write(`relaymux: skipped old tmux daemon cleanup: ${error.message}\n`);
       }
     }
-    runCommand("launchctl", ["enable", target], { allowFailure: true });
-    const result = runCommand("launchctl", ["bootstrap", launchAgentDomain(), plistPath], { allowFailure: true });
+    const result = loadLaunchAgentTarget({ target, domain: launchAgentDomain(), plistPath });
     if (result.status !== 0) {
-      io.stderr.write(`launchctl bootstrap did not complete (${result.status}); you can load manually with launchctl bootstrap ${launchAgentDomain()} ${plistPath}\n`);
-    } else {
-      runCommand("launchctl", ["kickstart", "-k", target], { allowFailure: true });
+      io.stderr.write(`launchctl bootstrap did not complete (${result.status}); watchdog will retry, or load manually with launchctl bootstrap ${launchAgentDomain()} ${plistPath}\n`);
     }
   }
   return plistPath;
+}
+
+export function installLaunchAgentWatchdog({ config, configPath, binPath, io, load = true }) {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+
+  const scriptPath = launchAgentWatchdogScriptPath(config);
+  const plistPath = launchAgentWatchdogPath(config);
+  const logDir = resolveLogDir(config);
+  const scriptSourcePath = resolveWatchdogSourcePath(binPath);
+  const script = fs.readFileSync(scriptSourcePath, "utf8");
+  ensureDirectory(path.dirname(scriptPath));
+  ensureDirectory(path.dirname(plistPath));
+  ensureDirectory(logDir);
+  fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+  try { fs.chmodSync(scriptPath, 0o755); } catch {}
+
+  const plist = renderLaunchAgentWatchdogPlist({ config, configPath, scriptPath });
+  fs.writeFileSync(plistPath, plist, { mode: 0o644 });
+  io.stdout.write(`Wrote ${plistPath}\n`);
+
+  if (load) {
+    const target = launchAgentWatchdogTarget(config);
+    const result = loadLaunchAgentTarget({ target, domain: launchAgentDomain(), plistPath });
+    if (result.status !== 0) {
+      io.stderr.write(`watchdog bootstrap did not complete (${result.status}); you can load manually with launchctl bootstrap ${launchAgentDomain()} ${plistPath}\n`);
+    }
+  }
+
+  return { plistPath, scriptPath };
+}
+
+export function renderLaunchAgentWatchdogPlist({ config, configPath, scriptPath }) {
+  const logDir = resolveLogDir(config);
+  const label = launchAgentWatchdogLabel(config);
+  return renderLaunchAgentPlist({
+    label,
+    programArguments: ["/bin/sh", scriptPath],
+    workingDirectory: os.homedir(),
+    environment: {
+      PATH: defaultLaunchPath(),
+      HOME: os.homedir(),
+      RELAYMUX_CONFIG: configPath,
+      RELAYMUX_MAIN_LABEL: launchAgentLabel(config),
+      RELAYMUX_MAIN_PLIST: launchAgentPath(config),
+      RELAYMUX_HEALTH_URL: launchAgentHealthUrl(config),
+      RELAYMUX_WATCHDOG_LOG: path.join(logDir, "launch-agent-watchdog.log"),
+    },
+    standardOutPath: path.join(logDir, "launch-agent-watchdog.out.log"),
+    standardErrorPath: path.join(logDir, "launch-agent-watchdog.err.log"),
+    keepAlive: false,
+    startInterval: launchAgentWatchdogIntervalSeconds(config),
+  });
 }
 
 export function stopLaunchAgent({ config, io }) {
@@ -139,9 +211,11 @@ export function restartLaunchAgent({ flags, configInfo, binPath, io }) {
 
 export function printLaunchAgentStatus({ config, io, json = false }) {
   const status: any = getLaunchAgentStatus(config);
+  const watchdog: any = getLaunchAgentWatchdogStatus(config);
   if (json) {
-    io.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
-    return status;
+    const payload = { ...status, watchdog };
+    io.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return payload;
   }
 
   if (!status.supported) {
@@ -158,14 +232,38 @@ export function printLaunchAgentStatus({ config, io, json = false }) {
   const pidText = status.pid ? ` pid=${status.pid}` : "";
   const exitText = status.lastExitCode ? ` lastExit=${status.lastExitCode}` : "";
   io.stdout.write(`LaunchAgent ${status.label}: direct/background (no tmux) loaded state=${status.state || "unknown"}${pidText}${exitText}; plist ${status.plistPath}\n`);
+  if (watchdog.enabled) {
+    const watchdogText = watchdog.loaded
+      ? `loaded state=${watchdog.state || "unknown"}${watchdog.pid ? ` pid=${watchdog.pid}` : ""}`
+      : `not loaded${watchdog.detail ? ` (${watchdog.detail})` : ""}`;
+    io.stdout.write(`Watchdog ${watchdog.label}: interval=${watchdog.intervalSeconds}s ${watchdogText}; plist ${watchdog.plistPath}; script ${watchdog.scriptPath}\n`);
+  }
   return status;
 }
 
 export function getLaunchAgentStatus(config) {
-  const label = launchAgentLabel(config);
-  const plistPath = launchAgentPath(config);
+  return getLaunchAgentStatusFor({
+    label: launchAgentLabel(config),
+    plistPath: launchAgentPath(config),
+    target: launchAgentTarget(config),
+  });
+}
+
+export function getLaunchAgentWatchdogStatus(config) {
+  return {
+    ...getLaunchAgentStatusFor({
+      label: launchAgentWatchdogLabel(config),
+      plistPath: launchAgentWatchdogPath(config),
+      target: launchAgentWatchdogTarget(config),
+    }),
+    enabled: shouldInstallWatchdog(config, {}),
+    intervalSeconds: launchAgentWatchdogIntervalSeconds(config),
+    scriptPath: launchAgentWatchdogScriptPath(config),
+  };
+}
+
+function getLaunchAgentStatusFor({ label, plistPath, target }) {
   const plistExists = fs.existsSync(plistPath);
-  const target = launchAgentTarget(config);
   const base = { label, plistPath, plistExists, target, supported: process.platform === "darwin", mode: "direct", background: true };
   if (!base.supported) {
     return { ...base, loaded: false, running: false, state: "unsupported" };
@@ -192,6 +290,19 @@ export function getLaunchAgentStatus(config) {
 }
 
 export function uninstallLaunchAgent({ config, io }) {
+  const watchdogPlistPath = launchAgentWatchdogPath(config);
+  if (fs.existsSync(watchdogPlistPath)) {
+    runCommand("launchctl", ["bootout", launchAgentWatchdogTarget(config)], { allowFailure: true });
+    fs.unlinkSync(watchdogPlistPath);
+    io.stdout.write(`Removed ${watchdogPlistPath}\n`);
+  }
+
+  const watchdogScriptPath = launchAgentWatchdogScriptPath(config);
+  if (fs.existsSync(watchdogScriptPath)) {
+    fs.unlinkSync(watchdogScriptPath);
+    io.stdout.write(`Removed ${watchdogScriptPath}\n`);
+  }
+
   const plistPath = launchAgentPath(config);
   if (fs.existsSync(plistPath)) {
     runCommand("launchctl", ["bootout", launchAgentTarget(config)], { allowFailure: true });
@@ -288,8 +399,82 @@ export function launchAgentTarget(config) {
   return `${launchAgentDomain()}/${launchAgentLabel(config)}`;
 }
 
+export function launchAgentWatchdogTarget(config) {
+  return `${launchAgentDomain()}/${launchAgentWatchdogLabel(config)}`;
+}
+
+export function shouldInstallWatchdog(config, flags: any = {}) {
+  if (flags.watchdog === false) return false;
+  if (config.daemon?.enabled === false) return false;
+  if (config.daemon?.watchdog?.enabled === false) return false;
+  return true;
+}
+
+export function launchAgentWatchdogScriptPath(config) {
+  const logDir = resolveLogDir(config);
+  const relaymuxHome = path.dirname(logDir);
+  return path.join(relaymuxHome, "bin", `${launchAgentLabel(config)}-watchdog.sh`);
+}
+
+export function launchAgentWatchdogIntervalSeconds(config) {
+  const raw = config.daemon?.watchdog?.intervalSeconds ?? config.daemon?.watchdogIntervalSeconds ?? 60;
+  const interval = Number(raw);
+  if (!Number.isFinite(interval) || interval <= 0) return 60;
+  return Math.max(15, Math.floor(interval));
+}
+
+export function resolveWatchdogSourcePath(binPath) {
+  const candidates = [
+    path.resolve(path.dirname(binPath || ""), "..", "..", "scripts", "relaymux-launch-agent-watchdog.sh"),
+    path.resolve(process.cwd(), "scripts", "relaymux-launch-agent-watchdog.sh"),
+  ];
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!found) {
+    throw new Error(`Could not find relaymux watchdog script. Checked: ${candidates.join(", ")}`);
+  }
+  return found;
+}
+
 function buildDirectDaemonArgs({ binPath, configPath }) {
-  return [process.execPath, binPath, "--config", configPath, "daemon"];
+  return [stableNodePath(), binPath, "--config", configPath, "daemon"];
+}
+
+function loadLaunchAgentTarget({ target, domain, plistPath }) {
+  let result: any = { status: 1, stdout: "", stderr: "" };
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    runCommand("launchctl", ["enable", target], { allowFailure: true });
+    result = runCommand("launchctl", ["bootstrap", domain, plistPath], { allowFailure: true });
+    if (result.status === 0) {
+      runCommand("launchctl", ["kickstart", "-k", target], { allowFailure: true });
+      return result;
+    }
+    runCommand("launchctl", ["bootout", target], { allowFailure: true });
+    runCommand("/bin/sleep", [String(attempt)], { allowFailure: true });
+  }
+  return result;
+}
+
+function stableNodePath() {
+  for (const candidate of ["/opt/homebrew/bin/node", "/usr/local/bin/node", process.execPath]) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return process.execPath;
+}
+
+function launchAgentHealthUrl(config) {
+  const host = formatHostForUrl(config.daemon?.host || "127.0.0.1");
+  const port = Number(config.daemon?.port || 47761);
+  return `http://${host}:${port}/health`;
+}
+
+function formatHostForUrl(host) {
+  const value = String(host || "").trim();
+  return value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
 }
 
 function resolveLaunchMode(flags, config) {
@@ -332,6 +517,12 @@ function defaultLaunchPath() {
     "/sbin",
   ];
   return pathParts.join(":");
+}
+
+function renderStartInterval(startInterval) {
+  const interval = Number(startInterval || 0);
+  if (!Number.isFinite(interval) || interval <= 0) return "";
+  return `\n  <key>StartInterval</key>\n  <integer>${Math.floor(interval)}</integer>`;
 }
 
 function renderEnvironment(environment) {

--- a/test/launch-agent.test.ts
+++ b/test/launch-agent.test.ts
@@ -2,7 +2,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { defaultConfig } from "../src/config.js";
-import { installLaunchAgent, isCurrentLaunchAgent, parseLaunchCtlPrint, renderLaunchAgentPlist, renderLaunchAgentReloadScript } from "../src/launch-agent.js";
+import {
+  installLaunchAgent,
+  isCurrentLaunchAgent,
+  parseLaunchCtlPrint,
+  renderLaunchAgentPlist,
+  renderLaunchAgentReloadScript,
+  renderLaunchAgentWatchdogPlist,
+  resolveWatchdogSourcePath,
+  shouldInstallWatchdog,
+} from "../src/launch-agent.js";
 
 
 test("renderLaunchAgentPlist escapes XML and includes daemon args", () => {
@@ -37,6 +46,60 @@ test("renderLaunchAgentPlist can include launch environment", () => {
   assert.match(plist, /<key>PATH<\/key>/);
   assert.match(plist, /<string>daemon<\/string>/);
   assert.match(plist, /<key>RELAYMUX_SESSION<\/key>/);
+});
+
+test("renderLaunchAgentPlist can include a start interval", () => {
+  const plist = renderLaunchAgentPlist({
+    label: "com.example.relaymux.watchdog",
+    programArguments: ["/bin/sh", "/tmp/watchdog.sh"],
+    workingDirectory: "/tmp/work",
+    standardOutPath: "/tmp/out.log",
+    standardErrorPath: "/tmp/err.log",
+    keepAlive: false,
+    startInterval: 60,
+  });
+
+  assert.match(plist, /<key>KeepAlive<\/key>\n  <false\/>/);
+  assert.match(plist, /<key>StartInterval<\/key>/);
+  assert.match(plist, /<integer>60<\/integer>/);
+});
+
+test("renderLaunchAgentWatchdogPlist points at the main daemon and health endpoint", () => {
+  const base = defaultConfig();
+  const config = {
+    ...base,
+    daemon: {
+      ...base.daemon,
+      launchAgentLabel: "com.example.relaymux",
+      port: 49999,
+      watchdog: { enabled: true, intervalSeconds: 45 },
+    },
+  };
+  const plist = renderLaunchAgentWatchdogPlist({
+    config,
+    configPath: "/tmp/relaymux-config.json",
+    scriptPath: "/tmp/watchdog.sh",
+  });
+
+  assert.match(plist, /<string>com.example.relaymux.watchdog<\/string>/);
+  assert.match(plist, /<string>\/tmp\/watchdog.sh<\/string>/);
+  assert.match(plist, /<key>RELAYMUX_MAIN_LABEL<\/key>/);
+  assert.match(plist, /<string>com.example.relaymux<\/string>/);
+  assert.match(plist, /<key>RELAYMUX_HEALTH_URL<\/key>/);
+  assert.match(plist, /http:\/\/127\.0\.0\.1:49999\/health/);
+  assert.match(plist, /<integer>45<\/integer>/);
+});
+
+test("watchdog install defaults on and can be disabled", () => {
+  const config = defaultConfig();
+  assert.equal(shouldInstallWatchdog(config, {}), true);
+  assert.equal(shouldInstallWatchdog(config, { watchdog: false }), false);
+  assert.equal(shouldInstallWatchdog({ ...config, daemon: { ...config.daemon, watchdog: { enabled: false } } }, {}), false);
+});
+
+test("resolveWatchdogSourcePath finds the checked-in script", () => {
+  const resolved = resolveWatchdogSourcePath("/tmp/nonexistent/dist/bin/relaymux.js");
+  assert.match(resolved, /scripts\/relaymux-launch-agent-watchdog\.sh$/);
 });
 
 test("installLaunchAgent direct dry-run does not invoke tmux or set tmux environment", () => {


### PR DESCRIPTION
## Summary
Adds a checked-in macOS LaunchAgent watchdog so the relaymux background daemon is automatically restored if launchd unloads it or the local health endpoint stops responding.

- Installs the watchdog alongside `restart-launch-agent` by default, with `--no-watchdog` as the opt-out.
- Documents where the checked-in script is copied and how to verify it.
- Keeps the existing self-restart helper path, but adds periodic recovery for cases where bootstrap leaves the main service dead.

## Design
### LaunchAgent watchdog
- `scripts/relaymux-launch-agent-watchdog.sh` — checked-in watchdog script; validates the main LaunchAgent state and `/health`, then bootouts/enables/bootstraps/kickstarts the daemon with bounded retries.
- `src/launch-agent.ts` — copies the script into the relaymux home, writes a sibling `<label>.watchdog` LaunchAgent with `StartInterval`, includes watchdog status helpers, and removes the watchdog plist/script during uninstall.
- `src/config.ts` and `src/args.ts` — adds default `daemon.watchdog.enabled=true`, `intervalSeconds=60`, and parses `--no-watchdog`/`--watchdog`.

### Status, doctor, and install packaging
- `src/cli.ts` — includes watchdog state in `relaymux status`, `status-launch-agent --json`, and help text.
- `src/doctor.ts` — adds a non-fatal `background-watchdog` check so missing watchdog setup is visible without blocking unrelated checks.
- `install.sh` — copies the checked-in `scripts/` directory into `~/.local/lib/relaymux` so installed CLIs can materialize the watchdog script.

### Documentation and tests
- `README.md` — documents the default watchdog, `--no-watchdog`, copied script/plist paths, and verification via `status-launch-agent`.
- `test/launch-agent.test.ts` — covers `StartInterval` rendering, watchdog plist environment, default/disabled behavior, and resolving the checked-in script.

## Validation
- `sh -n scripts/relaymux-launch-agent-watchdog.sh` — passed.
- `npm run validate` — passed (`tsc --noEmit`, `tsx --test test/*.test.ts` with 66 passing tests, and `tsc` build).
- `git diff --check origin/main...HEAD` — passed.
