### PR TITLE
Add first-reader relaymux Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,14 @@
 # relaymux
 
-`relaymux` coordinates terminal-run coding commands, such as `pi`, `codex`, `claude`, `aider`, or shell scripts, in `tmux` windows and gives them a small local API for status, requests, and completion notifications.
+`relaymux` launches local coding-agent commands in visible `tmux` windows and records each run's status and completion updates under `~/.relaymux`.
 
-```bash
-# Start a visible agent window in the shared tmux session.
-relaymux launch --repo ~/code/my-app --agent pi --name fix-tests \
-  --prompt "Fix the failing tests, then report back with relaymux notify."
-
-# From inside an agent when the work is done or blocked.
-relaymux notify --from fix-tests \
-  --message "Done: fixed the tests. Validation: npm test passed."
-```
+It is not a model provider, IDE, cloud runtime, or agent framework. It coordinates commands you already run in a terminal, such as `pi`, `codex`, `claude`, `aider`, or a shell script that can work from a prompt.
 
 ## Quickstart
 
-relaymux is a thin local coordinator for prompt-driven commands you already run in a terminal, such as `pi`, `codex`, `claude`, `aider`, or a shell script. You need Node.js 20+, npm, git, and `tmux`, a terminal multiplexer that keeps named windows running after you detach. Optional notification adapters such as iMessage/SMS and Telegram are not required for the first launch below.
+You need Node.js 20+, npm, git, and `tmux`. tmux is the terminal multiplexer relaymux uses to keep agent runs visible as attachable sessions and windows. Optional notification adapters such as iMessage/SMS and Telegram are not required for a local launch.
 
-Install from GitHub, then make sure the `relaymux` command is on your PATH:
+Install relaymux and put the command on your PATH:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/avyayv/relaymux/main/install.sh | bash
@@ -24,81 +16,15 @@ export PATH="$HOME/.local/bin:$PATH"
 relaymux --version
 ```
 
+The installer clones and builds relaymux locally with Node/npm/git, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin`.
+
 Create the default config:
 
 ```bash
 relaymux init
 ```
 
-`relaymux init` writes `~/.relaymux/config.json`. If you already have a config, edit it instead of overwriting it. At minimum, relaymux needs a shared `tmux` session name and an agent command template:
-
-```json
-{
-  "session": "agents",
-  "tmux": { "sessionMode": "shared" },
-  "agents": {
-    "my-agent": {
-      "command": ["my-agent-cli", "--prompt-file", "{promptFile}"]
-    }
-  }
-}
-```
-
-The `command` value is an argv array. relaymux replaces `{promptFile}` with the path to the prompt file it writes for the run. Replace `my-agent-cli` with the agent or wrapper command you actually use. The generated config also includes starter templates for `pi`, `codex`, `claude`, and a harmless `custom` agent for smoke tests. If your command does not use `{prompt}` or `{promptFile}`, set `promptMode` to `arg`, `env`, `stdin`, or `none` as described in Configuration.
-
-`relaymux init` refuses to overwrite an existing config unless you pass `--force`.
-
-Write a prompt file:
-
-```bash
-mkdir -p ~/.relaymux/tasks
-cat > ~/.relaymux/tasks/first-agent.md <<'EOF'
-Read the README, summarize what this project does, and report any unclear setup steps.
-EOF
-```
-
-A subagent is one delegated agent command running in its own tmux window. Launch one from that prompt file:
-
-```bash
-relaymux launch \
-  --repo ~/code/my-project \
-  --agent my-agent \
-  --name first-agent \
-  --prompt-file ~/.relaymux/tasks/first-agent.md
-```
-
-By default this creates a new `tmux` window in the shared `agents` session. relaymux does not create panes or splits; many terminal UIs display tmux windows like tabs. Check what is running, then attach to the session:
-
-```bash
-relaymux status
-tmux attach -t agents
-```
-
-Use a separate session only when you explicitly want to isolate a group of windows:
-
-```bash
-relaymux launch --session my-task --repo ~/code/my-project --agent my-agent --prompt-file ~/.relaymux/tasks/first-agent.md
-```
-
-For terminal-only status, relaymux records start/completion events automatically, and a launched subagent can use the injected notify helper:
-
-```bash
-$RELAYMUX_NOTIFY_COMMAND --message "Read the README; running checks next."
-```
-
-For user-visible completion messages through the optional iMessage/SMS adapter, use the setup path on a fresh install instead of bare `relaymux init`. `relaymux setup --imsg` writes a Messages-capable config, installs the background daemon, and then `relaymux notify --reply-mode imessage` can send completion updates:
-
-```bash
-relaymux setup --imsg --chat-id <chat-id-or-phone-number>
-relaymux doctor
-relaymux notify \
-  --from first-agent \
-  --reply-mode imessage \
-  --idempotency-key first-agent-done \
-  --message "Finished: summarized the README and found one unclear setup step."
-```
-
-The generated config also includes a `custom` agent for smoke tests. It prints the prompt and is useful for checking tmux/status behavior before wiring a real agent:
+`relaymux init` writes `~/.relaymux/config.json` and refuses to overwrite an existing config unless you pass `--force`. The generated config includes a harmless `custom` agent that prints its prompt, which is useful for checking that tmux/status behavior works before wiring a real agent:
 
 ```bash
 mkdir -p /tmp/relaymux-demo
@@ -110,354 +36,97 @@ relaymux launch \
   --prompt "hello from relaymux"
 ```
 
-The core product is local: CLI + `tmux` + run state + a loopback HTTP API/webhook. Notification adapters are optional. iMessage/SMS via `imsg` and Telegram via the Bot API are supported as add-ons; neither is required to launch agents, inspect status, or record local notifications.
+`--repo` is the command's working directory; it does not need to be a Git repository for this basic launch. `--hold` keeps the tmux window open after the command exits so you can inspect it. relaymux creates the shared tmux session automatically when it launches the first run.
 
-relaymux is not a model provider, coding agent, IDE, cloud runtime, or general messaging SDK.
-
-## Why relaymux exists
-
-Coding agents are useful, but running more than one usually turns into a pile of terminal tabs, forgotten prompts, and "did that finish?" checks. relaymux keeps the work visible in `tmux`, gives every delegated run a name and local state record, and provides one completion path: `relaymux notify`.
-
-Optional adapters can make those completions user-visible away from the keyboard. iMessage/SMS and Telegram are sibling integrations: configure one, both, or neither.
-
-## Core ideas
-
-An **agent** is just a command template in `~/.relaymux/config.json`. If you configure `pi`, relaymux runs `pi ...`; if you configure `codex`, it runs `codex ...`; if you configure `custom`, it can be any shell command.
-
-A **run** is one `relaymux launch`. By default, relaymux creates a new `tmux` window in one shared session named `agents`. tmux calls these windows; many terminal apps display them like tabs. relaymux does not create panes or splits for agent runs.
-
-The **daemon** is optional for local launches, but useful for the local API and adapter delivery. On macOS, `relaymux setup` can install it as a per-user LaunchAgent. The daemon stays outside `tmux`, accepts local `relaymux ask` and `relaymux notify` requests, and runs your orchestrator command. If the iMessage/SMS adapter is enabled, it also polls the configured `imsg` chat.
-
-The **orchestrator** is also just a command, but it has a different job from an agent. The orchestrator handles inbound requests from the local API or optional adapters; agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply.
-
-relaymux stores private config, token, run records, prompts, and logs under `~/.relaymux` by default:
-
-```text
-~/.relaymux/
-  config.json     # private config, written mode 0600
-  state/          # daemon state, run records, prompts, scripts, webhook token
-  logs/           # LaunchAgent stdout/stderr logs
-  tasks/          # optional task scratch space
-  reports/        # optional reports
-  research/       # optional research notes
-```
-
-## Install
-
-Requirements for local agent launches are Node.js 20+, npm, git, and `tmux`.
-
-Or install from a clone:
+Attach to the shared tmux session:
 
 ```bash
-git clone https://github.com/avyayv/relaymux.git
-cd relaymux
-./install.sh
-export PATH="$HOME/.local/bin:$PATH"
+tmux attach -t agents
 ```
 
-Optional adapter requirements:
-
-- iMessage/SMS: macOS, Messages signed in on that Mac, SMS forwarding if you want SMS, and an external `imsg` CLI. relaymux shells out to the command you configure; it does not vendor `imsg` or talk to Messages.app directly.
-- Telegram: a Telegram bot token and chat id. relaymux sends through the Telegram Bot API and reads the token from an environment variable or token file.
-
-## Local API And Agent Updates
-
-The daemon exposes the core integration point on loopback only. `relaymux ask` and `relaymux notify --reply-mode ...` are CLI wrappers over this API. The update endpoints are local callbacks for agents and helper scripts; they are not public webhooks.
-
-Default endpoints:
-
-- `GET /health` returns daemon, queue, and webhook status.
-- `POST /request` submits a terminal/local request to the orchestrator.
-- `POST /message` or `POST /agent-message` submits a subagent completion/update. The two paths are aliases.
-
-Requests to `POST` endpoints require `Authorization: Bearer <token>`, where the token is stored in `~/.relaymux/state/webhook-token` by default. For foreground debugging instead of LaunchAgent, run `relaymux daemon`.
+In tmux, you should see a window named `hello-relaymux`. Detach with `Ctrl-b d`, then inspect local status:
 
 ```bash
-TOKEN="$(cat ~/.relaymux/state/webhook-token)"
-curl -sS -X POST http://127.0.0.1:47761/message \
-  -H "authorization: Bearer $TOKEN" \
-  -H "content-type: application/json" \
-  -d '{"from":"build-agent","replyMode":"none","idempotencyKey":"build-agent:job-123:done","text":"Finished; tests passed."}'
+relaymux status --history
 ```
 
-`replyMode` can be:
+## Use A Real Agent
 
-| `replyMode` | Behavior |
-| --- | --- |
-| `none` | The daemon passes the update to the orchestrator, but no adapter message is sent. |
-| `imessage` | The daemon passes the update to the orchestrator, then sends the orchestrator's user-visible reply through the optional iMessage/SMS adapter. |
-| `telegram` | The daemon passes the update to the orchestrator, then sends the orchestrator's user-visible reply through the optional Telegram adapter. |
+At minimum, relaymux needs a shared tmux session name and an agent command template in `~/.relaymux/config.json`. An agent command can be interactive or noninteractive; relaymux's job is to start it with the prompt you provide.
 
-## Optional iMessage/SMS adapter
+```json
+{
+  "session": "agents",
+  "agents": {
+    "my-agent": {
+      "command": ["my-agent-cli", "--prompt-file", "{promptFile}"]
+    }
+  }
+}
+```
 
-The iMessage/SMS adapter is one optional integration. It uses your configured `imsg` command for both inbound polling and outbound replies. The expected command shapes are `imsg chats --limit <n> --json`, `imsg history --chat-id <id> --limit <n> --json`, and `imsg send --chat-id <id> --text <text> --json`.
+The `command` value is a list of command arguments. relaymux replaces `{promptFile}` with the path to the prompt file it writes for the run. Replace `my-agent-cli` with the agent or wrapper command you actually use. The prompt-file style is the simplest path; other prompt-passing modes and placeholders are covered in [Configuration](docs/configuration.md).
+
+Write a prompt file:
+
+```bash
+mkdir -p ~/.relaymux/tasks
+cat > ~/.relaymux/tasks/first-agent.md <<'EOF'
+Read the README, summarize what this project does, and report any unclear setup steps.
+EOF
+```
+
+A subagent is the command relaymux starts for one run. Launch one from that prompt file:
+
+```bash
+relaymux launch \
+  --repo ~/code/my-project \
+  --agent my-agent \
+  --name first-agent \
+  --prompt-file ~/.relaymux/tasks/first-agent.md
+```
+
+By default this creates a new tmux window in the shared `agents` session. relaymux does not create panes or splits; many terminal UIs display tmux windows like tabs.
+
+Use a separate session only when you explicitly want to isolate a group of windows:
+
+```bash
+relaymux launch --session my-task --repo ~/code/my-project --agent my-agent --prompt-file ~/.relaymux/tasks/first-agent.md
+```
+
+Inside every launched agent process, relaymux injects `RELAYMUX_NOTIFY_COMMAND`, a shell command string that records local progress or completion updates for that run:
+
+```bash
+$RELAYMUX_NOTIFY_COMMAND --message "Finished: checked the README and found no blockers."
+```
+
+## Optional Notifications
+
+relaymux works without message adapters. If you want user-visible updates away from the terminal, configure an adapter after the local flow works.
+
+iMessage/SMS through macOS Messages and an external `imsg` CLI:
 
 ```bash
 relaymux setup --imsg --chat-id <chat-id-or-phone-number>
 relaymux doctor
-relaymux status
 ```
 
-`relaymux setup --imsg` creates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps.
-
-After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
-
-Manual user-visible completion:
+Telegram through a Telegram bot:
 
 ```bash
-relaymux notify \
-  --from fix-api \
-  --reply-mode imessage \
-  --idempotency-key fix-api-20260614-done \
-  --message "Finished: fixed the API bug. Validation: npm test passed."
-```
-
-## Optional Telegram adapter
-
-The Telegram adapter is outbound notification support through `sendMessage`. It does not poll Telegram for inbound messages.
-
-Create a bot with BotFather, get a chat id for the chat you want to notify, and store the token outside the public config. A token file works well with LaunchAgent because it does not depend on your interactive shell environment:
-
-```bash
-mkdir -p ~/.relaymux/secrets
-printf '%s\n' '<telegram-bot-token>' > ~/.relaymux/secrets/telegram-bot-token
-chmod 600 ~/.relaymux/secrets/telegram-bot-token
-
 relaymux setup --telegram \
   --telegram-chat-id <telegram-chat-id> \
   --telegram-bot-token-file ~/.relaymux/secrets/telegram-bot-token
 relaymux doctor
-relaymux status
 ```
 
-You can also use an environment variable instead of a file:
+Then use `relaymux notify --reply-mode imessage` or `relaymux notify --reply-mode telegram` from an agent when you want an adapter-delivered update. In this command, reply mode means the delivery channel for a user-visible notification.
 
-```json
-{
-  "integrations": {
-    "telegram": {
-      "enabled": true,
-      "chatId": "<telegram-chat-id>",
-      "botTokenEnv": "TELEGRAM_BOT_TOKEN",
-      "parseMode": ""
-    }
-  }
-}
-```
+## Docs
 
-Manual Telegram completion:
-
-```bash
-relaymux notify \
-  --from fix-api \
-  --reply-mode telegram \
-  --idempotency-key fix-api-20260614-done \
-  --message "Finished: fixed the API bug. Validation: npm test passed."
-```
-
-## Configuration
-
-`relaymux init` writes a core config with no message adapters. Command arrays are argv templates; `{prompt}` and `{promptFile}` are substituted at launch time. The Pi commands below are examples, not requirements; edit them to match the agent CLIs you actually use.
-
-```json
-{
-  "version": 1,
-  "session": "agents",
-  "stateDir": "~/.relaymux/state",
-  "tmux": {
-    "sessionMode": "shared"
-  },
-  "daemon": {
-    "enabled": true,
-    "host": "127.0.0.1",
-    "port": 47761,
-    "tokenFile": "~/.relaymux/state/webhook-token",
-    "launchAgentLabel": "com.relaymux.daemon",
-    "watchdog": {
-      "enabled": true,
-      "intervalSeconds": 60
-    },
-    "logDir": "~/.relaymux/logs"
-  },
-  "integrations": {},
-  "orchestrator": {
-    "cwd": "~",
-    "command": ["pi", "--print", "--continue", "--session-dir", "~/.relaymux/state/sessions", "{prompt}"],
-    "promptMode": "arg"
-  },
-  "agents": {
-    "pi": { "command": ["pi", "{prompt}"], "promptMode": "arg" },
-    "codex": { "command": ["codex", "{prompt}"], "promptMode": "arg" },
-    "custom": { "command": ["sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""], "promptMode": "env" }
-  }
-}
-```
-
-Optional adapter config lives under `integrations`:
-
-```json
-{
-  "integrations": {
-    "imessage": {
-      "enabled": true,
-      "chatId": "<chat-id-or-phone-number>",
-      "pollMs": 3000,
-      "receive": {
-        "backend": "command",
-        "command": { "argv": ["imsg", "history", "--chat-id", "{chatId}", "--limit", "{limit}", "--json"] }
-      },
-      "send": {
-        "backend": "command",
-        "command": { "argv": ["imsg", "send", "--chat-id", "{chatId}", "--text", "{text}", "--json"] }
-      }
-    },
-    "telegram": {
-      "enabled": true,
-      "chatId": "<telegram-chat-id>",
-      "botTokenFile": "~/.relaymux/secrets/telegram-bot-token",
-      "parseMode": ""
-    }
-  }
-}
-```
-
-Legacy top-level `imessage` config is still accepted and normalized as `integrations.imessage` at load time.
-
-Prompt passing modes are:
-
-| `promptMode` | Behavior |
-| --- | --- |
-| `arg` | Append the prompt as a command-line argument unless `{prompt}` is already present. |
-| `env` | Put the prompt in `RELAYMUX_PROMPT`. |
-| `stdin` | Write the prompt under `~/.relaymux/state/prompts` and pipe that file to stdin. |
-| `none` | Do not pass the prompt automatically. |
-
-Use `--prompt @prompt.txt` or `--prompt-file prompt.txt` for longer prompts. The orchestrator follows the same command-template rules as agents: relaymux passes it a prompt, expects a useful final reply on stdout, and treats a nonzero exit as an error to report.
-
-## Common workflows
-
-Launch a named agent in the default shared session:
-
-```bash
-relaymux launch --repo ~/code/my-app --agent pi --name fix-api --prompt @prompt.txt
-```
-
-Ask the orchestrator from a terminal:
-
-```bash
-relaymux ask "Open an agent in ~/code/my-app to inspect the failing test."
-```
-
-Launch into a separate tmux session when you want an isolated group of windows:
-
-```bash
-relaymux launch --session release-fix --repo ~/code/my-app --agent codex --prompt @prompt.txt
-```
-
-Use per-worktree sessions when each Git worktree should get a stable session name. In this mode, relaymux derives the session from the repo/worktree/branch plus a short hash:
-
-```bash
-relaymux launch --session-mode per-worktree --repo ~/code/my-app --agent pi --prompt @prompt.txt
-```
-
-Send a local run-log completion from a delegated agent. Local runs still record automatic `started` and `completed` events even without the daemon:
-
-```bash
-relaymux notify \
-  --from fix-api \
-  --message "Finished: fixed the API bug. Validation: npm test passed."
-```
-
-Add `--reply-mode none` when the daemon should receive quiet context but no adapter message should be sent. Use `--reply-mode imessage` or `--reply-mode telegram` only when that adapter is configured and you want a user-visible update. Use a stable `--idempotency-key` for one logical update so retries do not send duplicates; keys are remembered in the daemon state under `~/.relaymux/state`.
-
-Turn on wrapper-level exit notifications if you want a fallback even when the agent forgets to call `relaymux notify`. `failure` means only nonzero exits notify; `always` also notifies on success; `never` is the default:
-
-```bash
-relaymux launch --repo ~/code/my-app --agent pi --name risky-task \
-  --notify-on-exit failure --notify-reply-mode telegram \
-  --prompt @prompt.txt
-```
-
-Adapter exit notifications require the daemon and the selected adapter. Local `started` and `completed` run events are still recorded without them.
-
-Inspect local state. `--history` includes old run records whose tmux windows have already exited:
-
-```bash
-relaymux status
-relaymux status --history
-relaymux doctor
-relaymux status-launch-agent
-```
-
-Manage the background service:
-
-```bash
-relaymux restart-launch-agent
-relaymux status-launch-agent
-relaymux uninstall-launch-agent
-```
-
-`restart-launch-agent` writes two LaunchAgents on macOS: the main relaymux daemon and a small watchdog. The watchdog runs once a minute, checks the daemon's launchd state plus `/health` on the local API, and bootstraps/kickstarts the daemon if it was killed or left unloaded. Use `--no-watchdog` only when you intentionally want to manage recovery yourself.
-
-## Safety model and limitations
-
-relaymux is designed for a single user's local machine. The daemon binds to `127.0.0.1` and API requests authenticate with a random token stored under `~/.relaymux/state`. The config file is written with private file permissions.
-
-That does not make arbitrary agents safe. If a local request or adapter message causes your orchestrator to launch `pi`, `codex`, `claude`, or a shell script, that command has the same local permissions it would have if you ran it yourself. Configure relaymux only with adapters and agents you trust, review your agent prompts, and assume prompts, logs, tmux scrollback, and run records may contain sensitive project context.
-
-relaymux is probably the wrong tool if you need a sandbox, a multi-tenant service, durable distributed jobs, a cron/scheduler, hosted model inference, or a web UI. It is also not a general iMessage, SMS, or Telegram library.
-
-## Troubleshooting
-
-If setup says the LaunchAgent is not loaded, reload it from a normal terminal:
-
-```bash
-relaymux restart-launch-agent
-relaymux status-launch-agent
-```
-
-A healthy install should show both the main LaunchAgent and `Watchdog ... loaded`. The checked-in watchdog script is copied to `~/.relaymux/bin/<launch-agent-label>-watchdog.sh`, and its plist lives at `~/Library/LaunchAgents/<launch-agent-label>.watchdog.plist`. Watchdog activity is logged under `~/.relaymux/logs/launch-agent-watchdog.log`.
-
-If iMessage/SMS send/receive fails, verify your `imsg` CLI first:
-
-```bash
-imsg chats --limit 5 --json
-relaymux doctor
-```
-
-You may need to grant the terminal or automation host the macOS permissions required by your message tool, such as Full Disk Access or Messages automation permission.
-
-If Telegram sending fails, verify the chat id, token source, and token file permissions:
-
-```bash
-chmod 600 ~/.relaymux/secrets/telegram-bot-token
-relaymux doctor
-```
-
-If tmux is missing:
-
-```bash
-brew install tmux
-relaymux doctor
-```
-
-If the notify token has loose permissions:
-
-```bash
-chmod 600 ~/.relaymux/state/webhook-token
-relaymux doctor
-```
-
-For a no-adapter smoke test from a clone:
-
-```bash
-npm run build
-rm -rf /tmp/relaymux-mock
-node ./dist/bin/relaymux.js --config examples/config.mock.json daemon --once
-node ./dist/bin/relaymux.js --config examples/config.mock.json launch \
-  --repo /tmp/relaymux-mock/repo --agent custom --name smoke --prompt "smoke"
-node ./dist/bin/relaymux.js --config examples/config.mock.json status --history
-```
+- [Configuration](docs/configuration.md): config shape, prompt passing, sessions, and common launch patterns.
+- [Integrations](docs/integrations.md): local HTTP API for agent callbacks, `relaymux ask`, `relaymux notify`, iMessage/SMS, and Telegram.
+- [Operations](docs/operations.md): install footprint, uninstall, background service, watchdog, safety model, troubleshooting, and development.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # relaymux
 
-Text your Mac to launch coding agents in `tmux` windows.
+Launch prompt-driven coding CLIs in visible `tmux` windows from a terminal or Messages.
 
 `relaymux` is a small local dispatcher for coding agents. You send a request over iMessage/SMS or from a terminal, a local orchestrator decides what to do, and delegated work runs as visible `tmux` windows you can attach to, inspect, and kill with normal terminal commands.
 
@@ -19,43 +19,93 @@ relaymux background daemon ──▶ orchestrator command stdout becomes the rep
 notify updates ◀────────── tmux window running Pi/Codex/Claude/etc.
 ```
 
-## Quick start
+## Quickstart
 
-Install from GitHub:
+relaymux is a local dispatcher that starts prompt-driven agent commands in visible `tmux` windows and lets those agents report status back through a terminal or message workflow.
+
+You need Node.js 20+, npm, git, and `tmux`, a terminal multiplexer that keeps named windows running after you detach. The optional iMessage/SMS workflow also needs macOS Messages plus an `imsg` CLI, but the first launch below only uses the terminal and tmux.
+
+Install from GitHub, then make sure the `relaymux` command is on your PATH:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/avyayv/relaymux/main/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
+relaymux --version
 ```
 
-Set up the iMessage/SMS adapter and background service:
+Create the default config:
 
 ```bash
-relaymux setup
-relaymux doctor
-relaymux status
+relaymux init
 ```
 
-`relaymux setup` tries to list recent Messages chats through `imsg chats --json` and prompts you to choose one. If discovery does not work, pass the chat id or phone number yourself:
+`relaymux init` writes `~/.relaymux/config.json`. If you already have a config, edit it instead of overwriting it. At minimum, relaymux needs a shared `tmux` session name and an agent command template:
+
+```json
+{
+  "session": "agents",
+  "tmux": { "sessionMode": "shared" },
+  "agents": {
+    "my-agent": {
+      "command": ["my-agent-cli", "--prompt-file", "{promptFile}"]
+    }
+  }
+}
+```
+
+The `command` value is an argv array. relaymux replaces `{promptFile}` with the path to the prompt file it writes for the run. Replace `my-agent-cli` with the agent or wrapper command you actually use. The generated config also includes starter templates for `pi`, `codex`, `claude`, and a harmless `custom` agent for smoke tests. If your command does not use `{prompt}` or `{promptFile}`, set `promptMode` to `arg`, `env`, `stdin`, or `none` as described in Configuration.
+
+Write a prompt file:
 
 ```bash
-relaymux setup --chat-id +15555550123
+mkdir -p ~/.relaymux/tasks
+cat > ~/.relaymux/tasks/first-agent.md <<'EOF'
+Read the README, summarize what this project does, and report any unclear setup steps.
+EOF
 ```
 
-Launch a first agent window manually:
+A subagent is one delegated agent command running in its own tmux window. Launch one from that prompt file:
 
 ```bash
 relaymux launch \
-  --repo ~/code/my-app \
-  --agent pi \
-  --name fix-api \
-  --prompt "Fix the API bug, run tests, and report back with relaymux notify."
+  --repo ~/code/my-project \
+  --agent my-agent \
+  --name first-agent \
+  --prompt-file ~/.relaymux/tasks/first-agent.md
 ```
 
-Attach to the shared `tmux` session shown by `relaymux status`. tmux calls these “windows”; many terminal UIs display them like tabs.
+By default this creates a new `tmux` window in the shared `agents` session. relaymux does not create panes or splits; many terminal UIs display tmux windows like tabs. Check what is running, then attach to the session:
 
 ```bash
+relaymux status
 tmux attach -t agents
+```
+
+Use a separate session only when you explicitly want to isolate a group of windows:
+
+```bash
+relaymux launch --session my-task --repo ~/code/my-project --agent my-agent --prompt-file ~/.relaymux/tasks/first-agent.md
+```
+
+For terminal-only status, relaymux records start/completion events automatically, and a launched subagent can use the injected run metadata:
+
+```bash
+relaymux --config "$RELAYMUX_CONFIG" notify \
+  --run-id "$RELAYMUX_RUN_ID" \
+  --event progress \
+  --message "Read the README; running checks next."
+```
+
+For user-visible completion messages through the optional Messages adapter, use the setup path on a fresh install instead of bare `relaymux init`. `relaymux setup` writes a Messages-capable config, installs the background daemon, and then `relaymux notify --reply-mode imessage` can send completion updates:
+
+```bash
+relaymux setup --chat-id CHAT_ID_OR_PHONE
+relaymux doctor
+relaymux notify \
+  --from first-agent \
+  --reply-mode imessage \
+  --idempotency-key first-agent-done \
+  --message "Finished: summarized the README and found one unclear setup step."
 ```
 
 ## Mental model
@@ -64,7 +114,7 @@ The background daemon runs directly as a macOS LaunchAgent, which is a per-user 
 
 The orchestrator is just a command from your config. It receives the incoming request as prompt text, and whatever it prints to stdout becomes the reply. Use a non-interactive command whose stdout is a clean final response; if a CLI mixes logs into stdout, wrap it. If the orchestrator exits nonzero or times out, relaymux sends an error update instead.
 
-The default setup uses [Pi](https://github.com/earendil-works/pi) in non-interactive mode. Pi can use shell tools, so it can decide to run `relaymux launch` for longer work. You can replace Pi with any command that accepts a prompt and prints a reply, but that command can only launch delegated agents if it has a way to run shell commands.
+The default setup uses [Pi](https://github.com/earendil-works/pi), a prompt-driven coding-agent CLI, in non-interactive mode. Pi can use shell tools, so it can decide to run `relaymux launch` for longer work. You can replace Pi with any command that accepts a prompt and prints a reply, but that command can only launch delegated agents if it has a way to run shell commands.
 
 relaymux adds its runtime instructions directly to the prompt text passed to the orchestrator. Those instructions tell the orchestrator how to launch delegated work with `relaymux launch` and how delegated agents should report back with `relaymux notify`. You can extend them with `orchestrator.systemPromptFile` or `orchestrator.extraSystemPrompt` in config.
 
@@ -95,7 +145,7 @@ export PATH="$HOME/.local/bin:$PATH"
 
 ## Configuration
 
-`relaymux setup` writes a private config file and managed data under `~/.relaymux`:
+`relaymux init` and `relaymux setup` use a private config file and managed data under `~/.relaymux`. `init` creates the terminal-friendly default config. `setup` is the Messages/daemon setup path; on a fresh install it writes a Messages-capable config and installs the background LaunchAgent.
 
 ```text
 ~/.relaymux/
@@ -235,7 +285,7 @@ relaymux notify \
   --message "Finished: fixed the API bug and tests pass."
 ```
 
-`--reply-mode imessage` asks the daemon to send a user-visible text update. `--reply-mode none` still re-prompts the daemon/orchestrator path, but suppresses the outgoing iMessage. Use it for progress notes that should affect the orchestrator's context or logs without texting the user. Whether that context persists depends on your orchestrator command; the default Pi command uses `--continue` with a relaymux session directory.
+`--reply-mode imessage` asks the daemon to send a user-visible text update. `--reply-mode none` still sends the notification through the daemon/orchestrator path, but suppresses the outgoing iMessage. Use it for progress notes that should affect the orchestrator's context or logs without texting the user. Whether that context persists depends on your orchestrator command; the default Pi command uses `--continue` with a relaymux session directory.
 
 The idempotency key is a stable de-duplication string for one logical update. If a delegated agent retries the same completion notification, reuse the same key so relaymux does not send duplicate text messages.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# relaymux docs
+
+Start with the [README quickstart](../README.md). The docs here hold the details that do not belong on the project landing page.
+
+- [Configuration](configuration.md): config shape, prompt passing, tmux sessions, and common launch patterns.
+- [Integrations](integrations.md): local API, `relaymux ask`, `relaymux notify`, iMessage/SMS, and Telegram.
+- [Operations](operations.md): background service, watchdog, safety model, troubleshooting, and development commands.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,102 @@
+# Configuration
+
+`relaymux init` writes a core config with no message adapters at `~/.relaymux/config.json`. The file is private by default and relaymux refuses to overwrite it unless you pass `--force`.
+
+relaymux stores private config, run records, prompts, logs, and local API token state under `~/.relaymux` by default:
+
+```text
+~/.relaymux/
+  config.json     # private config, written mode 0600
+  state/          # run records, prompts, scripts, daemon state, local API token
+  logs/           # LaunchAgent stdout/stderr logs
+  tasks/          # optional task scratch space
+  reports/        # optional reports
+  research/       # optional research notes
+```
+
+## Core Config
+
+Command arrays are argv templates. `{prompt}` and `{promptFile}` are substituted at launch time. The Pi commands below are examples, not requirements; edit them to match the agent CLIs you actually use.
+
+```json
+{
+  "version": 1,
+  "session": "agents",
+  "stateDir": "~/.relaymux/state",
+  "tmux": {
+    "sessionMode": "shared"
+  },
+  "daemon": {
+    "enabled": true,
+    "host": "127.0.0.1",
+    "port": 47761,
+    "tokenFile": "~/.relaymux/state/webhook-token",
+    "launchAgentLabel": "com.relaymux.daemon",
+    "watchdog": {
+      "enabled": true,
+      "intervalSeconds": 60
+    },
+    "logDir": "~/.relaymux/logs"
+  },
+  "integrations": {},
+  "orchestrator": {
+    "cwd": "~",
+    "command": ["pi", "--print", "--continue", "--session-dir", "~/.relaymux/state/sessions", "{prompt}"],
+    "promptMode": "arg"
+  },
+  "agents": {
+    "pi": { "command": ["pi", "{prompt}"], "promptMode": "arg" },
+    "codex": { "command": ["codex", "{prompt}"], "promptMode": "arg" },
+    "custom": { "command": ["sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""], "promptMode": "env" }
+  }
+}
+```
+
+## Agents And Orchestrator
+
+An agent is a command template in `~/.relaymux/config.json`. If you configure `pi`, relaymux runs `pi ...`; if you configure `codex`, it runs `codex ...`; if you configure `custom`, it can be any shell command.
+
+The orchestrator is also a command, but it has a different job from an agent. The orchestrator handles inbound requests from `relaymux ask` or optional message adapters. Agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply on stdout.
+
+## Prompt Passing
+
+If a command contains `{prompt}` or `{promptFile}`, relaymux substitutes those values. Agent command templates can also use run context such as `{agent}`, `{name}`, `{repo}`, `{workdir}`, `{runId}`, and `{session}`. If the command does not contain a prompt placeholder, `promptMode` decides what to do with the prompt:
+
+| `promptMode` | Behavior |
+| --- | --- |
+| `arg` | Append the prompt as a command-line argument unless `{prompt}` is already present. |
+| `env` | Put the prompt in `RELAYMUX_PROMPT`. |
+| `stdin` | Write the prompt under `~/.relaymux/state/prompts` and pipe that file to stdin. |
+| `none` | Do not pass the prompt automatically. |
+
+Use `--prompt @prompt.txt` or `--prompt-file prompt.txt` for longer prompts.
+
+## Tmux Sessions
+
+A run is one `relaymux launch`. By default, relaymux creates a new tmux window in one shared session named `agents`. tmux calls these windows; many terminal apps display them like tabs. relaymux does not create panes or splits for agent runs.
+
+Launch a named agent in the default shared session:
+
+```bash
+relaymux launch --repo ~/code/my-app --agent pi --name fix-api --prompt @prompt.txt
+```
+
+Launch into a separate tmux session when you want an isolated group of windows:
+
+```bash
+relaymux launch --session release-fix --repo ~/code/my-app --agent codex --prompt @prompt.txt
+```
+
+Use per-worktree sessions when each Git worktree should get a stable session name. In this mode, relaymux derives the session from the repo/worktree/branch plus a short hash:
+
+```bash
+relaymux launch --session-mode per-worktree --repo ~/code/my-app --agent pi --prompt @prompt.txt
+```
+
+Inspect local state. `--history` includes old run records whose tmux windows have already exited:
+
+```bash
+relaymux status
+relaymux status --history
+relaymux status --session agents
+```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,125 @@
+# Integrations
+
+relaymux works without message adapters. The core integration point is local: the daemon binds to loopback and accepts authenticated requests from the relaymux CLI helpers.
+
+## Local API And Agent Updates
+
+`relaymux ask` and `relaymux notify --reply-mode ...` are CLI wrappers over the local API. The update endpoints are local callbacks for agents and helper scripts; they are not public webhooks.
+
+Default endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /health` | Returns daemon, queue, and local API status. |
+| `POST /request` | Submits a terminal/local request to the orchestrator. |
+| `POST /message` | Submits a subagent completion or update. |
+| `POST /agent-message` | Alias for `POST /message`. |
+
+Requests to `POST` endpoints require `Authorization: Bearer <token>`, where the token is stored in `~/.relaymux/state/webhook-token` by default.
+
+Ask the orchestrator from a terminal:
+
+```bash
+relaymux ask "Open an agent in ~/code/my-app to inspect the failing test."
+```
+
+Send a local run-log completion from a delegated agent. Local runs still record automatic `started` and `completed` events even without the daemon:
+
+```bash
+relaymux notify \
+  --from fix-api \
+  --message "Finished: fixed the API bug. Validation: npm test passed."
+```
+
+Use a stable `--idempotency-key` for one logical update so retries do not send duplicates. Keys are remembered in the daemon state under `~/.relaymux/state`.
+
+## Reply Modes
+
+| `replyMode` | Behavior |
+| --- | --- |
+| `none` | The daemon passes the update to the orchestrator, but no adapter message is sent. |
+| `imessage` | The daemon passes the update to the orchestrator, then sends the orchestrator's user-visible reply through the optional iMessage/SMS adapter. |
+| `telegram` | The daemon passes the update to the orchestrator, then sends the orchestrator's user-visible reply through the optional Telegram adapter. |
+
+Use `--reply-mode imessage` or `--reply-mode telegram` only when that adapter is configured and you want a user-visible update.
+
+## Direct HTTP
+
+For foreground debugging instead of LaunchAgent, run `relaymux daemon`. If you cannot use the CLI helper, you can call the local API directly:
+
+```bash
+TOKEN="$(cat ~/.relaymux/state/webhook-token)"
+curl -sS -X POST http://127.0.0.1:47761/message \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"from":"build-agent","replyMode":"none","idempotencyKey":"build-agent:job-123:done","text":"Finished; tests passed."}'
+```
+
+## iMessage/SMS
+
+The iMessage/SMS adapter is optional. It uses your configured `imsg` command for both inbound polling and outbound replies. relaymux shells out to the command you configure; it does not vendor `imsg` or talk to Messages.app directly.
+
+Expected command shapes are `imsg chats --limit <n> --json`, `imsg history --chat-id <id> --limit <n> --json`, and `imsg send --chat-id <id> --text <text> --json`.
+
+```bash
+relaymux setup --imsg --chat-id <chat-id-or-phone-number>
+relaymux doctor
+relaymux status
+```
+
+`relaymux setup --imsg` creates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps.
+
+After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
+
+Manual user-visible completion:
+
+```bash
+relaymux notify \
+  --from fix-api \
+  --reply-mode imessage \
+  --idempotency-key fix-api-20260614-done \
+  --message "Finished: fixed the API bug. Validation: npm test passed."
+```
+
+## Telegram
+
+The Telegram adapter is optional outbound notification support through `sendMessage`. It does not poll Telegram for inbound messages.
+
+Create a bot with BotFather, get a chat id for the chat you want to notify, and store the token outside the public config. A token file works well with LaunchAgent because it does not depend on your interactive shell environment:
+
+```bash
+mkdir -p ~/.relaymux/secrets
+printf '%s\n' '<telegram-bot-token>' > ~/.relaymux/secrets/telegram-bot-token
+chmod 600 ~/.relaymux/secrets/telegram-bot-token
+
+relaymux setup --telegram \
+  --telegram-chat-id <telegram-chat-id> \
+  --telegram-bot-token-file ~/.relaymux/secrets/telegram-bot-token
+relaymux doctor
+relaymux status
+```
+
+You can also use an environment variable instead of a file:
+
+```json
+{
+  "integrations": {
+    "telegram": {
+      "enabled": true,
+      "chatId": "<telegram-chat-id>",
+      "botTokenEnv": "TELEGRAM_BOT_TOKEN",
+      "parseMode": ""
+    }
+  }
+}
+```
+
+Manual Telegram completion:
+
+```bash
+relaymux notify \
+  --from fix-api \
+  --reply-mode telegram \
+  --idempotency-key fix-api-20260614-done \
+  --message "Finished: fixed the API bug. Validation: npm test passed."
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,111 @@
+# Operations
+
+This page covers background service behavior, safety, troubleshooting, and development commands.
+
+## Install Footprint
+
+The install script builds relaymux locally, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin` unless you override the install directories.
+
+Stop the background service and remove the installed binary:
+
+```bash
+relaymux uninstall-launch-agent
+rm -rf ~/.local/lib/relaymux ~/.local/bin/relaymux
+```
+
+Optionally remove local state and config after checking for data you want to keep:
+
+```bash
+rm -rf ~/.relaymux
+```
+
+## Background Service
+
+The daemon is optional for local launches, but useful for the local API and adapter delivery. On macOS, `relaymux setup`, `relaymux install-launch-agent`, or `relaymux restart-launch-agent` can install it as a per-user LaunchAgent. The daemon runs outside tmux.
+
+```bash
+relaymux restart-launch-agent
+relaymux status-launch-agent
+relaymux uninstall-launch-agent
+```
+
+`restart-launch-agent` writes two LaunchAgents on macOS: the main relaymux daemon and a small watchdog. The watchdog runs once a minute, checks the daemon's launchd state plus `/health` on the local API, and bootstraps or kickstarts the daemon if it was killed or left unloaded. Use `--no-watchdog` only when you intentionally want to manage recovery yourself.
+
+Turn on wrapper-level exit notifications if you want a fallback even when the agent forgets to call `relaymux notify`. `failure` means only nonzero exits notify; `always` also notifies on success; `never` is the default:
+
+```bash
+relaymux launch --repo ~/code/my-app --agent pi --name risky-task \
+  --notify-on-exit failure --notify-reply-mode telegram \
+  --prompt @prompt.txt
+```
+
+Adapter exit notifications require the daemon and the selected adapter. Local `started` and `completed` run events are still recorded without them.
+
+## Safety Model And Limitations
+
+relaymux is designed for a single user's local machine. The daemon binds to `127.0.0.1` and API requests authenticate with a random token stored under `~/.relaymux/state`. The config file is written with private file permissions.
+
+That does not make arbitrary agents safe. If a local request or adapter message causes your orchestrator to launch `pi`, `codex`, `claude`, or a shell script, that command has the same local permissions it would have if you ran it yourself. Configure relaymux only with adapters and agents you trust, review your agent prompts, and assume prompts, logs, tmux scrollback, and run records may contain sensitive project context.
+
+relaymux is probably the wrong tool if you need a sandbox, a multi-tenant service, durable distributed jobs, a cron/scheduler, hosted model inference, or a web UI. It is also not a general iMessage, SMS, or Telegram library.
+
+## Troubleshooting
+
+If setup says the LaunchAgent is not loaded, reload it from a normal terminal:
+
+```bash
+relaymux restart-launch-agent
+relaymux status-launch-agent
+```
+
+A healthy install should show both the main LaunchAgent and `Watchdog ... loaded`. The checked-in watchdog script is copied to `~/.relaymux/bin/<launch-agent-label>-watchdog.sh`, and its plist lives at `~/Library/LaunchAgents/<launch-agent-label>.watchdog.plist`. Watchdog activity is logged under `~/.relaymux/logs/launch-agent-watchdog.log`.
+
+If iMessage/SMS send or receive fails, verify your `imsg` CLI first:
+
+```bash
+imsg chats --limit 5 --json
+relaymux doctor
+```
+
+You may need to grant the terminal or automation host the macOS permissions required by your message tool, such as Full Disk Access or Messages automation permission.
+
+If Telegram sending fails, verify the chat id, token source, and token file permissions:
+
+```bash
+chmod 600 ~/.relaymux/secrets/telegram-bot-token
+relaymux doctor
+```
+
+If tmux is missing:
+
+```bash
+brew install tmux
+relaymux doctor
+```
+
+If the notify token has loose permissions:
+
+```bash
+chmod 600 ~/.relaymux/state/webhook-token
+relaymux doctor
+```
+
+For a no-adapter smoke test from a clone:
+
+```bash
+npm run build
+rm -rf /tmp/relaymux-mock
+node ./dist/bin/relaymux.js --config examples/config.mock.json daemon --once
+node ./dist/bin/relaymux.js --config examples/config.mock.json launch \
+  --repo /tmp/relaymux-mock/repo --agent custom --name smoke --prompt "smoke"
+node ./dist/bin/relaymux.js --config examples/config.mock.json status --history
+```
+
+## Development
+
+```bash
+npm ci
+npm run validate
+```
+
+Please keep public examples free of private paths, phone numbers, chat ids, tokens, and secrets.


### PR DESCRIPTION
## Summary
Add a first-reader Quickstart and restructure public docs so the README stays clean: quickstart, basic usage, optional notifications, and links out to detailed docs.

- Keeps the README focused on install, smoke test, real-agent launch, status, and basic notification setup.
- Moves detailed configuration, integrations, local API, operations, safety, and troubleshooting into `docs/`.
- Preserves the newer local API, Telegram, and watchdog material from `main` after resolving conflicts.

## Design
### README
- `README.md` — now serves as the OSS front door: short product definition, install path, `custom` smoke test, real-agent prompt-file launch, tmux default behavior, optional adapter pointers, docs links, development, and license.
- `README.md` — defines only the terms needed for the first run: tmux session/window basics, `--repo`, `--hold`, subagent, `RELAYMUX_NOTIFY_COMMAND`, and reply-mode as notification delivery.

### Docs
- `docs/README.md` — adds a small docs index.
- `docs/configuration.md` — holds config shape, command templates, prompt passing, placeholders, shared sessions, separate sessions, per-worktree sessions, and status commands.
- `docs/integrations.md` — holds local API, `relaymux ask`, `relaymux notify`, reply modes, direct HTTP, iMessage/SMS, and Telegram.
- `docs/operations.md` — holds install footprint, uninstall, LaunchAgent/watchdog behavior, exit notifications, safety model, troubleshooting, and development commands.

## Validation
- `npm run validate` passed: lint, 66 tests, and build succeeded.
- `git diff --check` passed.
- `npx tsx bin/relaymux.ts --help` confirmed README/docs command options line up with current CLI help.
- `env -u RELAYMUX_SESSION npx tsx bin/relaymux.ts --config examples/config.mock.json launch --repo /tmp --agent custom --name smoke --prompt-file examples/subagent-completion.md --dry-run` confirmed the prompt-file launch path and configured shared-session dry run.
- First-reader README-only review found the slimmed README worked as a front door and recommended using the `custom` smoke test first. Follow-up fixes clarified tmux, install footprint, `--repo`, `--hold`, subagent, notify helper, reply mode, and docs links.