### PR TITLE
Fix relaymux first-run setup UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Requirements for local agent launches are Node.js 20+, npm, git, and `tmux`. tmu
 curl -fsSL https://raw.githubusercontent.com/avyayv/relaymux/main/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 relaymux --version
+relaymux setup
+relaymux status
 ```
 
 Or install from a clone:
@@ -61,7 +63,10 @@ git clone https://github.com/avyayv/relaymux.git
 cd relaymux
 ./install.sh
 export PATH="$HOME/.local/bin:$PATH"
+relaymux setup
 ```
+
+`relaymux setup` creates or updates `~/.relaymux/config.json`, installs/restarts the macOS LaunchAgent when supported, and prints the config path, log path, status, and next command. If launchd rejects the service, setup prints the plist path, daemon logs, `launchctl print ...` command, common causes, and the exact retry command.
 
 Optional adapter requirements:
 
@@ -135,11 +140,11 @@ The iMessage/SMS adapter is one optional integration. It uses your configured `i
 
 ```bash
 relaymux setup --imsg --chat-id <chat-id-or-phone-number>
-relaymux doctor
+relaymux status-launch-agent
 relaymux status
 ```
 
-`relaymux setup --imsg` creates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps.
+`relaymux setup --imsg` creates or updates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs/restarts the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps. Re-running `relaymux init --imsg` or `relaymux setup --imsg` adds or updates the adapter on the existing config; `--force` is only for replacing the whole config.
 
 After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
 
@@ -167,7 +172,7 @@ chmod 600 ~/.relaymux/secrets/telegram-bot-token
 relaymux setup --telegram \
   --telegram-chat-id <telegram-chat-id> \
   --telegram-bot-token-file ~/.relaymux/secrets/telegram-bot-token
-relaymux doctor
+relaymux status-launch-agent
 relaymux status
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,12 @@ CLI shim written to $bin_dir/relaymux
 If needed, add this to your shell profile:
   export PATH="$bin_dir:\$PATH"
 
-Try:
+Next:
   relaymux --version
   relaymux setup
+  relaymux status
+
+Optional adapters:
+  relaymux setup --imsg --chat-id <chat-id-or-phone-number>
+  relaymux setup --telegram --telegram-chat-id <chat-id>
 EOF

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { parseArgv } from "./args.js";
 import { buildAgentInvocation, buildTmuxShellCommand, buildTmuxShellScript, quoteArgv, renderTemplate, shellExportBlock } from "./command.js";
 import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
-import { defaultConfig, defaultConfigPath, isIntegrationEnabled, loadConfig, resolveLogDir, resolveStateDir, writeConfig } from "./config.js";
+import { defaultConfig, defaultConfigPath, getIntegration, isIntegrationEnabled, loadConfig, resolveLogDir, resolveStateDir, writeConfig } from "./config.js";
 import { runDaemon } from "./daemon.js";
 import { getLaunchAgentStatus, getLaunchAgentWatchdogStatus, installLaunchAgent, launchAgentPath, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
 import { handleNotify } from "./notify.js";
@@ -95,39 +95,75 @@ export async function main(argv, io = defaultIo()) {
 }
 
 async function handleSetup(flags, io) {
+  const wantsImsg = Boolean(flags.imsg || flags.preset === "imsg");
+  const wantsTelegram = Boolean(flags.telegram || flags.preset === "telegram");
+  const wantsAdapter = wantsImsg || wantsTelegram;
   const configPath = flags.config || defaultConfigPath(io.env);
   let configInfo = loadConfig({ configPath: flags.config, env: io.env });
   const shouldInstallLaunchAgent = flags.launchAgent !== false;
 
-  if (!configInfo.exists || flags.force) {
+  if (flags.dryRun) {
+    io.stdout.write(`Would ${configInfo.exists ? "update" : "create"} config at ${configInfo.exists ? configInfo.path : configPath}\n`);
+    if (wantsImsg) {
+      const imessage = getIntegration(configInfo.config, "imessage");
+      if (!flags.chatId && !flags.recipient && !imessage.chatId) {
+        io.stdout.write("Would prompt for iMessage/SMS chat unless --chat-id <id> is provided.\n");
+      } else {
+        io.stdout.write("Would configure the iMessage/SMS adapter.\n");
+      }
+    }
+    if (wantsTelegram) io.stdout.write("Would configure the Telegram adapter.\n");
+    io.stdout.write(shouldInstallLaunchAgent
+      ? "Would install/restart the background LaunchAgent and watchdog.\n"
+      : "Would skip LaunchAgent installation because --no-launch-agent was passed.\n");
+    return 0;
+  }
+
+  if (!configInfo.exists || flags.force || wantsAdapter) {
     await handleInit({
       ...flags,
-      installLaunchAgent: shouldInstallLaunchAgent,
+      installLaunchAgent: false,
     }, io);
-    configInfo = loadConfig({ configPath, env: io.env });
+    configInfo = loadConfig({ configPath: flags.config, env: io.env });
   } else {
     io.stdout.write(`Using existing config at ${configInfo.path}\n`);
     if (configInfo.usingLegacyDefault) {
       io.stdout.write("Tip: this is the legacy config path. Run `relaymux migrate-home --dry-run` to inventory a safe move into ~/.relaymux.\n");
     }
-    if (shouldInstallLaunchAgent) {
-      installLaunchAgent({
-        flags: { load: flags.load },
-        configInfo,
-        binPath: process.argv[1],
-        io,
-      });
-    }
+  }
+
+  if (shouldInstallLaunchAgent) {
+    restartLaunchAgent({
+      flags: { load: flags.load, watchdog: flags.watchdog },
+      configInfo,
+      binPath: process.argv[1],
+      io,
+    });
   }
 
   const status = handleDoctor(configInfo, io);
+  const launchAgent = getLaunchAgentStatus(configInfo.config);
+  if (shouldInstallLaunchAgent && flags.load !== false && launchAgent.supported && !launchAgent.loaded) {
+    io.stderr.write("Setup wrote the config, but the background LaunchAgent is not loaded. Review the LaunchAgent detail above and run `relaymux restart-launch-agent` after fixing it.\n");
+    return 1;
+  }
   if (status === 0) {
     io.stdout.write("Setup complete. relaymux is ready.\n");
+    io.stdout.write(`Config: ${configInfo.path}\n`);
+    io.stdout.write(`Logs: ${resolveLogDir(configInfo.config, io.env)}\n`);
     io.stdout.write("Next steps:\n");
     if (isIntegrationEnabled(configInfo.config, "imessage")) {
-      io.stdout.write("  1. Text the configured iMessage/SMS chat; relaymux should reply from the background LaunchAgent.\n");
+      if (shouldInstallLaunchAgent) {
+        io.stdout.write("  1. Text the configured iMessage/SMS chat; relaymux should reply from the background LaunchAgent.\n");
+      } else {
+        io.stdout.write("  1. Run `relaymux restart-launch-agent` when you are ready to receive iMessage/SMS requests in the background.\n");
+      }
     } else if (isIntegrationEnabled(configInfo.config, "telegram")) {
-      io.stdout.write("  1. Send a Telegram-mode request with `relaymux ask --reply-mode telegram <text>` after setting the bot token.\n");
+      if (shouldInstallLaunchAgent) {
+        io.stdout.write("  1. Send a Telegram-mode request with `relaymux ask --reply-mode telegram <text>` after setting the bot token.\n");
+      } else {
+        io.stdout.write("  1. Run `relaymux restart-launch-agent` when you are ready to deliver Telegram replies from the background service.\n");
+      }
     } else {
       io.stdout.write("  1. Use the local CLI/API path: `relaymux ask <text>` or `relaymux notify --reply-mode none ...`.\n");
     }
@@ -142,36 +178,65 @@ async function handleSetup(flags, io) {
 async function handleInit(flags, io) {
   const wantsImsg = Boolean(flags.imsg || flags.preset === "imsg");
   const wantsTelegram = Boolean(flags.telegram || flags.preset === "telegram");
+  const wantsAdapter = wantsImsg || wantsTelegram;
+  const existing = loadConfig({ configPath: flags.config, env: io.env });
+  const configPath = existing.exists ? existing.path : flags.config || defaultConfigPath(io.env);
   const labels = [];
   let config;
+  let updatedExisting = false;
 
-  if (wantsImsg) {
-    const chatId = await resolveImsgChatId(flags, io, io.env);
-    config = buildImsgConfig({
+  if (existing.exists && !flags.force && !wantsAdapter) {
+    throw new Error(`Config already exists at ${existing.path}. Use --force to overwrite.`);
+  }
+
+  if (existing.exists && !flags.force && wantsAdapter) {
+    config = cloneConfig(existing.config);
+    updatedExisting = true;
+  } else {
+    if (wantsImsg) {
+      const chatId = await resolveImsgChatId(flags, io, io.env);
+      config = buildImsgConfig({
+        ...initOptionsFromFlags(flags),
+        chatId,
+      }, io.env);
+      labels.push("iMessage/SMS adapter");
+    } else if (wantsTelegram) {
+      config = buildTelegramConfig(initTelegramOptionsFromFlags(flags), io.env);
+      labels.push("Telegram adapter");
+    } else {
+      config = defaultConfig(io.env);
+    }
+  }
+
+  if (updatedExisting && wantsImsg) {
+    const imessage = getIntegration(config, "imessage");
+    const chatId = flags.chatId || flags.recipient || imessage.chatId || await resolveImsgChatId(flags, io, io.env);
+    const imsgConfig = buildImsgConfig({
       ...initOptionsFromFlags(flags),
       chatId,
     }, io.env);
+    config.integrations = { ...(config.integrations || {}), imessage: imsgConfig.integrations.imessage };
+    config.launchNotifications = { ...(config.launchNotifications || {}), replyMode: "imessage" };
     labels.push("iMessage/SMS adapter");
-  } else if (wantsTelegram) {
-    config = buildTelegramConfig(initTelegramOptionsFromFlags(flags), io.env);
-    labels.push("Telegram adapter");
-  } else {
-    config = defaultConfig(io.env);
   }
 
   if (wantsTelegram && wantsImsg) {
     config = withTelegramIntegration(config, initTelegramOptionsFromFlags(flags));
     labels.push("Telegram adapter");
+  } else if (updatedExisting && wantsTelegram) {
+    config = withTelegramIntegration(config, initTelegramOptionsFromFlags(flags));
+    labels.push("Telegram adapter");
   }
 
-  const target = writeConfig(flags.config || defaultConfigPath(io.env), config, { force: Boolean(flags.force), env: io.env });
+  const target = writeConfig(configPath, config, { force: Boolean(flags.force) || updatedExisting, env: io.env });
   const homeDir = ensureRelaymuxHomeLayout(path.dirname(defaultConfigPath(io.env)));
-  io.stdout.write(`Created ${target}${labels.length ? ` with ${labels.join(" and ")} defaults` : " with core defaults"}\n`);
+  io.stdout.write(`${updatedExisting ? "Updated" : "Created"} ${target}${labels.length ? ` with ${labels.join(" and ")} defaults` : " with core defaults"}\n`);
   io.stdout.write(`relaymux home: ${homeDir} (state ${resolveStateDir(config, io.env)}, logs ${resolveLogDir(config, io.env)})\n`);
   if (labels.length) {
-    io.stdout.write("Next: relaymux doctor && relaymux restart-launch-agent && relaymux status\n");
+    io.stdout.write("Next: relaymux restart-launch-agent\n");
+    io.stdout.write("Then: relaymux status-launch-agent && relaymux status\n");
   } else {
-    io.stdout.write("Tip: add optional adapters later with `relaymux init --imsg` or `relaymux init --telegram` into a new config.\n");
+    io.stdout.write("Tip: add optional adapters later with `relaymux init --imsg` or `relaymux init --telegram`.\n");
   }
   if (flags.installLaunchAgent) {
     installLaunchAgent({
@@ -182,6 +247,10 @@ async function handleInit(flags, io) {
     });
   }
   return 0;
+}
+
+function cloneConfig(config) {
+  return JSON.parse(JSON.stringify(config));
 }
 
 function handleMigrateHome(flags, configInfo, io) {
@@ -769,6 +838,7 @@ function doctorStatusLabel(check) {
   if (check.ok) return "ok";
   if (check.severity === "warning") return "warning";
   if (check.severity === "error") return "error";
+  if (check.fatal === false) return "warning";
   return "missing";
 }
 
@@ -911,11 +981,10 @@ Mental model:
 
 Start here:
   relaymux setup
-  relaymux doctor
   relaymux status
 
 Usage:
-  relaymux setup [--imsg|--telegram] [--chat-id <id>] [--telegram-chat-id <id>] [--no-launch-agent]
+  relaymux setup [--imsg|--telegram] [--chat-id <id>] [--telegram-chat-id <id>] [--no-launch-agent] [--dry-run]
   relaymux init [--force] [--config <path>]
   relaymux init --imsg [--chat-id <id>] [--install-launch-agent]
   relaymux init --telegram [--telegram-chat-id <id>] [--install-launch-agent]
@@ -943,6 +1012,7 @@ Setup/init options:
   --state-dir <path>        State/token/log directory
   --install-launch-agent    Install the direct/background LaunchAgent after writing config
   --no-launch-agent         For setup: skip LaunchAgent installation
+  --dry-run                 For setup: print planned config/service changes without writing files
 
 Migration options:
   --apply                   Copy inventoried relaymux-owned files into ~/.relaymux

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -115,12 +115,17 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
   });
   const launchAgent: any = getLaunchAgentStatus(config);
   const daemonEnabled = config.daemon?.enabled !== false;
+  const logDir = resolveLogDir(config, env);
   checks.push({
     name: "background-service",
     ok: !daemonEnabled || !launchAgent.supported || launchAgent.loaded,
+    fatal: false,
+    severity: launchAgent.loaded || !daemonEnabled ? undefined : "warning",
     detail: daemonEnabled
       ? launchAgent.supported
-        ? `direct/background LaunchAgent ${launchAgent.loaded ? "loaded" : "not loaded"}: ${launchAgentPath(config)}${launchAgent.detail ? ` (${launchAgent.detail})` : ""}`
+        ? launchAgent.loaded
+          ? `direct/background LaunchAgent loaded: ${launchAgentPath(config)}${launchAgent.detail ? ` (${launchAgent.detail})` : ""}`
+          : `direct/background LaunchAgent not loaded: ${launchAgentPath(config)}${launchAgent.detail ? ` (launchctl: ${launchAgent.detail})` : ""}; run relaymux restart-launch-agent; logs ${logDir}/daemon.out.log and ${logDir}/daemon.err.log; inspect launchctl print ${launchAgent.target}`
         : `direct/background LaunchAgent unsupported on ${process.platform}: ${launchAgentPath(config)}`
       : "disabled in config",
   });

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -124,7 +124,16 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
     }
     const result = loadLaunchAgentTarget({ target, domain: launchAgentDomain(), plistPath });
     if (result.status !== 0) {
-      io.stderr.write(`launchctl bootstrap did not complete (${result.status}); watchdog will retry, or load manually with launchctl bootstrap ${launchAgentDomain()} ${plistPath}\n`);
+      io.stderr.write(formatLaunchAgentLoadFailure({
+        label,
+        result,
+        domain: launchAgentDomain(),
+        target,
+        plistPath,
+        logDir,
+        stdoutLog: path.join(logDir, `${logPrefix}.out.log`),
+        stderrLog: path.join(logDir, `${logPrefix}.err.log`),
+      }));
     }
   }
   return plistPath;
@@ -154,7 +163,16 @@ export function installLaunchAgentWatchdog({ config, configPath, binPath, io, lo
     const target = launchAgentWatchdogTarget(config);
     const result = loadLaunchAgentTarget({ target, domain: launchAgentDomain(), plistPath });
     if (result.status !== 0) {
-      io.stderr.write(`watchdog bootstrap did not complete (${result.status}); you can load manually with launchctl bootstrap ${launchAgentDomain()} ${plistPath}\n`);
+      io.stderr.write(formatLaunchAgentLoadFailure({
+        label: launchAgentWatchdogLabel(config),
+        result,
+        domain: launchAgentDomain(),
+        target,
+        plistPath,
+        logDir,
+        stdoutLog: path.join(logDir, "launch-agent-watchdog.out.log"),
+        stderrLog: path.join(logDir, "launch-agent-watchdog.err.log"),
+      }));
     }
   }
 
@@ -226,6 +244,9 @@ export function printLaunchAgentStatus({ config, io, json = false }) {
   if (!status.loaded) {
     io.stdout.write(`LaunchAgent ${status.label}: direct/background (no tmux) not loaded; plist ${status.plistExists ? status.plistPath : "missing"}\n`);
     if (status.detail) io.stdout.write(`Detail: ${status.detail}\n`);
+    io.stdout.write(`Logs: ${path.join(resolveLogDir(config), "daemon.out.log")} and ${path.join(resolveLogDir(config), "daemon.err.log")}\n`);
+    io.stdout.write(`Inspect: launchctl print ${status.target}\n`);
+    io.stdout.write("Next: relaymux restart-launch-agent\n");
     return status;
   }
 
@@ -260,6 +281,20 @@ export function getLaunchAgentWatchdogStatus(config) {
     intervalSeconds: launchAgentWatchdogIntervalSeconds(config),
     scriptPath: launchAgentWatchdogScriptPath(config),
   };
+}
+
+export function formatLaunchAgentLoadFailure({ label, result, domain, target, plistPath, logDir, stdoutLog, stderrLog }) {
+  const detail = firstLine(result.stderr) || firstLine(result.stdout) || "no launchctl detail";
+  return [
+    `relaymux: launchctl bootstrap failed for ${label} (status ${result.status}: ${detail})`,
+    `  plist: ${plistPath}`,
+    `  logs: ${stdoutLog || path.join(logDir, "daemon.out.log")} and ${stderrLog || path.join(logDir, "daemon.err.log")}`,
+    `  inspect: launchctl print ${target}`,
+    "  common causes: invalid plist, missing executable path, bad WorkingDirectory, or file permission problems",
+    `  next: run relaymux status-launch-agent; after fixing the issue, run relaymux restart-launch-agent`,
+    `  manual load: launchctl bootstrap ${domain} ${plistPath}`,
+    "",
+  ].join("\n");
 }
 
 function getLaunchAgentStatusFor({ label, plistPath, target }) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { main } from "../src/cli.js";
-import { writeDefaultConfig } from "../src/config.js";
+import { defaultConfig, loadConfig, writeConfig, writeDefaultConfig } from "../src/config.js";
 
 function makeIo(env: Record<string, string> = {}) {
   let stdout = "";
@@ -33,6 +33,12 @@ function writeTempConfig(name: string) {
   fs.rmSync(configPath, { force: true });
   writeDefaultConfig(configPath);
   return configPath;
+}
+
+function makeExecutable(dir: string, name: string, body = "printf 'fake\\n'") {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return file;
 }
 
 test("start-tmux daemon mode is retired by default", async () => {
@@ -215,4 +221,101 @@ test("install-launch-agent rejects tmux supervisor mode", async () => {
 
   assert.equal(code, 1);
   assert.match(harness.stderr, /tmux mode has been removed/);
+});
+
+test("init --imsg merges adapter into existing config without overwriting core settings", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-init-merge-"));
+  const configPath = path.join(dir, "config.json");
+  const config = defaultConfig();
+  config.session = "kept-session";
+  config.orchestrator.command = ["custom-orchestrator", "{prompt}"];
+  config.agents.local = { command: ["local-agent", "{prompt}"], promptMode: "arg" };
+  writeConfig(configPath, config, { force: true });
+
+  const harness = makeIo();
+  const code = await main(["--config", configPath, "init", "--imsg", "--chat-id", "chat-1"], harness.io);
+  const updated = loadConfig({ configPath }).config;
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /Updated .* with iMessage\/SMS adapter defaults/);
+  assert.doesNotMatch(harness.stdout, /doctor &&/);
+  assert.equal(updated.session, "kept-session");
+  assert.deepEqual(updated.orchestrator.command, ["custom-orchestrator", "{prompt}"]);
+  assert.deepEqual(updated.agents.local.command, ["local-agent", "{prompt}"]);
+  assert.equal(updated.integrations.imessage.enabled, true);
+  assert.equal(updated.integrations.imessage.chatId, "chat-1");
+});
+
+test("init --imsg is idempotent on an existing imsg config without prompting", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-init-imsg-idempotent-"));
+  const configPath = path.join(dir, "config.json");
+  const config = defaultConfig();
+  config.integrations.imessage = {
+    enabled: true,
+    chatId: "chat-1",
+  };
+  writeConfig(configPath, config, { force: true });
+
+  const harness = makeIo();
+  const code = await main(["--config", configPath, "init", "--imsg"], harness.io);
+  const updated = loadConfig({ configPath }).config;
+
+  assert.equal(code, 0);
+  assert.equal(harness.stderr, "");
+  assert.equal(updated.integrations.imessage.chatId, "chat-1");
+});
+
+test("setup --imsg guidance uses separate recovery commands", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-setup-guidance-"));
+  const binDir = path.join(dir, "bin");
+  fs.mkdirSync(binDir);
+  makeExecutable(binDir, "tmux", "printf 'tmux 3.4\\n'");
+  makeExecutable(binDir, "pi");
+  makeExecutable(binDir, "imsg");
+  const configPath = path.join(dir, "config.json");
+  const harness = makeIo({ PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`, RELAYMUX_HOME: path.join(dir, "home") });
+  const code = await main(["--config", configPath, "setup", "--imsg", "--chat-id", "chat-1", "--no-launch-agent"], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /Updated|Created/);
+  assert.match(harness.stdout, /Next: relaymux restart-launch-agent/);
+  assert.match(harness.stdout, /Logs:/);
+  assert.doesNotMatch(harness.stdout, /doctor && relaymux restart-launch-agent && relaymux status/);
+});
+
+test("setup dry-run does not write config or mutate LaunchAgents", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-setup-dry-run-"));
+  const configPath = path.join(dir, "config.json");
+  const harness = makeIo();
+  const code = await main(["--config", configPath, "setup", "--imsg", "--dry-run"], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /Would create config/);
+  assert.match(harness.stdout, /Would prompt for iMessage\/SMS chat/);
+  assert.equal(fs.existsSync(configPath), false);
+});
+
+test("doctor exits zero when only the background service is missing", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-doctor-background-"));
+  const binDir = path.join(dir, "bin");
+  fs.mkdirSync(binDir);
+  makeExecutable(binDir, "tmux", "printf 'tmux 3.4\\n'");
+  const configPath = path.join(dir, "config.json");
+  const config = defaultConfig();
+  config.orchestrator.command = [process.execPath, "--version"];
+  config.daemon.launchAgentLabel = `com.relaymux.test.${process.pid}`;
+  writeConfig(configPath, config, { force: true });
+
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
+  try {
+    const harness = makeIo({ PATH: process.env.PATH });
+    const code = await main(["--config", configPath, "doctor"], harness.io);
+
+    assert.equal(code, 0);
+    assert.match(harness.stdout, /warning\tbackground-service\t/);
+    assert.match(harness.stdout, /relaymux restart-launch-agent|unsupported/);
+  } finally {
+    process.env.PATH = oldPath;
+  }
 });

--- a/test/launch-agent.test.ts
+++ b/test/launch-agent.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { defaultConfig } from "../src/config.js";
 import {
+  formatLaunchAgentLoadFailure,
   installLaunchAgent,
   isCurrentLaunchAgent,
   parseLaunchCtlPrint,
@@ -170,4 +171,24 @@ test("parseLaunchCtlPrint extracts running status", () => {
   assert.equal(status.state, "running");
   assert.equal(status.pid, 1234);
   assert.equal(status.lastExitCode, "0");
+});
+
+test("formatLaunchAgentLoadFailure includes actionable launchctl context", () => {
+  const text = formatLaunchAgentLoadFailure({
+    label: "com.example.relaymux",
+    result: { status: 5, stdout: "", stderr: "Bootstrap failed: 5: Bad request.\n" },
+    domain: "gui/501",
+    target: "gui/501/com.example.relaymux",
+    plistPath: "/Users/example/Library/LaunchAgents/com.example.relaymux.plist",
+    logDir: "/Users/example/.relaymux/logs",
+    stdoutLog: "/Users/example/.relaymux/logs/daemon.out.log",
+    stderrLog: "/Users/example/.relaymux/logs/daemon.err.log",
+  });
+
+  assert.match(text, /Bad request/);
+  assert.match(text, /plist: \/Users\/example\/Library\/LaunchAgents\/com\.example\.relaymux\.plist/);
+  assert.match(text, /daemon\.out\.log/);
+  assert.match(text, /launchctl print gui\/501\/com\.example\.relaymux/);
+  assert.match(text, /common causes/);
+  assert.match(text, /relaymux restart-launch-agent/);
 });


### PR DESCRIPTION
## Summary
Fixes the first-run relaymux setup path so adapter setup can be re-run safely, setup has one clear path, and LaunchAgent failures show actionable recovery context.

- `init --imsg` / `setup --imsg` now merge adapter config into an existing config instead of prompting and then failing on the existing file.
- `doctor` treats an unloaded background service as a warning with restart/log guidance instead of blocking chained setup flows.
- LaunchAgent bootstrap failures now include plist, logs, inspect command, common causes, and retry command.

## Design
### Setup and init flow
- `src/cli.ts` — preflights existing config before prompting, merges requested iMessage/Telegram adapter config into existing configs, adds `setup --dry-run`, and changes first-run guidance away from `doctor && restart-launch-agent && status`.
- `test/cli.test.ts` — covers adapter merge/idempotency, setup dry-run, setup guidance, and doctor exit behavior without mutating real LaunchAgents.

### Diagnostics
- `src/doctor.ts` — marks the background LaunchAgent check as non-fatal and prints the exact restart command, daemon log paths, and `launchctl print` inspection command.
- `src/launch-agent.ts` — formats `launchctl bootstrap` failures with plist/log/inspect/common-cause context for both daemon and watchdog LaunchAgents.
- `test/launch-agent.test.ts` — verifies the LaunchAgent error formatter includes the actionable context.

### First-run docs
- `install.sh` — recommends `relaymux setup` followed by `relaymux status`, with adapters shown as optional setup variants.
- `README.md` — updates install and adapter quickstarts to use `setup`, `status-launch-agent`, and `status` instead of chained doctor/restart/status commands.

## Validation
- `npx tsx --test test/cli.test.ts test/launch-agent.test.ts test/doctor.test.ts` passed: 27 tests.
- `npm run lint` passed.
- `npm run validate` passed: lint, 72 tests, build.
- `git diff --check` passed.
- Smoke commands passed:
  - `npx tsx bin/relaymux.ts setup --help`
  - `npx tsx bin/relaymux.ts init --help`
  - `npx tsx bin/relaymux.ts --config /tmp/relaymux-smoke-setup-dry-run.json setup --imsg --dry-run`
  - temp-config `init`, `init --imsg --chat-id chat-1`, repeated `init --imsg`
  - temp-config `setup --imsg --chat-id chat-1 --no-launch-agent` plus `doctor` with fake local executables

