### PR TITLE
Add Linux background service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ relaymux setup
 relaymux status
 ```
 
-The installer clones and builds relaymux locally with Node/npm/git, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin`.
+The installer clones and builds relaymux locally with Node/npm/git, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin`. On Linux, `relaymux setup` expects per-user systemd services (`systemctl --user`) for the daemon; scheduled prompts use cron when `--scheduler auto` is selected.
 
-`relaymux setup` creates or updates `~/.relaymux/config.json`, installs/restarts the macOS LaunchAgent when supported, and prints the config path, log path, status, and next command. If launchd rejects the service, setup prints the plist path, daemon logs, `launchctl print ...` command, common causes, and the exact retry command.
+`relaymux setup` creates or updates `~/.relaymux/config.json`, installs/restarts the per-user background service when supported, and prints the config path, log path, status, and next command. macOS uses launchd LaunchAgents; Linux uses a systemd user unit (`systemctl --user`). If the service manager rejects the service, setup prints the service file path, daemon logs, inspect command, common causes, and the exact retry command.
 
-For a config-only setup without starting the background service, use `relaymux setup --no-launch-agent`. `relaymux init` is the lower-level config writer; it refuses to overwrite an existing config unless you pass `--force`.
+For a config-only setup without starting the background service, use `relaymux setup --no-launch-agent` (command names remain launch-agent-compatible for now). `relaymux init` is the lower-level config writer; it refuses to overwrite an existing config unless you pass `--force`.
 
 The generated config includes a harmless `custom` agent that prints its prompt, which is useful for checking that tmux/status behavior works before wiring a real agent:
 
@@ -140,7 +140,7 @@ relaymux schedule add \
   --prompt "Check the active agent runs and send me a concise status."
 ```
 
-Scheduled prompts are local OS jobs. The default `auto` scheduler uses macOS launchd on macOS and cron elsewhere. Each job runs `relaymux ask --no-wait` when the schedule fires; relaymux does not create a hidden cloud scheduler or a durable in-process loop inside the daemon. Use `relaymux schedule add --dry-run` to inspect the generated job before installing it, or pass `--scheduler launchd|cron` when you want a specific backend.
+Scheduled prompts are local OS jobs. The default `auto` scheduler uses macOS launchd on macOS and cron elsewhere, including Linux. Each job runs `relaymux ask --no-wait` when the schedule fires; relaymux does not create a hidden cloud scheduler or a durable in-process loop inside the daemon. Use `relaymux schedule add --dry-run` to inspect the generated job before installing it, or pass `--scheduler launchd|cron` when you want a specific backend. On Linux, install a cron implementation such as cron/cronie if `crontab` is missing.
 
 ## Docs
 

--- a/bin/relaymux.ts
+++ b/bin/relaymux.ts
@@ -4,6 +4,7 @@ import { main } from "../src/cli.js";
 
 process.exitCode = await main(process.argv.slice(2), {
   env: process.env,
+  platform: process.platform,
   stdin: process.stdin,
   stdout: process.stdout,
   stderr: process.stderr,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ relaymux stores private config, run records, prompts, logs, and local API token 
 ~/.relaymux/
   config.json     # private config, written mode 0600
   state/          # run records, prompts, scripts, schedules, daemon state, local API token
-  logs/           # LaunchAgent stdout/stderr logs
+  logs/           # background service stdout/stderr logs
   tasks/          # optional task scratch space
   reports/        # optional reports
   research/       # optional research notes
@@ -51,6 +51,8 @@ Command arrays are argv templates. `{prompt}` and `{promptFile}` are substituted
   }
 }
 ```
+
+`daemon.launchAgentLabel` names the macOS LaunchAgent. On Linux the same value is reused as the systemd user service name with a `.service` suffix unless you set `daemon.systemdServiceName`.
 
 ## Agents And Orchestrator
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -23,7 +23,7 @@ Ask the orchestrator from a terminal:
 relaymux ask "Open an agent in ~/code/my-app to inspect the failing test."
 ```
 
-`relaymux ask` requires the relaymux daemon to be running. `relaymux setup` installs the daemon as a per-user LaunchAgent on macOS, and `relaymux restart-launch-agent` reloads it after config changes.
+`relaymux ask` requires the relaymux daemon to be running. `relaymux setup` installs the daemon as a per-user LaunchAgent on macOS or a systemd user service on Linux, and `relaymux restart-launch-agent` reloads it after config changes (the command name is kept for CLI compatibility).
 
 Send a local run-log completion from a delegated agent. Local runs still record automatic `started` and `completed` events even without the daemon:
 
@@ -57,7 +57,7 @@ relaymux schedule add \
   --prompt "Check the active agent runs and send me a concise status."
 ```
 
-Scheduled prompts are local OS jobs. The default `auto` scheduler uses macOS launchd on macOS and cron elsewhere. Each job runs `relaymux ask --no-wait` on the schedule; relaymux does not create a hidden cloud scheduler or a durable in-process loop inside the daemon. The relaymux daemon must be running when the schedule fires, so run `relaymux restart-launch-agent` after setup if needed. Use `--dry-run` to inspect the generated job before installing it, or pass `--scheduler launchd|cron` when you want a specific backend.
+Scheduled prompts are local OS jobs. The default `auto` scheduler uses macOS launchd on macOS and cron elsewhere, including Linux. Each job runs `relaymux ask --no-wait` on the schedule; relaymux does not create a hidden cloud scheduler or a durable in-process loop inside the daemon. The relaymux daemon must be running when the schedule fires, so run `relaymux restart-launch-agent` after setup if needed. On Linux, make sure `crontab` is available through cron/cronie. Use `--dry-run` to inspect the generated job before installing it, or pass `--scheduler launchd|cron` when you want a specific backend.
 
 Use `--prompt-file prompt.txt` for longer prompts. relaymux copies the prompt into `~/.relaymux/state/schedules/<name>/prompt.txt`, stores schedule metadata beside it, and writes schedule logs under `~/.relaymux/logs/schedules`. Re-adding the same `--name` updates that schedule instead of creating a duplicate.
 
@@ -70,7 +70,7 @@ relaymux schedule remove --name weekday-checkin
 
 ## Direct HTTP
 
-For foreground debugging instead of LaunchAgent, run `relaymux daemon`. If you cannot use the CLI helper, you can call the local API directly:
+For foreground debugging instead of the installed background service, run `relaymux daemon`. If you cannot use the CLI helper, you can call the local API directly:
 
 ```bash
 TOKEN="$(cat ~/.relaymux/state/webhook-token)"
@@ -92,7 +92,7 @@ relaymux status-launch-agent
 relaymux status
 ```
 
-`relaymux setup --imsg` creates or updates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs/restarts the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps. Re-running `relaymux init --imsg` or `relaymux setup --imsg` adds or updates the adapter on the existing config; `--force` is only for replacing the whole config.
+`relaymux setup --imsg` creates or updates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs/restarts the background service unless `--no-launch-agent` is passed, and prints next steps. Re-running `relaymux init --imsg` or `relaymux setup --imsg` adds or updates the adapter on the existing config; `--force` is only for replacing the whole config.
 
 After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
 
@@ -110,7 +110,7 @@ relaymux notify \
 
 The Telegram adapter is optional outbound notification support through `sendMessage`. It does not poll Telegram for inbound messages.
 
-Create a bot with BotFather, get a chat id for the chat you want to notify, and store the token outside the public config. A token file works well with LaunchAgent because it does not depend on your interactive shell environment:
+Create a bot with BotFather, get a chat id for the chat you want to notify, and store the token outside the public config. A token file works well with the background service because it does not depend on your interactive shell environment:
 
 ```bash
 mkdir -p ~/.relaymux/secrets

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,7 +4,7 @@ This page covers background service behavior, safety, troubleshooting, and devel
 
 ## Install Footprint
 
-The install script builds relaymux locally, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin` unless you override the install directories.
+The install script builds relaymux locally, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin` unless you override the install directories. Service files are created only when you run setup/restart: `~/Library/LaunchAgents` on macOS or `~/.config/systemd/user` (or `$XDG_CONFIG_HOME/systemd/user`) on Linux.
 
 Stop the background service and remove the installed binary:
 
@@ -21,7 +21,7 @@ rm -rf ~/.relaymux
 
 ## Background Service
 
-The daemon is optional for local launches, but useful for the local API and adapter delivery. On macOS, `relaymux setup`, `relaymux install-launch-agent`, or `relaymux restart-launch-agent` can install it as a per-user LaunchAgent. The daemon runs outside tmux.
+The daemon is optional for local launches, but useful for the local API and adapter delivery. `relaymux setup`, `relaymux install-launch-agent`, and `relaymux restart-launch-agent` install the per-user background service for the current platform. The command names are kept for CLI compatibility: macOS uses a launchd LaunchAgent, while Linux uses a systemd user service (`systemctl --user`). The daemon runs outside tmux.
 
 ```bash
 relaymux restart-launch-agent
@@ -29,7 +29,9 @@ relaymux status-launch-agent
 relaymux uninstall-launch-agent
 ```
 
-`restart-launch-agent` writes two LaunchAgents on macOS: the main relaymux daemon and a small watchdog. The watchdog runs once a minute, checks the daemon's launchd state plus `/health` on the local API, and bootstraps or kickstarts the daemon if it was killed or left unloaded. Use `--no-watchdog` only when you intentionally want to manage recovery yourself.
+On macOS, `restart-launch-agent` writes two LaunchAgents: the main relaymux daemon and a small watchdog. The watchdog runs once a minute, checks the daemon's launchd state plus `/health` on the local API, and bootstraps or kickstarts the daemon if it was killed or left unloaded. Use `--no-watchdog` only when you intentionally want to manage recovery yourself.
+
+On Linux, `restart-launch-agent` writes `~/.config/systemd/user/<service>.service` (or `$XDG_CONFIG_HOME/systemd/user/<service>.service`) and runs `systemctl --user daemon-reload`, `systemctl --user enable <service>`, and `systemctl --user restart <service>`. The unit uses `Restart=always`, so no separate watchdog unit is installed. If `systemctl --user` cannot connect to a user bus, run `relaymux daemon` in the foreground or enable user services for the account (for example, a real systemd login session and, on headless servers, `loginctl enable-linger "$USER"`).
 
 Turn on wrapper-level exit notifications if you want a fallback even when the agent forgets to call `relaymux notify`. `failure` means only nonzero exits notify; `always` also notifies on success; `never` is the default:
 
@@ -51,14 +53,23 @@ relaymux is probably the wrong tool if you need a sandbox, a multi-tenant servic
 
 ## Troubleshooting
 
-If setup says the LaunchAgent is not loaded, reload it from a normal terminal:
+If setup says the background service is not running, reload it from a normal terminal:
 
 ```bash
 relaymux restart-launch-agent
 relaymux status-launch-agent
 ```
 
-A healthy install should show both the main LaunchAgent and `Watchdog ... loaded`. The checked-in watchdog script is copied to `~/.relaymux/bin/<launch-agent-label>-watchdog.sh`, and its plist lives at `~/Library/LaunchAgents/<launch-agent-label>.watchdog.plist`. Watchdog activity is logged under `~/.relaymux/logs/launch-agent-watchdog.log`.
+A healthy macOS install should show both the main LaunchAgent and `Watchdog ... loaded`. The checked-in watchdog script is copied to `~/.relaymux/bin/<launch-agent-label>-watchdog.sh`, and its plist lives at `~/Library/LaunchAgents/<launch-agent-label>.watchdog.plist`. Watchdog activity is logged under `~/.relaymux/logs/launch-agent-watchdog.log`.
+
+A healthy Linux install should show `systemd user service ... active`. If it does not, inspect it with:
+
+```bash
+systemctl --user status com.relaymux.daemon.service
+journalctl --user -u com.relaymux.daemon.service -e
+```
+
+If `systemctl --user` reports that it cannot connect to the bus, use a normal systemd user login session, check `XDG_RUNTIME_DIR`, or enable lingering for the account on a headless machine. As a temporary fallback, run `relaymux daemon` in a foreground shell.
 
 If iMessage/SMS send or receive fails, verify your `imsg` CLI first:
 
@@ -76,10 +87,15 @@ chmod 600 ~/.relaymux/secrets/telegram-bot-token
 relaymux doctor
 ```
 
-If tmux is missing:
+If tmux is missing, install it with your OS package manager:
 
 ```bash
+# macOS
 brew install tmux
+
+# Debian/Ubuntu
+sudo apt-get install tmux
+
 relaymux doctor
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,11 @@ Next:
   relaymux setup
   relaymux status
 
+Background service:
+  macOS uses a per-user launchd LaunchAgent.
+  Linux uses a systemd user service via: systemctl --user
+  Scheduled prompts use cron on Linux when --scheduler auto is selected.
+
 Optional adapters:
   relaymux setup --imsg --chat-id <chat-id-or-phone-number>
   relaymux setup --telegram --telegram-chat-id <chat-id>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
 import { defaultConfig, defaultConfigPath, getIntegration, isIntegrationEnabled, loadConfig, resolveLogDir, resolveStateDir, writeConfig } from "./config.js";
 import { runDaemon } from "./daemon.js";
-import { getLaunchAgentStatus, getLaunchAgentWatchdogStatus, installLaunchAgent, launchAgentPath, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
+import { backgroundServicePath, getLaunchAgentStatus, getLaunchAgentWatchdogStatus, installLaunchAgent, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
 import { handleNotify } from "./notify.js";
 import { handleSchedule, scheduleHelpText } from "./schedule.js";
 import { webhookConfig, webhookStatus } from "./webhook.js";
@@ -25,6 +25,7 @@ import { isReplyMode, replyModesText } from "./reply-modes.js";
 
 export async function main(argv, io = defaultIo()) {
   try {
+    const platform = io.platform || process.platform;
     const parsed = parseArgv(argv);
     if (parsed.flags.version || parsed.command === "version") {
       io.stdout.write("relaymux 0.1.0\n");
@@ -40,11 +41,11 @@ export async function main(argv, io = defaultIo()) {
     }
 
     if (parsed.command === "init") {
-      return handleInit(parsed.flags, io);
+      return handleInit(parsed.flags, io, platform);
     }
 
     if (parsed.command === "setup") {
-      return handleSetup(parsed.flags, io);
+      return handleSetup(parsed.flags, io, platform);
     }
 
     const configInfo = loadConfig({ configPath: parsed.flags.config, env: io.env });
@@ -56,7 +57,7 @@ export async function main(argv, io = defaultIo()) {
       case "launch":
         return handleLaunch(parsed.flags, configInfo, stateDir, io);
       case "status":
-        return handleStatus(parsed.flags, configInfo, stateDir, io);
+        return handleStatus(parsed.flags, configInfo, stateDir, io, platform);
       case "notify":
         await handleNotify({
           flags: parsed.flags,
@@ -77,6 +78,7 @@ export async function main(argv, io = defaultIo()) {
           stateDir,
           binPath: process.argv[1],
           io,
+          platform,
         });
       case "daemon":
         return await runDaemon({ flags: parsed.flags, configInfo, stateDir, io });
@@ -85,20 +87,20 @@ export async function main(argv, io = defaultIo()) {
       case "supervise-tmux":
         return await handleSuperviseTmux(parsed.flags, configInfo, stateDir, io);
       case "install-launch-agent":
-        installLaunchAgent({ flags: parsed.flags, configInfo, binPath: process.argv[1], io });
+        installLaunchAgent({ flags: parsed.flags, configInfo, binPath: process.argv[1], io, platform });
         return 0;
       case "restart-launch-agent":
-        restartLaunchAgent({ flags: parsed.flags, configInfo, binPath: process.argv[1], io });
+        restartLaunchAgent({ flags: parsed.flags, configInfo, binPath: process.argv[1], io, platform });
         return 0;
       case "status-launch-agent":
       case "launch-agent-status":
-        printLaunchAgentStatus({ config: configInfo.config, io, json: Boolean(parsed.flags.json) });
+        printLaunchAgentStatus({ config: configInfo.config, io, json: Boolean(parsed.flags.json), platform });
         return 0;
       case "uninstall-launch-agent":
-        uninstallLaunchAgent({ config: configInfo.config, io });
+        uninstallLaunchAgent({ config: configInfo.config, io, platform });
         return 0;
       case "doctor":
-        return handleDoctor(configInfo, io);
+        return handleDoctor(configInfo, io, platform);
       default:
         throw new Error(`Unknown command "${parsed.command}"`);
     }
@@ -108,7 +110,7 @@ export async function main(argv, io = defaultIo()) {
   }
 }
 
-async function handleSetup(flags, io) {
+async function handleSetup(flags, io, platform = process.platform) {
   const wantsImsg = Boolean(flags.imsg || flags.preset === "imsg");
   const wantsTelegram = Boolean(flags.telegram || flags.preset === "telegram");
   const wantsAdapter = wantsImsg || wantsTelegram;
@@ -128,8 +130,8 @@ async function handleSetup(flags, io) {
     }
     if (wantsTelegram) io.stdout.write("Would configure the Telegram adapter.\n");
     io.stdout.write(shouldInstallLaunchAgent
-      ? "Would install/restart the background LaunchAgent and watchdog.\n"
-      : "Would skip LaunchAgent installation because --no-launch-agent was passed.\n");
+      ? `Would install/restart the ${backgroundServiceDryRunName(platform)}.\n`
+      : "Would skip background service installation because --no-launch-agent was passed.\n");
     return 0;
   }
 
@@ -137,7 +139,7 @@ async function handleSetup(flags, io) {
     await handleInit({
       ...flags,
       installLaunchAgent: false,
-    }, io);
+    }, io, platform);
     configInfo = loadConfig({ configPath: flags.config, env: io.env });
   } else {
     io.stdout.write(`Using existing config at ${configInfo.path}\n`);
@@ -152,13 +154,14 @@ async function handleSetup(flags, io) {
       configInfo,
       binPath: process.argv[1],
       io,
+      platform,
     });
   }
 
-  const status = handleDoctor(configInfo, io);
-  const launchAgent = getLaunchAgentStatus(configInfo.config);
-  if (shouldInstallLaunchAgent && flags.load !== false && launchAgent.supported && !launchAgent.loaded) {
-    io.stderr.write("Setup wrote the config, but the background LaunchAgent is not loaded. Review the LaunchAgent detail above and run `relaymux restart-launch-agent` after fixing it.\n");
+  const status = handleDoctor(configInfo, io, platform);
+  const launchAgent = getLaunchAgentStatus(configInfo.config, { platform, env: io.env });
+  if (shouldInstallLaunchAgent && flags.load !== false && backgroundServiceNeedsSetupFailure(launchAgent)) {
+    io.stderr.write(`Setup wrote the config, but the ${backgroundServiceStatusName(launchAgent, platform)} is not running. Review the service detail above and run \`relaymux restart-launch-agent\` after fixing it.\n`);
     return 1;
   }
   if (status === 0) {
@@ -168,9 +171,9 @@ async function handleSetup(flags, io) {
     io.stdout.write("Next steps:\n");
     if (isIntegrationEnabled(configInfo.config, "imessage")) {
       if (shouldInstallLaunchAgent) {
-        io.stdout.write("  1. Text the configured iMessage/SMS chat; relaymux should reply from the background LaunchAgent.\n");
+        io.stdout.write("  1. Text the configured iMessage/SMS chat; relaymux should reply from the background service.\n");
       } else {
-        io.stdout.write("  1. Run `relaymux restart-launch-agent` when you are ready to receive iMessage/SMS requests in the background.\n");
+        io.stdout.write("  1. Run `relaymux restart-launch-agent` when you are ready to receive iMessage/SMS requests in the background service.\n");
       }
     } else if (isIntegrationEnabled(configInfo.config, "telegram")) {
       if (shouldInstallLaunchAgent) {
@@ -189,7 +192,7 @@ async function handleSetup(flags, io) {
   return status;
 }
 
-async function handleInit(flags, io) {
+async function handleInit(flags, io, platform = process.platform) {
   const wantsImsg = Boolean(flags.imsg || flags.preset === "imsg");
   const wantsTelegram = Boolean(flags.telegram || flags.preset === "telegram");
   const wantsAdapter = wantsImsg || wantsTelegram;
@@ -247,7 +250,7 @@ async function handleInit(flags, io) {
   io.stdout.write(`${updatedExisting ? "Updated" : "Created"} ${target}${labels.length ? ` with ${labels.join(" and ")} defaults` : " with core defaults"}\n`);
   io.stdout.write(`relaymux home: ${homeDir} (state ${resolveStateDir(config, io.env)}, logs ${resolveLogDir(config, io.env)})\n`);
   if (labels.length) {
-    io.stdout.write("Next: relaymux restart-launch-agent\n");
+    io.stdout.write("Next: relaymux restart-launch-agent (starts the background service)\n");
     io.stdout.write("Then: relaymux status-launch-agent && relaymux status\n");
   } else {
     io.stdout.write("Tip: add optional adapters later with `relaymux init --imsg` or `relaymux init --telegram`.\n");
@@ -258,9 +261,27 @@ async function handleInit(flags, io) {
       configInfo: { config, path: target, exists: true },
       binPath: process.argv[1],
       io,
+      platform,
     });
   }
   return 0;
+}
+
+function backgroundServiceDryRunName(platform) {
+  if (platform === "darwin") return "macOS LaunchAgent and watchdog";
+  if (platform === "linux") return "Linux systemd user service";
+  return `background service if supported on ${platform}`;
+}
+
+function backgroundServiceStatusName(status, platform) {
+  if (status.serviceManager === "systemd") return "Linux systemd user service";
+  if (status.serviceManager === "launchd" || platform === "darwin") return "macOS LaunchAgent";
+  return "background service";
+}
+
+function backgroundServiceNeedsSetupFailure(status) {
+  if (status.serviceManager === "unsupported") return false;
+  return !status.loaded;
 }
 
 function cloneConfig(config) {
@@ -460,7 +481,7 @@ async function handleAsk(flags, positionals, configInfo, io) {
 
 function handleStartTmux(flags, configInfo, stateDir, io) {
   if (!flags.allowTmuxDaemon) {
-    throw new Error("start-tmux daemon mode is retired: the relaymux background service must run as a direct LaunchAgent outside tmux. Use `relaymux restart-launch-agent` for the background service and `relaymux launch` for agent tmux tabs.");
+    throw new Error("start-tmux daemon mode is retired: the relaymux background service must run directly outside tmux (LaunchAgent on macOS, systemd user service on Linux). Use `relaymux restart-launch-agent` for the background service and `relaymux launch` for agent tmux tabs.");
   }
   if (!flags.session) {
     throw new Error("Missing --session <name> for start-tmux");
@@ -493,7 +514,7 @@ function handleStartTmux(flags, configInfo, stateDir, io) {
     io.stdout.write(`# session: ${session}\n`);
     io.stdout.write(`# window: ${windowName}\n`);
     io.stdout.write(`# cwd: ${cwd}\n`);
-    io.stdout.write("# leaving configured LaunchAgent/background service alone\n");
+    io.stdout.write("# leaving configured background service alone\n");
     if (flags.restart !== false) {
       io.stdout.write(`# would replace existing tmux window ${session}:${windowName} if present\n`);
     }
@@ -578,7 +599,7 @@ function handleStartTmux(flags, configInfo, stateDir, io) {
 
 async function handleSuperviseTmux(flags, configInfo, stateDir, io) {
   if (!flags.allowTmuxDaemon) {
-    throw new Error("supervise-tmux daemon mode is retired: the relaymux background service must run direct outside tmux.");
+    throw new Error("supervise-tmux daemon mode is retired: the relaymux background service must run directly outside tmux.");
   }
   const config = configInfo.config;
   const session = String(flags.session || io.env.RELAYMUX_SESSION || config.session || "agents");
@@ -732,7 +753,7 @@ function normalizePositiveInteger(value, fallback) {
   return Math.floor(number);
 }
 
-function handleStatus(flags, configInfo, stateDir, io) {
+function handleStatus(flags, configInfo, stateDir, io, platform = process.platform) {
   const config = configInfo.config;
   const session = flags.session ? String(flags.session) : undefined;
   const windows = listAgentWindows({ session });
@@ -756,7 +777,7 @@ function handleStatus(flags, configInfo, stateDir, io) {
   }
 
   rows.sort((a, b) => String(b.started).localeCompare(String(a.started)));
-  const daemon = daemonStatus(config, configInfo.path, io.env);
+  const daemon = daemonStatus(config, configInfo.path, io.env, platform);
 
   if (flags.json) {
     io.stdout.write(`${JSON.stringify({ daemon, runs: rows }, null, 2)}\n`);
@@ -764,18 +785,10 @@ function handleStatus(flags, configInfo, stateDir, io) {
   }
 
   const launchAgent: any = daemon.launchAgent;
-  const launchAgentText = launchAgent.supported
-    ? launchAgent.loaded
-      ? `LaunchAgent ${launchAgent.label} loaded${launchAgent.running ? ` pid=${launchAgent.pid}` : ""}`
-      : `LaunchAgent ${launchAgent.label} not loaded`
-    : `LaunchAgent unsupported on ${process.platform}`;
+  const launchAgentText = formatBackgroundServiceSummary(launchAgent, platform);
   io.stdout.write(`Home: ${daemon.homeDir}; config ${daemon.configPath}; state ${daemon.stateDir}; logs ${daemon.logDir}\n`);
   const watchdog: any = daemon.launchAgentWatchdog;
-  const watchdogText = watchdog?.enabled
-    ? watchdog.loaded
-      ? `watchdog ${watchdog.label} loaded every ${watchdog.intervalSeconds}s`
-      : `watchdog ${watchdog.label} not loaded`
-    : "watchdog disabled";
+  const watchdogText = formatBackgroundWatchdogSummary(watchdog, platform);
   io.stdout.write(`Background service: ${daemon.enabled ? "enabled" : "disabled"}; mode ${daemon.launchMode}/background (no tmux); ${launchAgentText}; ${watchdogText}; webhook ${daemon.webhook.endpoints.message}; token ${daemon.webhook.tokenFileExists ? daemon.webhook.tokenFileMode : "missing"}\n`);
   io.stdout.write(`Agent tmux: session mode ${daemon.agentSessionMode}; ${session ? `filter session ${session}` : "showing all relaymux-managed sessions"}; tabs are tmux windows, never panes/splits.\n`);
 
@@ -788,7 +801,34 @@ function handleStatus(flags, configInfo, stateDir, io) {
   return 0;
 }
 
-function daemonStatus(config, configPath, env = process.env) {
+function formatBackgroundServiceSummary(status, platform) {
+  if (status.serviceManager === "systemd") {
+    if (!status.supported) return `systemd user service ${status.serviceName} unavailable`;
+    return status.loaded
+      ? `systemd user service ${status.serviceName} active${status.running && status.pid ? ` pid=${status.pid}` : ""}`
+      : `systemd user service ${status.serviceName} not active`;
+  }
+  if (status.serviceManager === "launchd" || platform === "darwin") {
+    return status.supported
+      ? status.loaded
+        ? `LaunchAgent ${status.label} loaded${status.running ? ` pid=${status.pid}` : ""}`
+        : `LaunchAgent ${status.label} not loaded`
+      : `LaunchAgent unsupported on ${platform}`;
+  }
+  return `background service unsupported on ${platform}`;
+}
+
+function formatBackgroundWatchdogSummary(watchdog, platform) {
+  if (platform === "linux") return "restart policy systemd Restart=always";
+  if (watchdog?.enabled) {
+    return watchdog.loaded
+      ? `watchdog ${watchdog.label} loaded every ${watchdog.intervalSeconds}s`
+      : `watchdog ${watchdog.label} not loaded`;
+  }
+  return "watchdog disabled";
+}
+
+function daemonStatus(config, configPath, env = process.env, platform = process.platform) {
   const agentSessionMode = resolveTmuxSessionMode({ config });
   return {
     enabled: config.daemon?.enabled !== false,
@@ -800,9 +840,10 @@ function daemonStatus(config, configPath, env = process.env) {
     agentSessionMode,
     featureSessionMode: agentSessionMode,
     webhook: webhookStatus(config),
-    launchAgentPath: launchAgentPath(config),
-    launchAgent: getLaunchAgentStatus(config),
-    launchAgentWatchdog: getLaunchAgentWatchdogStatus(config),
+    backgroundServicePath: backgroundServicePath(config, { platform, env }),
+    launchAgentPath: backgroundServicePath(config, { platform, env }),
+    launchAgent: getLaunchAgentStatus(config, { platform, env }),
+    launchAgentWatchdog: getLaunchAgentWatchdogStatus(config, { platform, env }),
   };
 }
 
@@ -840,8 +881,8 @@ function targetTab(target) {
   return tab.replace(/\.\d+$/, "");
 }
 
-function handleDoctor(configInfo, io) {
-  const checks = collectDoctorChecks(configInfo.config, configInfo, io.env);
+function handleDoctor(configInfo, io, platform = process.platform) {
+  const checks = collectDoctorChecks(configInfo.config, configInfo, io.env, { platform });
   for (const check of checks) {
     io.stdout.write(`${doctorStatusLabel(check)}\t${check.name}\t${check.detail}\n`);
   }
@@ -978,6 +1019,7 @@ function formatTable(rows, columns) {
 function defaultIo() {
   return {
     env: process.env,
+    platform: process.platform,
     stdin: process.stdin,
     stdout: process.stdout,
     stderr: process.stderr,
@@ -988,7 +1030,7 @@ function helpText() {
   return `relaymux - coordinate local CLI agents in tmux with optional notification adapters
 
 Mental model:
-  - The background daemon/local API runs as a direct macOS LaunchAgent outside tmux when installed.
+  - The background daemon/local API runs directly outside tmux (LaunchAgent on macOS, systemd user service on Linux) when installed.
   - By default, all agents open as tmux tabs/windows in one shared session.
   - Managed config/state/logs/prompts/scratch live under ~/.relaymux by default.
   - Use --session only when you explicitly want a separate/new/named tmux session; panes/splits are never used.
@@ -1026,8 +1068,8 @@ Setup/init options:
   --telegram-timeout-ms <ms>        Telegram sendMessage timeout (default 30000)
   --cwd <path>              Working directory for Pi and message commands
   --state-dir <path>        State/token/log directory
-  --install-launch-agent    Install the direct/background LaunchAgent after writing config
-  --no-launch-agent         For setup: skip LaunchAgent installation
+  --install-launch-agent    Install the direct/background service after writing config (LaunchAgent on macOS, systemd on Linux)
+  --no-launch-agent         For setup: skip background service installation
   --dry-run                 For setup: print planned config/service changes without writing files
 
 Migration options:
@@ -1055,8 +1097,8 @@ Launch options:
   --notify-tail-bytes <n>    Max bytes of recent tmux output in nonzero auto notifications
 
 Background service options:
-  --no-load                  Write the LaunchAgent plist without loading it
-  --no-watchdog              Skip installing the periodic LaunchAgent health watchdog
+  --no-load                  Write the service file without loading/starting it
+  --no-watchdog              On macOS, skip installing the periodic LaunchAgent health watchdog
   --keep-tmux-daemon         During migration, do not stop an old relaymux-daemon tmux tab
 
 Request/notify/status options:

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { defaultConfigPath, getIntegration, isIntegrationEnabled, legacyDefaultConfigPath, resolveLogDir, resolveStateDir } from "./config.js";
 import { validateConfiguredAgentCommand } from "./command-validation.js";
 import { runCommand } from "./process.js";
-import { getLaunchAgentStatus, getLaunchAgentWatchdogStatus, launchAgentPath, launchAgentWatchdogPath } from "./launch-agent.js";
+import { backgroundServicePath, getLaunchAgentStatus, getLaunchAgentWatchdogStatus, launchAgentPath, launchAgentWatchdogPath } from "./launch-agent.js";
 import { defaultRelaymuxHome } from "./paths.js";
 import { webhookStatus } from "./webhook.js";
 
@@ -38,7 +38,8 @@ export function findExecutable(command, env = process.env) {
   return null;
 }
 
-export function collectDoctorChecks(config, configInfo, env = process.env) {
+export function collectDoctorChecks(config, configInfo, env = process.env, options: any = {}) {
+  const platform = options.platform || process.platform;
   const checks = [];
   const tmuxPath = findExecutable("tmux", env);
   let tmuxVersion = "";
@@ -113,32 +114,36 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
     ok: !webhook.tokenFileExists || webhook.tokenFileMode === "0600",
     detail: webhook.tokenFileExists ? `${webhook.tokenFile} mode ${webhook.tokenFileMode}` : `will be created at ${webhook.tokenFile}`,
   });
-  const launchAgent: any = getLaunchAgentStatus(config);
+  const launchAgent: any = getLaunchAgentStatus(config, { platform, env });
   const daemonEnabled = config.daemon?.enabled !== false;
   const logDir = resolveLogDir(config, env);
+  const backgroundOk = !daemonEnabled || launchAgent.loaded || launchAgent.serviceManager === "unsupported";
   checks.push({
     name: "background-service",
-    ok: !daemonEnabled || !launchAgent.supported || launchAgent.loaded,
+    ok: backgroundOk,
     fatal: false,
-    severity: launchAgent.loaded || !daemonEnabled ? undefined : "warning",
+    severity: backgroundOk ? undefined : "warning",
     detail: daemonEnabled
-      ? launchAgent.supported
-        ? launchAgent.loaded
-          ? `direct/background LaunchAgent loaded: ${launchAgentPath(config)}${launchAgent.detail ? ` (${launchAgent.detail})` : ""}`
-          : `direct/background LaunchAgent not loaded: ${launchAgentPath(config)}${launchAgent.detail ? ` (launchctl: ${launchAgent.detail})` : ""}; run relaymux restart-launch-agent; logs ${logDir}/daemon.out.log and ${logDir}/daemon.err.log; inspect launchctl print ${launchAgent.target}`
-        : `direct/background LaunchAgent unsupported on ${process.platform}: ${launchAgentPath(config)}`
+      ? formatBackgroundServiceDoctorDetail({ config, status: launchAgent, logDir, platform, env })
       : "disabled in config",
   });
 
-  const watchdog: any = getLaunchAgentWatchdogStatus(config);
-  if (daemonEnabled && watchdog.enabled) {
+  const watchdog: any = getLaunchAgentWatchdogStatus(config, { platform, env });
+  if (daemonEnabled && platform === "darwin" && watchdog.enabled) {
     checks.push({
       name: "background-watchdog",
       ok: !watchdog.supported || watchdog.loaded,
       fatal: false,
       detail: watchdog.supported
         ? `watchdog LaunchAgent ${watchdog.loaded ? "loaded" : "not loaded"}: ${launchAgentWatchdogPath(config)}; interval ${watchdog.intervalSeconds}s`
-        : `watchdog LaunchAgent unsupported on ${process.platform}: ${launchAgentWatchdogPath(config)}`,
+        : `watchdog LaunchAgent unsupported on ${platform}: ${launchAgentWatchdogPath(config)}`,
+    });
+  } else if (daemonEnabled && platform === "linux") {
+    checks.push({
+      name: "background-restart-policy",
+      ok: true,
+      fatal: false,
+      detail: "Linux systemd user service uses Restart=always; no separate watchdog unit is installed.",
     });
   }
 
@@ -173,6 +178,28 @@ export function collectDoctorChecks(config, configInfo, env = process.env) {
   }
 
   return checks;
+}
+
+function formatBackgroundServiceDoctorDetail({ config, status, logDir, platform, env }) {
+  if (status.serviceManager === "systemd") {
+    if (!status.supported) {
+      return `systemd user services unavailable for ${status.serviceName}: ${status.detail}; unit ${status.unitPath}; run relaymux daemon manually or enable systemd --user, then run relaymux restart-launch-agent`;
+    }
+    if (status.loaded) {
+      return `systemd user service active: ${status.unitPath}${status.detail ? ` (${status.detail})` : ""}`;
+    }
+    return `systemd user service not active: ${status.unitPath}${status.detail ? ` (${status.detail})` : ""}; run relaymux restart-launch-agent; logs ${logDir}/daemon.out.log and ${logDir}/daemon.err.log; inspect systemctl --user status ${status.serviceName}; journalctl --user -u ${status.serviceName} -e`;
+  }
+
+  if (status.serviceManager === "launchd" || platform === "darwin") {
+    return status.supported
+      ? status.loaded
+        ? `direct/background LaunchAgent loaded: ${launchAgentPath(config)}${status.detail ? ` (${status.detail})` : ""}`
+        : `direct/background LaunchAgent not loaded: ${launchAgentPath(config)}${status.detail ? ` (launchctl: ${status.detail})` : ""}; run relaymux restart-launch-agent; logs ${logDir}/daemon.out.log and ${logDir}/daemon.err.log; inspect launchctl print ${status.target}`
+      : `direct/background LaunchAgent unsupported on ${platform}: ${launchAgentPath(config)}`;
+  }
+
+  return `background service unsupported on ${platform}: ${backgroundServicePath(config, { platform, env })}; run relaymux daemon manually or use an external service manager`;
 }
 
 function commandCheck(name, command, env) {

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -26,6 +26,25 @@ export function launchAgentWatchdogLabel(config) {
   return `${launchAgentLabel(config)}.watchdog`;
 }
 
+export function backgroundServicePath(config, { platform = process.platform, env = process.env }: any = {}) {
+  return platform === "linux" ? systemdUserUnitPath(config, env) : launchAgentPath(config);
+}
+
+export function systemdServiceName(config) {
+  const configured = config.daemon?.systemdServiceName || config.daemon?.systemdUnitName || launchAgentLabel(config);
+  const raw = String(configured || "relaymux-daemon").trim();
+  const withoutSuffix = raw.endsWith(".service") ? raw.slice(0, -".service".length) : raw;
+  const safe = withoutSuffix
+    .replace(/[^A-Za-z0-9:_.@-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "relaymux-daemon";
+  return `${safe}.service`;
+}
+
+export function systemdUserUnitPath(config, env = process.env) {
+  const configHome = env.XDG_CONFIG_HOME ? expandPath(env.XDG_CONFIG_HOME) : path.join(os.homedir(), ".config");
+  return path.join(configHome, "systemd", "user", systemdServiceName(config));
+}
+
 export function renderLaunchAgentPlist({
   label,
   programArguments,
@@ -67,9 +86,45 @@ ${args}
 `;
 }
 
-export function installLaunchAgent({ flags, configInfo, binPath, io }) {
+export function renderSystemdUserServiceUnit({
+  serviceName,
+  programArguments,
+  workingDirectory,
+  standardOutPath,
+  standardErrorPath,
+  environment = {},
+  restartSec = 5,
+}) {
+  const env = renderSystemdEnvironment(environment);
+  return `[Unit]
+Description=relaymux background daemon
+Documentation=https://github.com/avyayv/relaymux
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${systemdUnitValue(workingDirectory)}
+ExecStart=${programArguments.map(systemdUnitValue).join(" ")}
+Restart=always
+RestartSec=${Math.max(1, Math.floor(Number(restartSec) || 5))}
+${env}StandardOutput=${systemdUnitValue(`append:${standardOutPath}`)}
+StandardError=${systemdUnitValue(`append:${standardErrorPath}`)}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function installLaunchAgent({ flags, configInfo, binPath, io, platform = process.platform }) {
   if (!configInfo.exists) {
     throw new Error(`Config does not exist at ${configInfo.path}. Run relaymux init first.`);
+  }
+
+  if (platform === "linux") {
+    return installSystemdUserService({ flags, configInfo, binPath, io, env: io.env || process.env });
+  }
+  if (platform !== "darwin") {
+    throw new Error(`Background service installation is not supported on ${platform}. Run \`relaymux daemon\` manually or use an external service manager.`);
   }
 
   const config = configInfo.config;
@@ -111,6 +166,7 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
       binPath,
       io,
       load: flags.load !== false,
+      platform,
     });
   }
 
@@ -151,8 +207,66 @@ export function installLaunchAgent({ flags, configInfo, binPath, io }) {
   return plistPath;
 }
 
-export function installLaunchAgentWatchdog({ config, configPath, binPath, io, load = true }) {
-  if (process.platform !== "darwin") {
+function installSystemdUserService({ flags, configInfo, binPath, io, env = process.env }) {
+  const config = configInfo.config;
+  const serviceName = systemdServiceName(config);
+  const unitPath = systemdUserUnitPath(config, env);
+  const logDir = resolveLogDir(config, env);
+  const workingDirectory = expandPath(config.orchestrator?.cwd || "~");
+  const launchMode = resolveLaunchMode(flags, config);
+  if ((config.daemon?.launchMode === "tmux" || config.daemon?.launchMode === "supervised-tmux") && !flags.mode && !flags.launchMode) {
+    io.stderr.write("relaymux: daemon.launchMode=tmux is deprecated; installing direct/background systemd user service instead.\n");
+  }
+  const programArguments = buildDirectDaemonArgs({ binPath, configPath: configInfo.path });
+  const logPrefix = "daemon";
+  const stdoutLog = path.join(logDir, `${logPrefix}.out.log`);
+  const stderrLog = path.join(logDir, `${logPrefix}.err.log`);
+  const unit = renderSystemdUserServiceUnit({
+    serviceName,
+    programArguments,
+    workingDirectory,
+    environment: launchAgentEnvironment(config, configInfo.path),
+    standardOutPath: stdoutLog,
+    standardErrorPath: stderrLog,
+    restartSec: config.daemon?.systemdRestartSec || config.daemon?.restartSec || 5,
+  });
+
+  if (flags.dryRun) {
+    io.stdout.write(unit);
+    return unitPath;
+  }
+
+  ensureDirectory(path.dirname(unitPath));
+  ensureDirectory(logDir);
+  fs.writeFileSync(unitPath, unit, { mode: 0o644 });
+  io.stdout.write(`Wrote ${unitPath}\n`);
+  io.stdout.write(`Background service ${serviceName} mode: ${launchMode}/background systemd user service (no tmux)\n`);
+
+  if (flags.watchdog !== false) {
+    io.stdout.write("Linux uses systemd Restart=always for daemon recovery; no separate watchdog unit is installed.\n");
+  }
+
+  if (flags.load !== false) {
+    const result = loadSystemdUserService({ serviceName });
+    if (result.status !== 0) {
+      io.stderr.write(formatSystemdServiceLoadFailure({
+        serviceName,
+        result,
+        unitPath,
+        logDir,
+        stdoutLog,
+        stderrLog,
+      }));
+    } else {
+      io.stdout.write(`Enabled and started systemd user service ${serviceName}\n`);
+    }
+  }
+
+  return unitPath;
+}
+
+export function installLaunchAgentWatchdog({ config, configPath, binPath, io, load = true, platform = process.platform }) {
+  if (platform !== "darwin") {
     return null;
   }
 
@@ -214,8 +328,18 @@ export function renderLaunchAgentWatchdogPlist({ config, configPath, scriptPath 
   });
 }
 
-export function stopLaunchAgent({ config, io }) {
-  if (process.platform !== "darwin") {
+export function stopLaunchAgent({ config, io, platform = process.platform }) {
+  if (platform === "linux") {
+    const serviceName = systemdServiceName(config);
+    const result = runCommand("systemctl", ["--user", "stop", serviceName], { allowFailure: true });
+    if (result.status === 0) {
+      io.stdout.write(`Stopped systemd user service ${serviceName}\n`);
+      return true;
+    }
+    return false;
+  }
+
+  if (platform !== "darwin") {
     return false;
   }
 
@@ -228,28 +352,33 @@ export function stopLaunchAgent({ config, io }) {
   return false;
 }
 
-export function restartLaunchAgent({ flags, configInfo, binPath, io }) {
+export function restartLaunchAgent({ flags, configInfo, binPath, io, platform = process.platform }) {
   const plistPath = installLaunchAgent({
     flags: { ...flags, load: true },
     configInfo,
     binPath,
     io,
+    platform,
   });
-  printLaunchAgentStatus({ config: configInfo.config, io });
+  printLaunchAgentStatus({ config: configInfo.config, io, platform });
   return plistPath;
 }
 
-export function printLaunchAgentStatus({ config, io, json = false }) {
-  const status: any = getLaunchAgentStatus(config);
-  const watchdog: any = getLaunchAgentWatchdogStatus(config);
+export function printLaunchAgentStatus({ config, io, json = false, platform = process.platform }) {
+  const status: any = getLaunchAgentStatus(config, { platform, env: io.env || process.env });
+  const watchdog: any = getLaunchAgentWatchdogStatus(config, { platform, env: io.env || process.env });
   if (json) {
     const payload = { ...status, watchdog };
     io.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
     return payload;
   }
 
+  if (status.serviceManager === "systemd") {
+    return printSystemdServiceStatus({ status, config, io });
+  }
+
   if (!status.supported) {
-    io.stdout.write(`LaunchAgent ${status.label}: direct/background (no tmux) unsupported on ${process.platform}; plist ${status.plistPath}\n`);
+    io.stdout.write(`Background service ${status.label}: direct/background (no tmux) unsupported on ${platform}; path ${status.plistPath}\n`);
     return status;
   }
 
@@ -274,20 +403,87 @@ export function printLaunchAgentStatus({ config, io, json = false }) {
   return status;
 }
 
-export function getLaunchAgentStatus(config) {
+function printSystemdServiceStatus({ status, config, io }) {
+  const logDir = resolveLogDir(config, io.env || process.env);
+  if (!status.supported) {
+    io.stdout.write(`Background service ${status.serviceName}: systemd user services unavailable; unit ${status.unitPath}\n`);
+    if (status.detail) io.stdout.write(`Detail: ${status.detail}\n`);
+    io.stdout.write(`Logs: ${path.join(logDir, "daemon.out.log")} and ${path.join(logDir, "daemon.err.log")}\n`);
+    io.stdout.write(`Inspect: systemctl --user status ${status.serviceName}\n`);
+    io.stdout.write(`Journal: journalctl --user -u ${status.serviceName} -e\n`);
+    io.stdout.write("Fallback: run `relaymux daemon` in a foreground shell, or enable systemd user services and run `relaymux restart-launch-agent`.\n");
+    return status;
+  }
+
+  if (!status.loaded) {
+    io.stdout.write(`Background service ${status.serviceName}: systemd user service not active; unit ${status.unitExists ? status.unitPath : "missing"}\n`);
+    if (status.detail) io.stdout.write(`Detail: ${status.detail}\n`);
+    io.stdout.write(`Logs: ${path.join(logDir, "daemon.out.log")} and ${path.join(logDir, "daemon.err.log")}\n`);
+    io.stdout.write(`Inspect: systemctl --user status ${status.serviceName}\n`);
+    io.stdout.write(`Journal: journalctl --user -u ${status.serviceName} -e\n`);
+    io.stdout.write("Next: relaymux restart-launch-agent (writes and restarts the Linux systemd user service)\n");
+    return status;
+  }
+
+  const pidText = status.pid ? ` pid=${status.pid}` : "";
+  const exitText = status.lastExitCode ? ` lastExit=${status.lastExitCode}` : "";
+  const stateText = [status.activeState, status.subState].filter(Boolean).join("/") || status.state || "unknown";
+  io.stdout.write(`Background service ${status.serviceName}: systemd user service active state=${stateText}${pidText}${exitText}; unit ${status.unitPath}\n`);
+  io.stdout.write("Restart policy: systemd Restart=always (no separate watchdog unit on Linux)\n");
+  return status;
+}
+
+export function getLaunchAgentStatus(config, { platform = process.platform, env = process.env }: any = {}) {
+  if (platform === "linux") {
+    return getSystemdUserServiceStatus(config, env);
+  }
+  if (platform !== "darwin") {
+    return unsupportedBackgroundServiceStatus(config, platform, env);
+  }
   return getLaunchAgentStatusFor({
     label: launchAgentLabel(config),
     plistPath: launchAgentPath(config),
     target: launchAgentTarget(config),
+    platform,
   });
 }
 
-export function getLaunchAgentWatchdogStatus(config) {
+export function getLaunchAgentWatchdogStatus(config, { platform = process.platform }: any = {}) {
+  if (platform === "linux") {
+    return {
+      label: "systemd Restart=always",
+      enabled: false,
+      supported: true,
+      loaded: false,
+      running: false,
+      state: "managed-by-systemd",
+      serviceManager: "systemd",
+      detail: "Linux systemd user service units use Restart=always; no separate watchdog unit is installed.",
+      intervalSeconds: 0,
+      plistPath: "",
+      scriptPath: "",
+    };
+  }
+  if (platform !== "darwin") {
+    return {
+      label: launchAgentWatchdogLabel(config),
+      enabled: false,
+      supported: false,
+      loaded: false,
+      running: false,
+      state: "unsupported",
+      serviceManager: "unsupported",
+      intervalSeconds: 0,
+      plistPath: launchAgentWatchdogPath(config),
+      scriptPath: launchAgentWatchdogScriptPath(config),
+    };
+  }
   return {
     ...getLaunchAgentStatusFor({
       label: launchAgentWatchdogLabel(config),
       plistPath: launchAgentWatchdogPath(config),
       target: launchAgentWatchdogTarget(config),
+      platform,
     }),
     enabled: shouldInstallWatchdog(config, {}),
     intervalSeconds: launchAgentWatchdogIntervalSeconds(config),
@@ -309,9 +505,111 @@ export function formatLaunchAgentLoadFailure({ label, result, domain, target, pl
   ].join("\n");
 }
 
-function getLaunchAgentStatusFor({ label, plistPath, target }) {
+export function formatSystemdServiceLoadFailure({ serviceName, result, unitPath, logDir, stdoutLog, stderrLog }) {
+  const detail = systemdFailureDetail(result);
+  return [
+    `relaymux: systemctl --user failed for ${serviceName} (status ${result.status}: ${detail})`,
+    `  unit: ${unitPath}`,
+    `  logs: ${stdoutLog || path.join(logDir, "daemon.out.log")} and ${stderrLog || path.join(logDir, "daemon.err.log")}`,
+    `  inspect: systemctl --user status ${serviceName}`,
+    `  journal: journalctl --user -u ${serviceName} -e`,
+    "  common causes: systemd user services unavailable, missing executable path, bad WorkingDirectory, or file permission problems",
+    "  next: run relaymux status-launch-agent; after fixing the issue, run relaymux restart-launch-agent",
+    "  fallback: run relaymux daemon in a foreground shell when systemd --user is unavailable",
+    "",
+  ].join("\n");
+}
+
+function getSystemdUserServiceStatus(config, env = process.env) {
+  const serviceName = systemdServiceName(config);
+  const unitPath = systemdUserUnitPath(config, env);
+  const unitExists = fs.existsSync(unitPath);
+  const base = {
+    label: launchAgentLabel(config),
+    serviceName,
+    unitPath,
+    plistPath: unitPath,
+    unitExists,
+    plistExists: unitExists,
+    target: serviceName,
+    supported: true,
+    serviceManager: "systemd",
+    mode: "direct",
+    background: true,
+  };
+
+  const result = runCommand("systemctl", ["--user", "show", serviceName, "--no-page"], { allowFailure: true });
+  if (result.status !== 0) {
+    const unavailable = isSystemdUserUnavailable(result);
+    return {
+      ...base,
+      supported: !unavailable,
+      loaded: false,
+      running: false,
+      state: unavailable ? "unavailable" : "not-active",
+      detail: systemdFailureDetail(result),
+    };
+  }
+
+  const parsed = parseSystemctlShow(result.stdout);
+  const active = parsed.activeState === "active";
+  const detail = parsed.loadState === "not-found"
+    ? "unit not found by systemd; run relaymux restart-launch-agent"
+    : parsed.result && parsed.result !== "success"
+      ? `last result: ${parsed.result}`
+      : "";
+  return {
+    ...base,
+    loaded: active,
+    running: active,
+    state: parsed.activeState || parsed.loadState || "unknown",
+    detail,
+    ...parsed,
+  };
+}
+
+export function parseSystemctlShow(output) {
+  const properties: Record<string, string> = {};
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const index = line.indexOf("=");
+    if (index <= 0) continue;
+    properties[line.slice(0, index)] = line.slice(index + 1);
+  }
+  const pid = Number(properties.MainPID || 0);
+  const execStatus = properties.ExecMainStatus || "";
+  return {
+    loadState: properties.LoadState || "",
+    activeState: properties.ActiveState || "",
+    subState: properties.SubState || "",
+    unitFileState: properties.UnitFileState || "",
+    fragmentPath: properties.FragmentPath || "",
+    result: properties.Result || "",
+    pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+    lastExitCode: execStatus && execStatus !== "0" ? execStatus : "",
+  };
+}
+
+function unsupportedBackgroundServiceStatus(config, platform, env = process.env) {
+  const servicePath = backgroundServicePath(config, { platform, env });
+  return {
+    label: launchAgentLabel(config),
+    plistPath: servicePath,
+    plistExists: fs.existsSync(servicePath),
+    target: "",
+    supported: false,
+    serviceManager: "unsupported",
+    mode: "direct",
+    background: true,
+    loaded: false,
+    running: false,
+    state: "unsupported",
+    detail: `No relaymux background service manager is implemented for ${platform}. Run relaymux daemon manually or use an external service manager.`,
+  };
+}
+
+function getLaunchAgentStatusFor({ label, plistPath, target, platform = process.platform }) {
   const plistExists = fs.existsSync(plistPath);
-  const base = { label, plistPath, plistExists, target, supported: process.platform === "darwin", mode: "direct", background: true };
+  const base = { label, plistPath, plistExists, target, supported: platform === "darwin", serviceManager: "launchd", mode: "direct", background: true };
   if (!base.supported) {
     return { ...base, loaded: false, running: false, state: "unsupported" };
   }
@@ -336,7 +634,16 @@ function getLaunchAgentStatusFor({ label, plistPath, target }) {
   };
 }
 
-export function uninstallLaunchAgent({ config, io }) {
+export function uninstallLaunchAgent({ config, io, platform = process.platform }) {
+  if (platform === "linux") {
+    return uninstallSystemdUserService({ config, io, env: io.env || process.env });
+  }
+  if (platform !== "darwin") {
+    const servicePath = backgroundServicePath(config, { platform, env: io.env || process.env });
+    io.stdout.write(`No supported relaymux background service manager on ${platform}; nothing installed by relaymux at ${servicePath}\n`);
+    return servicePath;
+  }
+
   const watchdogPlistPath = launchAgentWatchdogPath(config);
   if (fs.existsSync(watchdogPlistPath)) {
     runCommand("launchctl", ["bootout", launchAgentWatchdogTarget(config)], { allowFailure: true });
@@ -359,6 +666,28 @@ export function uninstallLaunchAgent({ config, io }) {
     io.stdout.write(`No LaunchAgent found at ${plistPath}\n`);
   }
   return plistPath;
+}
+
+function uninstallSystemdUserService({ config, io, env = process.env }) {
+  const serviceName = systemdServiceName(config);
+  const unitPath = systemdUserUnitPath(config, env);
+  const stop = runCommand("systemctl", ["--user", "disable", "--now", serviceName], { allowFailure: true });
+  if (stop.status !== 0 && !isSystemdUserUnavailable(stop)) {
+    io.stderr.write(`relaymux: systemctl --user disable --now ${serviceName} failed: ${systemdFailureDetail(stop)}\n`);
+  }
+
+  if (fs.existsSync(unitPath)) {
+    fs.unlinkSync(unitPath);
+    io.stdout.write(`Removed ${unitPath}\n`);
+  } else {
+    io.stdout.write(`No systemd user unit found at ${unitPath}\n`);
+  }
+
+  const reload = runCommand("systemctl", ["--user", "daemon-reload"], { allowFailure: true });
+  if (reload.status !== 0 && !isSystemdUserUnavailable(reload)) {
+    io.stderr.write(`relaymux: systemctl --user daemon-reload failed: ${systemdFailureDetail(reload)}\n`);
+  }
+  return unitPath;
 }
 
 export function isCurrentLaunchAgent(config, env = process.env) {
@@ -501,8 +830,18 @@ function loadLaunchAgentTarget({ target, domain, plistPath }) {
   return result;
 }
 
+function loadSystemdUserService({ serviceName }) {
+  const reload = runCommand("systemctl", ["--user", "daemon-reload"], { allowFailure: true });
+  if (reload.status !== 0) return reload;
+
+  const enable = runCommand("systemctl", ["--user", "enable", serviceName], { allowFailure: true });
+  if (enable.status !== 0) return enable;
+
+  return runCommand("systemctl", ["--user", "restart", serviceName], { allowFailure: true });
+}
+
 export function stableNodePath() {
-  for (const candidate of ["/opt/homebrew/bin/node", "/usr/local/bin/node", process.execPath]) {
+  for (const candidate of ["/opt/homebrew/bin/node", "/usr/local/bin/node", process.execPath, "/usr/bin/node"]) {
     try {
       fs.accessSync(candidate, fs.constants.X_OK);
       return candidate;
@@ -529,7 +868,7 @@ function resolveLaunchMode(flags, config) {
   const rawMode = String(explicitMode || config.daemon?.launchMode || "direct");
   const mode = rawMode === "background" ? "direct" : rawMode;
   if (explicitMode && !["direct", "background"].includes(String(explicitMode))) {
-    throw new Error("LaunchAgent tmux mode has been removed. The relaymux background service must run direct; use start-tmux only for legacy manual debugging.");
+    throw new Error("Background service tmux mode has been removed. The relaymux daemon must run directly outside tmux; use start-tmux only for legacy manual debugging.");
   }
   if (["direct", "tmux", "supervised-tmux"].includes(mode)) {
     return "direct";
@@ -612,6 +951,15 @@ function renderEnvironment(environment) {
   return `\n  <key>EnvironmentVariables</key>\n  <dict>\n${body}\n  </dict>`;
 }
 
+function renderSystemdEnvironment(environment) {
+  const entries = Object.entries(environment || {})
+    .filter(([key, value]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(String(key)) && value !== undefined && value !== null);
+  if (!entries.length) return "";
+  return entries
+    .map(([key, value]) => `Environment=${systemdUnitValue(`${key}=${value}`)}`)
+    .join("\n") + "\n";
+}
+
 export function parseLaunchCtlPrint(output) {
   const pidMatch = /^\s*pid = (\d+)\s*$/m.exec(output);
   const stateMatch = /^\s*state = (.+?)\s*$/m.exec(output);
@@ -621,6 +969,37 @@ export function parseLaunchCtlPrint(output) {
     state: stateMatch ? stateMatch[1] : (pidMatch ? "running" : "loaded"),
     lastExitCode: lastExitMatch ? lastExitMatch[1] : "",
   };
+}
+
+function systemdUnitValue(value) {
+  const text = String(value ?? "")
+    .replaceAll("%", "%%")
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\n", "\\n");
+  if (/^[A-Za-z0-9_@%+=:,./\\-]+$/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '\\"')}"`;
+}
+
+function systemdFailureDetail(result) {
+  if (result?.error?.code === "ENOENT") {
+    return "systemctl not found on PATH; install/use systemd user services or run relaymux daemon manually";
+  }
+  const raw = firstLine(result?.stderr) || firstLine(result?.stdout) || result?.error?.message || `exit ${result?.status ?? 1}`;
+  if (isSystemdUserUnavailable(result)) {
+    return `${raw}; systemd --user is unavailable in this session. Use a normal systemd user login, ensure XDG_RUNTIME_DIR is set, consider 'loginctl enable-linger $USER' on headless servers, or run relaymux daemon manually.`;
+  }
+  return raw;
+}
+
+function isSystemdUserUnavailable(result) {
+  const text = `${result?.stderr || ""}\n${result?.stdout || ""}\n${result?.error?.message || ""}`.toLowerCase();
+  return result?.error?.code === "ENOENT"
+    || text.includes("failed to connect to bus")
+    || text.includes("no medium found")
+    || text.includes("no such file or directory") && text.includes("bus")
+    || text.includes("system has not been booted with systemd");
 }
 
 function firstLine(value) {

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -62,17 +62,17 @@ const CRON_FIELDS = [
   { name: "day of week", key: "Weekday", min: 0, max: 7, names: WEEKDAY_NAMES },
 ];
 
-export function handleSchedule({ flags, positionals, configInfo, stateDir, binPath, io }) {
+export function handleSchedule({ flags, positionals, configInfo, stateDir, binPath, io, platform = process.platform }) {
   const action = String(positionals[0] || "help");
 
   switch (action) {
     case "add":
-      return handleScheduleAdd({ flags, configInfo, stateDir, binPath, io });
+      return handleScheduleAdd({ flags, configInfo, stateDir, binPath, io, platform });
     case "list":
       return handleScheduleList({ flags, stateDir, io });
     case "remove":
     case "rm":
-      return handleScheduleRemove({ flags, positionals, configInfo, stateDir, io });
+      return handleScheduleRemove({ flags, positionals, configInfo, stateDir, io, platform });
     case "help":
       io.stdout.write(scheduleHelpText());
       return 0;
@@ -110,7 +110,7 @@ schedule fires.
 `;
 }
 
-function handleScheduleAdd({ flags, configInfo, stateDir, binPath, io }) {
+function handleScheduleAdd({ flags, configInfo, stateDir, binPath, io, platform = process.platform }) {
   if (!configInfo.exists) {
     throw new Error(`Config does not exist at ${configInfo.path}. Run relaymux setup first.`);
   }
@@ -126,6 +126,7 @@ function handleScheduleAdd({ flags, configInfo, stateDir, binPath, io }) {
     configPath: configInfo.path,
     stateDir,
     binPath,
+    platform,
   });
 
   if (flags.dryRun) {
@@ -150,7 +151,7 @@ function handleScheduleAdd({ flags, configInfo, stateDir, binPath, io }) {
 
   installSchedulePlan(plan, io);
   io.stdout.write(`Installed schedule ${plan.name} with ${plan.scheduler}\n`);
-  io.stdout.write("Requires the relaymux daemon to be running when the schedule fires; use `relaymux restart-launch-agent` if needed.\n");
+  io.stdout.write(`Requires the relaymux daemon to be running when the schedule fires; use \`relaymux restart-launch-agent\` if needed (${platform === "linux" ? "Linux systemd user service" : platform === "darwin" ? "macOS LaunchAgent" : "background service"}).\n`);
   return 0;
 }
 
@@ -170,10 +171,10 @@ function handleScheduleList({ flags, stateDir, io }) {
   return 0;
 }
 
-function handleScheduleRemove({ flags, positionals, configInfo, stateDir, io }) {
+function handleScheduleRemove({ flags, positionals, configInfo, stateDir, io, platform = process.platform }) {
   const name = normalizeScheduleName(flags.name || positionals[1]);
   const existing = readScheduleMetadata(scheduleMetadataPath(stateDir, name));
-  const scheduler = existing?.scheduler || resolveScheduleBackend(flags.scheduler);
+  const scheduler = existing?.scheduler || resolveScheduleBackend(flags.scheduler, platform);
   const label = existing?.label || (scheduler === "launchd" ? scheduleLaunchAgentLabel(configInfo.config, name) : "");
   const plistPath = existing?.plistPath || (label ? scheduleLaunchAgentPath(label) : "");
   const scheduleDir = scheduleDirectory(stateDir, name);
@@ -617,15 +618,19 @@ function readCrontab({ allowUnavailable }) {
   if (result.status === 0) {
     return { available: true, text: normalizeCrontabText(result.stdout) };
   }
-  const detail = `${result.stderr || ""}\n${result.stdout || ""}`.toLowerCase();
-  const hasNoCrontab = detail.includes("no crontab") || detail.includes("no crontab for");
+  const outputDetail = `${result.stderr || ""}\n${result.stdout || ""}`.toLowerCase();
+  const hasNoCrontab = outputDetail.includes("no crontab") || outputDetail.includes("no crontab for");
   if (hasNoCrontab) {
     return { available: true, text: "" };
   }
   if (allowUnavailable) {
     return { available: false, text: "" };
   }
-  throw new Error(`Could not read crontab: ${firstLine(result.stderr) || firstLine(result.stdout) || result.error?.message || `exit ${result.status}`}`);
+  const unavailable = result.error?.code === "ENOENT";
+  const detail = unavailable
+    ? "crontab command not found; install cron/cronie or use --dry-run to copy the generated entry manually"
+    : firstLine(result.stderr) || firstLine(result.stdout) || result.error?.message || `exit ${result.status}`;
+  throw new Error(`Could not read crontab: ${detail}`);
 }
 
 function replaceCronMarker(currentText, marker, cronLine) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 import { main } from "../src/cli.js";
 import { defaultConfig, loadConfig, writeConfig, writeDefaultConfig } from "../src/config.js";
 
-function makeIo(env: Record<string, string> = {}) {
+function makeIo(env: Record<string, string> = {}, platform = process.platform) {
   let stdout = "";
   let stderr = "";
   const baseEnv = { ...process.env };
@@ -15,6 +15,7 @@ function makeIo(env: Record<string, string> = {}) {
   return {
     io: {
       env: { ...baseEnv, ...env },
+      platform,
       stdin: { isTTY: false },
       stdout: { isTTY: false, write: (chunk) => { stdout += String(chunk); } },
       stderr: { write: (chunk) => { stderr += String(chunk); } },
@@ -189,7 +190,7 @@ test("launch dry-run includes opt-in exit notification wrapper", async () => {
 });
 
 test("install-launch-agent dry-run runs the daemon directly by default", async () => {
-  const harness = makeIo();
+  const harness = makeIo({}, "darwin");
   const code = await main([
     "--config",
     writeTempConfig("launch-agent-direct"),
@@ -207,8 +208,54 @@ test("install-launch-agent dry-run runs the daemon directly by default", async (
   assert.doesNotMatch(harness.stdout, /supervise-tmux/);
 });
 
+test("install-launch-agent dry-run emits a Linux systemd user service", async () => {
+  const harness = makeIo({ XDG_CONFIG_HOME: path.join(os.tmpdir(), "relaymux-xdg-cli") }, "linux");
+  const code = await main([
+    "--config",
+    writeTempConfig("launch-agent-systemd"),
+    "install-launch-agent",
+    "--dry-run",
+    "--no-load",
+  ], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /\[Unit\]/);
+  assert.match(harness.stdout, /ExecStart=.*daemon/);
+  assert.match(harness.stdout, /Restart=always/);
+  assert.doesNotMatch(harness.stdout, /<plist/);
+  assert.doesNotMatch(harness.stdout, /launchctl/);
+});
+
+test("status-launch-agent uses Linux systemd status when platform is Linux", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-status-linux-"));
+  const binDir = path.join(dir, "bin");
+  fs.mkdirSync(binDir);
+  makeExecutable(binDir, "systemctl", `
+if [ "$1" = "--user" ] && [ "$2" = "show" ]; then
+  printf '%s\n' 'LoadState=loaded' 'ActiveState=active' 'SubState=running' 'MainPID=2468' 'ExecMainStatus=0' 'Result=success'
+  exit 0
+fi
+exit 0
+`);
+  const configPath = writeTempConfig("status-systemd");
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
+  try {
+    const harness = makeIo({ PATH: process.env.PATH, XDG_CONFIG_HOME: path.join(dir, "xdg") }, "linux");
+    const code = await main(["--config", configPath, "status-launch-agent"], harness.io);
+
+    assert.equal(code, 0);
+    assert.match(harness.stdout, /systemd user service active/);
+    assert.match(harness.stdout, /pid=2468/);
+    assert.doesNotMatch(harness.stdout, /LaunchAgent/);
+    assert.doesNotMatch(harness.stdout, /launchctl/);
+  } finally {
+    process.env.PATH = oldPath;
+  }
+});
+
 test("install-launch-agent rejects tmux supervisor mode", async () => {
-  const harness = makeIo();
+  const harness = makeIo({}, "darwin");
   const code = await main([
     "--config",
     writeTempConfig("launch-agent-tmux"),
@@ -283,7 +330,7 @@ test("setup --imsg guidance uses separate recovery commands", async () => {
   assert.doesNotMatch(harness.stdout, /doctor && relaymux restart-launch-agent && relaymux status/);
 });
 
-test("setup dry-run does not write config or mutate LaunchAgents", async () => {
+test("setup dry-run does not write config or mutate background services", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-setup-dry-run-"));
   const configPath = path.join(dir, "config.json");
   const harness = makeIo();
@@ -295,7 +342,20 @@ test("setup dry-run does not write config or mutate LaunchAgents", async () => {
   assert.equal(fs.existsSync(configPath), false);
 });
 
-test("doctor exits zero when only the background service is missing or unsupported", async () => {
+test("setup dry-run uses Linux systemd wording", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-setup-linux-dry-run-"));
+  const configPath = path.join(dir, "config.json");
+  const harness = makeIo({}, "linux");
+  const code = await main(["--config", configPath, "setup", "--dry-run"], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /Linux systemd user service/);
+  assert.doesNotMatch(harness.stdout, /LaunchAgent/);
+  assert.doesNotMatch(harness.stdout, /launchctl/);
+  assert.equal(fs.existsSync(configPath), false);
+});
+
+test("doctor exits zero when only the macOS LaunchAgent is missing", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-doctor-background-"));
   const binDir = path.join(dir, "bin");
   fs.mkdirSync(binDir);
@@ -309,16 +369,39 @@ test("doctor exits zero when only the background service is missing or unsupport
   const oldPath = process.env.PATH;
   process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
   try {
-    const harness = makeIo({ PATH: process.env.PATH });
+    const harness = makeIo({ PATH: process.env.PATH }, "darwin");
     const code = await main(["--config", configPath, "doctor"], harness.io);
 
     assert.equal(code, 0);
-    if (process.platform === "darwin") {
-      assert.match(harness.stdout, /warning\tbackground-service\t/);
-      assert.match(harness.stdout, /relaymux restart-launch-agent/);
-    } else {
-      assert.match(harness.stdout, /ok\tbackground-service\t.*unsupported/);
-    }
+    assert.match(harness.stdout, /warning\tbackground-service\t/);
+    assert.match(harness.stdout, /relaymux restart-launch-agent/);
+    assert.match(harness.stdout, /launchctl print/);
+  } finally {
+    process.env.PATH = oldPath;
+  }
+});
+
+test("doctor uses Linux systemd wording without launchd instructions", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-doctor-linux-"));
+  const binDir = path.join(dir, "bin");
+  fs.mkdirSync(binDir);
+  makeExecutable(binDir, "tmux", "printf 'tmux 3.4\\n'");
+  const configPath = path.join(dir, "config.json");
+  const config = defaultConfig({ RELAYMUX_HOME: path.join(dir, "home") });
+  config.orchestrator.command = [process.execPath, "--version"];
+  config.daemon.launchAgentLabel = `com.relaymux.test.${process.pid}.linux`;
+  writeConfig(configPath, config, { force: true });
+
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
+  try {
+    const harness = makeIo({ PATH: process.env.PATH, XDG_CONFIG_HOME: path.join(dir, "xdg") }, "linux");
+    const code = await main(["--config", configPath, "doctor"], harness.io);
+
+    assert.equal(code, 0);
+    assert.match(harness.stdout, /background-service\t.*systemd user service/);
+    assert.match(harness.stdout, /relaymux restart-launch-agent/);
+    assert.doesNotMatch(harness.stdout, /launchctl/);
   } finally {
     process.env.PATH = oldPath;
   }

--- a/test/launch-agent.test.ts
+++ b/test/launch-agent.test.ts
@@ -4,14 +4,18 @@ import test from "node:test";
 import { defaultConfig } from "../src/config.js";
 import {
   formatLaunchAgentLoadFailure,
+  formatSystemdServiceLoadFailure,
   installLaunchAgent,
   isCurrentLaunchAgent,
   parseLaunchCtlPrint,
+  parseSystemctlShow,
   renderLaunchAgentPlist,
   renderLaunchAgentReloadScript,
   renderLaunchAgentWatchdogPlist,
+  renderSystemdUserServiceUnit,
   resolveWatchdogSourcePath,
   shouldInstallWatchdog,
+  systemdServiceName,
 } from "../src/launch-agent.js";
 
 
@@ -63,6 +67,27 @@ test("renderLaunchAgentPlist can include a start interval", () => {
   assert.match(plist, /<key>KeepAlive<\/key>\n  <false\/>/);
   assert.match(plist, /<key>StartInterval<\/key>/);
   assert.match(plist, /<integer>60<\/integer>/);
+});
+
+test("renderSystemdUserServiceUnit runs the daemon directly with restart policy", () => {
+  const unit = renderSystemdUserServiceUnit({
+    serviceName: "com.example.relaymux.service",
+    programArguments: ["/usr/bin/node", "/opt/relaymux/relaymux.js", "--config", "/tmp/relaymux config.json", "daemon"],
+    workingDirectory: "/tmp/work dir",
+    standardOutPath: "/tmp/relaymux/daemon.out.log",
+    standardErrorPath: "/tmp/relaymux/daemon.err.log",
+    environment: {
+      PATH: "/usr/local/bin:/usr/bin:/bin",
+      RELAYMUX_CONFIG: "/tmp/relaymux config.json",
+    },
+  });
+
+  assert.match(unit, /\[Service\]/);
+  assert.match(unit, /Type=simple/);
+  assert.match(unit, /ExecStart=\/usr\/bin\/node \/opt\/relaymux\/relaymux\.js --config "\/tmp\/relaymux config\.json" daemon/);
+  assert.match(unit, /Restart=always/);
+  assert.match(unit, /Environment=PATH=\/usr\/local\/bin:\/usr\/bin:\/bin/);
+  assert.match(unit, /StandardOutput=append:\/tmp\/relaymux\/daemon\.out\.log/);
 });
 
 test("renderLaunchAgentPlist can include launchd calendar intervals", () => {
@@ -139,6 +164,7 @@ test("installLaunchAgent direct dry-run does not invoke tmux or set tmux environ
     flags: { dryRun: true },
     configInfo: { config, path: "/tmp/relaymux-config.json", exists: true },
     binPath: "/tmp/relaymux.js",
+    platform: "darwin",
     io: {
       stdout: { write: (chunk) => { stdout += String(chunk); } },
       stderr: { write: () => {} },
@@ -151,6 +177,47 @@ test("installLaunchAgent direct dry-run does not invoke tmux or set tmux environ
   assert.doesNotMatch(stdout, /<string>tmux<\/string>/);
   assert.doesNotMatch(stdout, /TMUX/);
   assert.doesNotMatch(stdout, /RELAYMUX_SESSION/);
+});
+
+test("installLaunchAgent dry-run emits a systemd user unit on Linux", () => {
+  let stdout = "";
+  const config = {
+    ...defaultConfig(),
+    daemon: {
+      ...defaultConfig().daemon,
+      launchAgentLabel: "com.example.relaymux",
+    },
+  };
+
+  installLaunchAgent({
+    flags: { dryRun: true },
+    configInfo: { config, path: "/tmp/relaymux-config.json", exists: true },
+    binPath: "/tmp/relaymux.js",
+    platform: "linux",
+    io: {
+      env: { XDG_CONFIG_HOME: "/tmp/xdg" },
+      stdout: { write: (chunk) => { stdout += String(chunk); } },
+      stderr: { write: () => {} },
+    },
+  });
+
+  assert.match(stdout, /\[Unit\]/);
+  assert.match(stdout, /ExecStart=.*relaymux\.js.*daemon/);
+  assert.match(stdout, /Restart=always/);
+  assert.doesNotMatch(stdout, /<plist/);
+  assert.doesNotMatch(stdout, /launchctl/);
+});
+
+test("systemdServiceName reuses the configured label with a service suffix", () => {
+  const config = {
+    ...defaultConfig(),
+    daemon: {
+      ...defaultConfig().daemon,
+      launchAgentLabel: "com.example.relaymux",
+    },
+  };
+
+  assert.equal(systemdServiceName(config), "com.example.relaymux.service");
 });
 
 test("isCurrentLaunchAgent detects inherited launchd service context", () => {
@@ -191,6 +258,22 @@ test("parseLaunchCtlPrint extracts running status", () => {
   assert.equal(status.lastExitCode, "0");
 });
 
+test("parseSystemctlShow extracts active service status", () => {
+  const status = parseSystemctlShow([
+    "LoadState=loaded",
+    "ActiveState=active",
+    "SubState=running",
+    "MainPID=4321",
+    "ExecMainStatus=0",
+  ].join("\n"));
+
+  assert.equal(status.loadState, "loaded");
+  assert.equal(status.activeState, "active");
+  assert.equal(status.subState, "running");
+  assert.equal(status.pid, 4321);
+  assert.equal(status.lastExitCode, "");
+});
+
 test("formatLaunchAgentLoadFailure includes actionable launchctl context", () => {
   const text = formatLaunchAgentLoadFailure({
     label: "com.example.relaymux",
@@ -209,4 +292,21 @@ test("formatLaunchAgentLoadFailure includes actionable launchctl context", () =>
   assert.match(text, /launchctl print gui\/501\/com\.example\.relaymux/);
   assert.match(text, /common causes/);
   assert.match(text, /relaymux restart-launch-agent/);
+});
+
+test("formatSystemdServiceLoadFailure includes actionable systemd context", () => {
+  const text = formatSystemdServiceLoadFailure({
+    serviceName: "com.example.relaymux.service",
+    result: { status: 1, stdout: "", stderr: "Failed to connect to bus: No medium found\n" },
+    unitPath: "/home/example/.config/systemd/user/com.example.relaymux.service",
+    logDir: "/home/example/.relaymux/logs",
+    stdoutLog: "/home/example/.relaymux/logs/daemon.out.log",
+    stderrLog: "/home/example/.relaymux/logs/daemon.err.log",
+  });
+
+  assert.match(text, /systemctl --user/);
+  assert.match(text, /systemd --user is unavailable/);
+  assert.match(text, /unit: \/home\/example\/\.config\/systemd\/user\/com\.example\.relaymux\.service/);
+  assert.match(text, /journalctl --user -u com\.example\.relaymux\.service -e/);
+  assert.match(text, /fallback: run relaymux daemon/);
 });

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -8,7 +8,7 @@ import { main } from "../src/cli.js";
 import { defaultConfig, writeConfig } from "../src/config.js";
 import { buildScheduledPromptPlan, normalizeScheduleName, parseCronExpression } from "../src/schedule.js";
 
-function makeIo(env: Record<string, string> = {}) {
+function makeIo(env: Record<string, string> = {}, platform = process.platform) {
   let stdout = "";
   let stderr = "";
   const baseEnv = { ...process.env };
@@ -16,6 +16,7 @@ function makeIo(env: Record<string, string> = {}) {
   return {
     io: {
       env: { ...baseEnv, ...env },
+      platform,
       stdin: { isTTY: false },
       stdout: { isTTY: false, write: (chunk) => { stdout += String(chunk); } },
       stderr: { write: (chunk) => { stderr += String(chunk); } },
@@ -72,7 +73,7 @@ test("parseCronExpression allows cron day matching when launchd output is not ne
   assert.deepEqual(parsed.launchd, []);
 });
 
-test("normalizeScheduleName keeps LaunchAgent labels predictable", () => {
+test("normalizeScheduleName keeps schedule identifiers predictable", () => {
   assert.equal(normalizeScheduleName("daily-check"), "daily-check");
   assert.throws(() => normalizeScheduleName("daily check"), /letters, numbers/);
 });
@@ -193,8 +194,7 @@ test("schedule add dry-run prints the planned launchd job without writing state"
 
 test("schedule add dry-run can print a cron job without writing state", async () => {
   const { configPath, env, root } = writeScheduleTestConfig();
-  const harness = makeIo(env);
-  const code = await main([
+  const harness = makeIo(env);  const code = await main([
     "--config",
     configPath,
     "schedule",
@@ -215,6 +215,30 @@ test("schedule add dry-run can print a cron job without writing state", async ()
   assert.match(harness.stdout, /# crontab entry/);
   assert.match(harness.stdout, /# relaymux schedule:daily-check/);
   assert.doesNotMatch(harness.stdout, /secret prompt text/);
+  assert.equal(fs.existsSync(path.join(root, "state", "schedules", "daily-check")), false);
+});
+
+test("schedule add dry-run auto-selects cron with Linux platform wording", async () => {
+  const { configPath, env, root } = writeScheduleTestConfig();
+  const harness = makeIo(env, "linux");
+  const code = await main([
+    "--config",
+    configPath,
+    "schedule",
+    "add",
+    "--name",
+    "daily-check",
+    "--prompt",
+    "secret prompt text",
+    "--cron",
+    "0 9 * * *",
+    "--dry-run",
+  ], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /# scheduler: cron/);
+  assert.match(harness.stdout, /# crontab entry/);
+  assert.doesNotMatch(harness.stdout, /LaunchAgent/);
   assert.equal(fs.existsSync(path.join(root, "state", "schedules", "daily-check")), false);
 });
 


### PR DESCRIPTION
## Summary
Adds Linux support for relaymux background daemon management and scheduler UX while preserving existing macOS launchd behavior.

- Uses systemd user services for Linux daemon install/status/restart/uninstall.
- Keeps scheduled prompts on cron when `--scheduler auto` is used off macOS.
- Updates setup/doctor/status/docs to avoid macOS-only guidance on Linux.

## Design
### Background service platform support
- `src/launch-agent.ts` — adds systemd user unit rendering, service naming/path resolution, Linux install/restart/status/uninstall flows, systemd status parsing, and actionable `systemctl --user` failure messages while keeping launchd code paths for macOS.
- `src/cli.ts` — threads an injectable platform through setup/status/doctor/service commands, switches user-facing background-service wording by platform, and keeps existing `*-launch-agent` command names as compatibility wrappers.
- `bin/relaymux.ts` — passes `process.platform` into the CLI entrypoint so production behavior matches the injected test path.

### Doctor, status, and scheduling
- `src/doctor.ts` — reports systemd user service state and recovery commands on Linux, launchd state on macOS, and avoids launchctl instructions outside macOS.
- `src/schedule.ts` — keeps `auto` mapped to cron off macOS, propagates platform injection through schedule add/remove, improves cron-unavailable errors, and uses platform-aware daemon guidance.

### Docs and tests
- `README.md`, `docs/configuration.md`, `docs/integrations.md`, `docs/operations.md`, `install.sh` — document Linux systemd user services, cron scheduling, service paths, recovery commands, and the compatibility meaning of the launch-agent command names.
- `test/launch-agent.test.ts` — covers systemd unit rendering, Linux dry-run install output, service naming, systemctl parsing, and systemd failure formatting.
- `test/cli.test.ts` — covers platform-injected setup/status/doctor Linux behavior without requiring real systemd.
- `test/schedule.test.ts` — covers Linux auto scheduler selection and cron dry-run output.

## Validation
- `npm run validate` — passed (`tsc --noEmit`, 97 tests passing, build completed).
- `git diff --check` — passed.
- Manual dry-runs — passed: built CLI emitted a macOS LaunchAgent plist on the local platform, and a platform-injected Linux path emitted a systemd user unit with `Restart=always` and no plist/launchctl output.
