### PR TITLE
Add one-command Telegram setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,162 +1,92 @@
 # relaymux
 
-`relaymux` launches local coding-agent commands in visible `tmux` windows and records each run's status and completion updates under `~/.relaymux`.
+`relaymux` lets you talk to local coding agents from Telegram. It runs the agent on your machine in `tmux`, keeps the background service running, and replies through your Telegram bot.
 
-It is not a model provider, IDE, cloud runtime, or agent framework. It coordinates commands you already run in a terminal, such as `pi`, `codex`, `claude`, `aider`, or a shell script that can work from a prompt.
+iMessage/SMS support exists, but it is beta.
 
-## Quickstart
+## Requirements
 
-You need Node.js 20+, npm, git, and `tmux`. tmux is the terminal multiplexer relaymux uses to keep agent runs visible as attachable sessions and windows. Optional notification adapters such as iMessage/SMS and Telegram are not required for a local launch.
+You need Node.js 20+, npm, git, tmux, and a local agent CLI such as `pi`, `codex`, or `claude`.
 
-Install relaymux and put the command on your PATH:
+## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/avyayv/relaymux/main/install.sh | bash
+git clone https://github.com/mupt-ai/relaymux.git
+cd relaymux
+./install.sh
 export PATH="$HOME/.local/bin:$PATH"
-relaymux --version
-relaymux setup
+```
+
+## Set up Telegram
+
+Create a bot with [BotFather](https://t.me/BotFather), copy the token, then run:
+
+```bash
+relaymux setup --telegram --telegram-bot-token '<telegram-bot-token>'
+```
+
+When prompted, open your bot in Telegram and send `/start`. relaymux stores the token in `~/.relaymux/secrets/telegram-bot-token`, discovers your chat id, writes `~/.relaymux/config.json`, and starts the background service.
+
+Check it:
+
+```bash
 relaymux status
 ```
 
-The installer clones and builds relaymux locally with Node/npm/git, writes app files under `~/.local/lib/relaymux`, and writes a `relaymux` shim under `~/.local/bin`. On Linux, `relaymux setup` expects per-user systemd services (`systemctl --user`) for the daemon; scheduled prompts use cron when `--scheduler auto` is selected.
+## Use it
 
-`relaymux setup` creates or updates `~/.relaymux/config.json`, installs/restarts the per-user background service when supported, and prints the config path, log path, status, and next command. macOS uses launchd LaunchAgents; Linux uses a systemd user unit (`systemctl --user`). If the service manager rejects the service, setup prints the service file path, daemon logs, inspect command, common causes, and the exact retry command.
+Send your Telegram bot a message like:
 
-For a config-only setup without starting the background service, use `relaymux setup --no-launch-agent` (command names remain launch-agent-compatible for now). `relaymux init` is the lower-level config writer; it refuses to overwrite an existing config unless you pass `--force`.
-
-The generated config includes a harmless `custom` agent that prints its prompt, which is useful for checking that tmux/status behavior works before wiring a real agent:
-
-```bash
-mkdir -p /tmp/relaymux-demo
-relaymux launch \
-  --repo /tmp/relaymux-demo \
-  --agent custom \
-  --name hello-relaymux \
-  --hold \
-  --prompt "hello from relaymux"
+```text
+Open an agent in ~/code/my-app and inspect the failing tests.
 ```
 
-`--repo` is the command's working directory; it does not need to be a Git repository for this basic launch. `--hold` keeps the tmux window open after the command exits so you can inspect it. relaymux creates the shared tmux session automatically when it launches the first run.
+relaymux passes the message to your configured local orchestrator and replies in Telegram.
 
-Attach to the shared tmux session:
+Manual notification test:
+
+```bash
+relaymux notify --from test --reply-mode telegram --message "hello from relaymux"
+```
+
+## Optional: launch an agent manually
+
+```bash
+relaymux launch \
+  --repo ~/code/my-app \
+  --agent pi \
+  --name inspect-tests \
+  --prompt "Inspect the failing tests and summarize what is broken."
+```
+
+Attach to the tmux session:
 
 ```bash
 tmux attach -t agents
 ```
 
-In tmux, you should see a window named `hello-relaymux`. Detach with `Ctrl-b d`, then inspect local status:
+Detach with `Ctrl-b d`.
+
+## iMessage/SMS beta
+
+iMessage/SMS depends on a working local `imsg` command. The minimal setup is:
 
 ```bash
+relaymux setup --imsg
+```
+
+relaymux will try to show recent chats. Pick one, then text that chat to use relaymux. If chat discovery does not work, pass the chat id directly:
+
+```bash
+relaymux setup --imsg --chat-id '<chat-id-or-phone-number>'
+```
+
+## Troubleshooting
+
+```bash
+relaymux doctor
+relaymux status-launch-agent
 relaymux status --history
 ```
 
-## Use A Real Agent
-
-At minimum, relaymux needs a shared tmux session name and an agent command template in `~/.relaymux/config.json`. An agent command can be interactive or noninteractive; relaymux's job is to start it with the prompt you provide.
-
-```json
-{
-  "session": "agents",
-  "agents": {
-    "my-agent": {
-      "command": ["my-agent-cli", "--prompt-file", "{promptFile}"]
-    }
-  }
-}
-```
-
-The `command` value is a list of command arguments. relaymux replaces `{promptFile}` with the path to the prompt file it writes for the run. Replace `my-agent-cli` with the agent or wrapper command you actually use. The prompt-file style is the simplest path; other prompt-passing modes and placeholders are covered in [Configuration](docs/configuration.md).
-
-Write a prompt file:
-
-```bash
-mkdir -p ~/.relaymux/tasks
-cat > ~/.relaymux/tasks/first-agent.md <<'EOF'
-Read the README, summarize what this project does, and report any unclear setup steps.
-EOF
-```
-
-A subagent is the command relaymux starts for one run. Launch one from that prompt file:
-
-```bash
-relaymux launch \
-  --repo ~/code/my-project \
-  --agent my-agent \
-  --name first-agent \
-  --prompt-file ~/.relaymux/tasks/first-agent.md
-```
-
-By default this creates a new tmux window in the shared `agents` session. relaymux does not create panes or splits; many terminal UIs display tmux windows like tabs.
-
-Use a separate session only when you explicitly want to isolate a group of windows:
-
-```bash
-relaymux launch --session my-task --repo ~/code/my-project --agent my-agent --prompt-file ~/.relaymux/tasks/first-agent.md
-```
-
-Inside every launched agent process, relaymux injects `RELAYMUX_NOTIFY_COMMAND`, a shell command string that records local progress or completion updates for that run:
-
-```bash
-$RELAYMUX_NOTIFY_COMMAND --message "Finished: checked the README and found no blockers."
-```
-
-## Optional Notifications
-
-relaymux works without message adapters. If you want user-visible updates away from the terminal, configure an adapter after the local flow works.
-
-iMessage/SMS through macOS Messages and an external `imsg` CLI:
-
-```bash
-relaymux setup --imsg --chat-id <chat-id-or-phone-number>
-relaymux status-launch-agent
-relaymux status
-```
-
-`relaymux setup --imsg` creates or updates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs/restarts the LaunchAgent unless `--no-launch-agent` is passed, and prints next steps. Re-running `relaymux init --imsg` or `relaymux setup --imsg` adds or updates the adapter on the existing config; `--force` is only for replacing the whole config.
-
-After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
-
-Telegram through a Telegram bot:
-
-```bash
-relaymux setup --telegram \
-  --telegram-chat-id <telegram-chat-id> \
-  --telegram-bot-token-file ~/.relaymux/secrets/telegram-bot-token
-relaymux status-launch-agent
-relaymux status
-```
-
-Then use `relaymux notify --reply-mode imessage` or `relaymux notify --reply-mode telegram` from an agent when you want an adapter-delivered update. In this command, reply mode means the delivery channel for a user-visible notification.
-
-## Scheduled Prompts
-
-Use `relaymux schedule` when you want the configured orchestrator asked on a recurring local schedule:
-
-```bash
-relaymux schedule add \
-  --name weekday-checkin \
-  --cron "0 9 * * 1-5" \
-  --reply-mode imessage \
-  --prompt "Check the active agent runs and send me a concise status."
-```
-
-Scheduled prompts are local OS jobs. The default `auto` scheduler uses macOS launchd on macOS and cron elsewhere, including Linux. Each job runs `relaymux ask --no-wait` when the schedule fires; relaymux does not create a hidden cloud scheduler or a durable in-process loop inside the daemon. Use `relaymux schedule add --dry-run` to inspect the generated job before installing it, or pass `--scheduler launchd|cron` when you want a specific backend. On Linux, install a cron implementation such as cron/cronie if `crontab` is missing.
-
-## Docs
-
-- [Configuration](docs/configuration.md): config shape, prompt passing, sessions, and common launch patterns.
-- [Integrations](docs/integrations.md): local HTTP API for agent callbacks, `relaymux ask`, `relaymux notify`, scheduled prompts, iMessage/SMS, and Telegram.
-- [Operations](docs/operations.md): install footprint, uninstall, background service, watchdog, safety model, troubleshooting, and development.
-
-## Development
-
-```bash
-npm ci
-npm run validate
-```
-
-Issues and pull requests are welcome. Please keep public examples free of private paths, phone numbers, chat ids, tokens, and secrets.
-
-## License
-
-MIT
+Logs live in `~/.relaymux/logs`. Config lives at `~/.relaymux/config.json`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,7 +128,11 @@ async function handleSetup(flags, io, platform = process.platform) {
         io.stdout.write("Would configure the iMessage/SMS adapter.\n");
       }
     }
-    if (wantsTelegram) io.stdout.write("Would configure the Telegram adapter.\n");
+    if (wantsTelegram) {
+      io.stdout.write("Would configure the Telegram adapter.\n");
+      if (!flags.telegramChatId) io.stdout.write("Would discover the Telegram chat id after you send /start to the bot.\n");
+      if (flags.telegramBotToken) io.stdout.write("Would store the Telegram bot token under ~/.relaymux/secrets.\n");
+    }
     io.stdout.write(shouldInstallLaunchAgent
       ? `Would install/restart the ${backgroundServiceDryRunName(platform)}.\n`
       : "Would skip background service installation because --no-launch-agent was passed.\n");
@@ -218,7 +222,7 @@ async function handleInit(flags, io, platform = process.platform) {
       }, io.env);
       labels.push("iMessage/SMS adapter");
     } else if (wantsTelegram) {
-      config = buildTelegramConfig(initTelegramOptionsFromFlags(flags), io.env);
+      config = buildTelegramConfig(await initTelegramOptionsFromFlags(flags, io, io.env), io.env);
       labels.push("Telegram adapter");
     } else {
       config = defaultConfig(io.env);
@@ -238,10 +242,10 @@ async function handleInit(flags, io, platform = process.platform) {
   }
 
   if (wantsTelegram && wantsImsg) {
-    config = withTelegramIntegration(config, initTelegramOptionsFromFlags(flags));
+    config = withTelegramIntegration(config, await initTelegramOptionsFromFlags(telegramFlagsWithExisting(flags, config), io, io.env));
     labels.push("Telegram adapter");
   } else if (updatedExisting && wantsTelegram) {
-    config = withTelegramIntegration(config, initTelegramOptionsFromFlags(flags));
+    config = withTelegramIntegration(config, await initTelegramOptionsFromFlags(telegramFlagsWithExisting(flags, config), io, io.env));
     labels.push("Telegram adapter");
   }
 
@@ -282,6 +286,16 @@ function backgroundServiceStatusName(status, platform) {
 function backgroundServiceNeedsSetupFailure(status) {
   if (status.serviceManager === "unsupported") return false;
   return !status.loaded;
+}
+
+function telegramFlagsWithExisting(flags, config) {
+  const telegram = getIntegration(config, "telegram");
+  return {
+    ...flags,
+    telegramChatId: flags.telegramChatId || telegram.chatId,
+    telegramBotTokenFile: flags.telegramBotTokenFile || telegram.botTokenFile,
+    telegramBotTokenEnv: flags.telegramBotTokenEnv || telegram.botTokenEnv,
+  };
 }
 
 function cloneConfig(config) {
@@ -1040,6 +1054,8 @@ Start here:
   relaymux status
 
 Usage:
+  relaymux setup --telegram --telegram-bot-token <token>
+  relaymux setup --imsg
   relaymux setup [--imsg|--telegram] [--chat-id <id>] [--telegram-chat-id <id>] [--no-launch-agent] [--dry-run]
   relaymux init [--force] [--config <path>]
   relaymux init --imsg [--chat-id <id>] [--install-launch-agent]
@@ -1059,9 +1075,10 @@ Usage:
 
 Setup/init options:
   --imsg                    Enable the optional iMessage/SMS adapter and prompt for a chat when possible
-  --telegram                Enable the optional Telegram adapter
-  --chat-id <id>            Messages chat id/phone for imsg history/send
-  --telegram-chat-id <id>   Telegram chat id for Bot API sendMessage
+  --telegram                Enable the optional Telegram adapter; waits for /start when chat id is missing
+  --chat-id <id>            Messages chat id/phone for imsg history/send; omit to pick from recent chats
+  --telegram-chat-id <id>   Telegram chat id for Bot API sendMessage; omit to discover from /start
+  --telegram-bot-token <token>      Telegram bot token to store in ~/.relaymux/secrets/telegram-bot-token
   --telegram-bot-token-env <name>   Env var that contains the Telegram bot token (default TELEGRAM_BOT_TOKEN)
   --telegram-bot-token-file <path>  File that contains the Telegram bot token (contents are never printed)
   --telegram-parse-mode <mode>      Optional Telegram parse_mode such as MarkdownV2 or HTML

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,12 @@ export function defaultTelegramIntegration() {
     apiBaseUrl: "https://api.telegram.org",
     timeoutMs: 30000,
     maxMessageChars: 3900,
+    receive: {
+      enabled: false,
+      pollMs: 3000,
+      syncLimit: 20,
+      timeoutMs: 30000,
+    },
   };
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { createCompletionWebhookServer } from "./webhook.js";
 import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorPrompt, runOrchestrator } from "./orchestrator.js";
 import { formatIncomingForPrompt, isImessageReceiveEnabled, isIncomingUserMessage, receiveMessages, sendMessage } from "./message-io.js";
-import { sendTelegramMessage } from "./telegram.js";
+import { isTelegramReceiveEnabled, receiveTelegramMessages, sendTelegramMessage } from "./telegram.js";
 import { ensureDirectory } from "./paths.js";
 import { validateSessionName } from "./tmux.js";
 
@@ -49,12 +49,12 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     });
   }
 
-  function enqueueIncoming(messages) {
+  function enqueueIncoming(adapter, messages, replyMode) {
     if (!messages.length) return;
     const ids = messages.map((message) => String(message.id));
     for (const id of ids) queuedIncomingIds.add(id);
-    queue.push({ type: "imessage", requestId: `imsg-${Date.now().toString(36)}`, messages, ids, enqueuedAt: new Date().toISOString() });
-    log(`queued incoming message(s): ${ids.join(",")}`);
+    queue.push({ type: "incoming", adapter, replyMode, requestId: `${adapter}-${Date.now().toString(36)}`, messages, ids, enqueuedAt: new Date().toISOString() });
+    log(`queued incoming ${adapter} message(s): ${ids.join(",")}`);
     scheduleProcessQueue();
   }
 
@@ -76,7 +76,7 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
   }
 
   async function processIncomingJob(job) {
-    log(`processing incoming message(s): ${job.ids.join(",")}`);
+    log(`processing incoming ${job.adapter || "message"} message(s): ${job.ids.join(",")}`);
     let marked = false;
     const markSeen = () => {
       if (marked) return;
@@ -89,16 +89,16 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
       const prompt = buildIncomingOrchestratorPrompt({
         config,
         configPath: configInfo.path,
-        incomingText: formatIncomingForPrompt(job.messages),
+        incomingText: formatIncomingForPrompt(job.messages, job.adapter),
       });
       const reply = await runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId });
-      await sendMessage(config, reply, io);
+      await sendReply(config, job.replyMode || "imessage", reply, io);
       markSeen();
-      log(`replied to ${job.ids.join(",")}`);
+      log(`replied to ${job.ids.join(",")} via ${job.replyMode || "imessage"}`);
     } catch (error) {
       warn(`failed processing incoming ${job.ids.join(",")}:`, describeError(error));
       try {
-        await sendMessage(config, `relaymux orchestrator hit an error: ${error.message || String(error)}`, io);
+        await sendReply(config, job.replyMode || "imessage", `relaymux orchestrator hit an error: ${error.message || String(error)}`, io);
       } catch (sendError) {
         warn("also failed to send error message:", describeError(sendError));
       }
@@ -163,7 +163,7 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     try {
       while (queue.length > 0) {
         const job = queue.shift();
-        if (job.type === "imessage") await processIncomingJob(job);
+        if (job.type === "incoming" || job.type === "imessage") await processIncomingJob(job);
         else if (job.type === "webhook") await processWebhookJob(job);
         else if (job.type === "request") await processTerminalRequestJob(job);
         else warn("dropping unknown job:", JSON.stringify(job));
@@ -176,23 +176,47 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
 
   async function pollOnce() {
     if (processing || queue.length > 0) return;
-    const recent = await receiveMessages(config);
     const seen = new Set((state.seenIncomingIds || []).map(String));
-    const fresh = recent
-      .filter(isIncomingUserMessage)
-      .filter((message) => !seen.has(String(message.id)) && !queuedIncomingIds.has(String(message.id)))
-      .sort(compareMessages);
-    if (fresh.length) enqueueIncoming(fresh);
+    if (inboundImessageEnabled) {
+      try {
+        const recent = await receiveMessages(config);
+        const fresh = freshIncoming(recent, seen, queuedIncomingIds);
+        if (fresh.length) enqueueIncoming("imessage", fresh, "imessage");
+      } catch (error) {
+        warn("iMessage poll failed:", describeError(error));
+      }
+    }
+    if (inboundTelegramEnabled) {
+      try {
+        const recent = await receiveTelegramMessages(config, state, io.env || process.env);
+        saveState();
+        const fresh = freshIncoming(recent, seen, queuedIncomingIds);
+        if (fresh.length) enqueueIncoming("telegram", fresh, "telegram");
+      } catch (error) {
+        warn("Telegram poll failed:", describeError(error));
+      }
+    }
   }
 
   const inboundImessageEnabled = isImessageReceiveEnabled(config);
+  const inboundTelegramEnabled = isTelegramReceiveEnabled(config);
+  const inboundEnabled = inboundImessageEnabled || inboundTelegramEnabled;
   log("starting relaymux background daemon");
   if (inboundImessageEnabled) log("iMessage/SMS adapter enabled for inbound polling");
-  else log("no inbound message adapter enabled; serving local API/webhook only");
+  if (inboundTelegramEnabled) log("Telegram adapter enabled for inbound polling");
+  if (!inboundEnabled) log("no inbound message adapter enabled; serving local API/webhook only");
 
-  if (inboundImessageEnabled && !state.initialized) {
+  if (inboundEnabled && !state.initialized) {
     try {
-      const recent = await receiveMessages(config);
+      const recent: any[] = [];
+      if (inboundImessageEnabled) {
+        try { recent.push(...await receiveMessages(config)); }
+        catch (error) { warn("iMessage initial sync failed:", describeError(error)); }
+      }
+      if (inboundTelegramEnabled) {
+        try { recent.push(...await receiveTelegramMessages(config, state, io.env || process.env)); }
+        catch (error) { warn("Telegram initial sync failed:", describeError(error)); }
+      }
       const initialIds = recent.filter(isIncomingUserMessage).map((message) => String(message.id));
       state.initialized = true;
       rememberSeen(state, initialIds);
@@ -217,7 +241,7 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
       });
   if (webhookServer) log(`local completion webhook listening on ${config.daemon?.host || "127.0.0.1"}:${Number(config.daemon?.port || 47761)}`);
 
-  if (inboundImessageEnabled) {
+  if (inboundEnabled) {
     await pollOnce().catch((error) => warn("initial poll failed:", describeError(error)));
   }
   await drainIfOnce(flags, processQueue);
@@ -228,10 +252,14 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     return 0;
   }
 
-  const interval = inboundImessageEnabled
+  const pollMs = Math.min(
+    inboundImessageEnabled ? Number(config.integrations?.imessage?.pollMs || config.imessage?.pollMs || 3000) : Infinity,
+    inboundTelegramEnabled ? Number(config.integrations?.telegram?.receive?.pollMs || 3000) : Infinity,
+  );
+  const interval = inboundEnabled
     ? setInterval(() => {
         pollOnce().catch((error) => warn("poll failed:", describeError(error)));
-      }, Number(config.integrations?.imessage?.pollMs || config.imessage?.pollMs || 3000))
+      }, Number.isFinite(pollMs) ? pollMs : 3000)
     : null;
 
   await new Promise<void>((resolve) => {
@@ -254,6 +282,7 @@ export function readDaemonState(stateFile) {
       initialized: Boolean(parsed.initialized),
       seenIncomingIds: Array.isArray(parsed.seenIncomingIds) ? parsed.seenIncomingIds.map(String) : [],
       seenWebhookIdempotencyKeys: Array.isArray(parsed.seenWebhookIdempotencyKeys) ? parsed.seenWebhookIdempotencyKeys.map(String) : [],
+      lastTelegramUpdateId: parsed.lastTelegramUpdateId,
       lastProcessedAt: parsed.lastProcessedAt,
       lastWebhookAt: parsed.lastWebhookAt,
     };
@@ -274,6 +303,13 @@ function rememberSeen(state, ids) {
   for (const id of ids) seen.add(String(id));
   state.seenIncomingIds = Array.from(seen).slice(-1000);
   state.lastProcessedAt = new Date().toISOString();
+}
+
+function freshIncoming(messages, seen, queuedIncomingIds) {
+  return messages
+    .filter(isIncomingUserMessage)
+    .filter((message) => !seen.has(String(message.id)) && !queuedIncomingIds.has(String(message.id)))
+    .sort(compareMessages);
 }
 
 function compareMessages(a, b) {

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -55,12 +55,13 @@ export function isIncomingUserMessage(message) {
   return Boolean(message && !message.isFromMe && (message.text?.trim() || message.attachments?.length));
 }
 
-export function formatIncomingForPrompt(messages) {
+export function formatIncomingForPrompt(messages, adapter = "imessage") {
   const normalized = normalizeMessages(messages);
+  const channel = adapter === "telegram" ? "Telegram bot chat" : adapter === "imessage" ? "iMessage/SMS adapter chat" : "message adapter chat";
   if (normalized.length === 1) {
     const message = normalized[0];
     const attachments = formatAttachments(message.attachments);
-    return `New incoming message from the configured iMessage/SMS adapter chat (${message.createdAt || "unknown time"}, message id ${message.id}).\n\n${message.text || "[no text]"}${attachments}\n\nReply directly and concisely. Do not mention daemon internals.`;
+    return `New incoming message from the configured ${channel} (${message.createdAt || "unknown time"}, message id ${message.id}).\n\n${message.text || "[no text]"}${attachments}\n\nReply directly and concisely. Do not mention daemon internals.`;
   }
 
   const body = normalized
@@ -69,7 +70,7 @@ export function formatIncomingForPrompt(messages) {
       return `- ${message.createdAt || "unknown time"} id=${message.id}: ${message.text || "[no text]"}${attachments}`;
     })
     .join("\n");
-  return `The configured iMessage/SMS adapter chat sent these new messages, in order:\n${body}\n\nRespond once, directly and concisely. Do not mention daemon internals.`;
+  return `The configured ${channel} sent these new messages, in order:\n${body}\n\nRespond once, directly and concisely. Do not mention daemon internals.`;
 }
 
 export function splitMessage(text, maxChars = 1400) {

--- a/src/setup-telegram.ts
+++ b/src/setup-telegram.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import readline from "node:readline/promises";
 
 import { defaultConfig, defaultTelegramIntegration } from "./config.js";
 import { findExecutable } from "./doctor.js";
 import { expandPath } from "./paths.js";
+import { resolveTelegramToken } from "./telegram.js";
 
 export function buildTelegramIntegration(options: any = {}) {
   const defaults = defaultTelegramIntegration();
@@ -16,6 +20,13 @@ export function buildTelegramIntegration(options: any = {}) {
     apiBaseUrl: options.telegramApiBaseUrl || options.apiBaseUrl || defaults.apiBaseUrl,
     timeoutMs: Number(options.telegramTimeoutMs || options.timeoutMs || defaults.timeoutMs),
     maxMessageChars: Number(options.telegramMaxMessageChars || options.maxMessageChars || defaults.maxMessageChars),
+    receive: {
+      ...defaults.receive,
+      enabled: options.telegramReceiveEnabled ?? options.receiveEnabled ?? true,
+      pollMs: Number(options.telegramPollMs || options.pollMs || defaults.receive.pollMs),
+      syncLimit: Number(options.telegramSyncLimit || options.syncLimit || defaults.receive.syncLimit),
+      timeoutMs: Number(options.telegramReceiveTimeoutMs || options.receiveTimeoutMs || defaults.receive.timeoutMs),
+    },
   };
 }
 
@@ -80,11 +91,13 @@ export function buildTelegramConfig(options: any = {}, env = process.env) {
   }, { ...options, defaultReplyMode: options.defaultReplyMode || "telegram" });
 }
 
-export function initTelegramOptionsFromFlags(flags) {
+export async function initTelegramOptionsFromFlags(flags, io: any = process, env = process.env) {
+  const tokenFile = await resolveTelegramTokenFile(flags, io, env);
+  const chatId = flags.telegramChatId || await resolveTelegramChatId({ ...flags, telegramBotTokenFile: tokenFile }, io, env);
   return {
-    telegramChatId: flags.telegramChatId,
-    telegramBotTokenEnv: flags.telegramBotTokenEnv,
-    telegramBotTokenFile: flags.telegramBotTokenFile,
+    telegramChatId: chatId,
+    telegramBotTokenEnv: tokenFile ? "" : flags.telegramBotTokenEnv,
+    telegramBotTokenFile: tokenFile || flags.telegramBotTokenFile,
     telegramParseMode: flags.telegramParseMode,
     telegramTimeoutMs: flags.telegramTimeoutMs,
     telegramApiBaseUrl: flags.telegramApiBaseUrl,
@@ -98,4 +111,106 @@ export function initTelegramOptionsFromFlags(flags) {
     codexPath: flags.codexPath,
     claudePath: flags.claudePath,
   };
+}
+
+export async function resolveTelegramTokenFile(flags: any, io: any = process, env = process.env) {
+  if (flags.telegramBotTokenFile) return String(flags.telegramBotTokenFile);
+  if (flags.telegramBotTokenEnv && env[flags.telegramBotTokenEnv] && !flags.telegramBotToken) return "";
+
+  let token = flags.telegramBotToken || flags.botToken;
+  if (!token && env.TELEGRAM_BOT_TOKEN) token = env.TELEGRAM_BOT_TOKEN;
+  if (!token && isInteractive(io)) token = await promptSecret(io, "Telegram bot token: ");
+  if (!token) return "";
+
+  const tokenFile = expandPath(flags.telegramStoreTokenFile || defaultTelegramTokenFile(env));
+  fs.mkdirSync(path.dirname(tokenFile), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(tokenFile, `${String(token).trim()}\n`, { mode: 0o600 });
+  try { fs.chmodSync(path.dirname(tokenFile), 0o700); } catch {}
+  try { fs.chmodSync(tokenFile, 0o600); } catch {}
+  io.stdout?.write?.(`Stored Telegram bot token at ${tokenFile}\n`);
+  return tokenFile;
+}
+
+export async function resolveTelegramChatId(flags: any, io: any = process, env = process.env) {
+  if (flags.telegramChatId) return String(flags.telegramChatId);
+
+  const probeConfig = {
+    integrations: {
+      telegram: buildTelegramIntegration({
+        ...flags,
+        telegramChatId: "0",
+        telegramBotTokenFile: flags.telegramBotTokenFile,
+        telegramBotTokenEnv: flags.telegramBotTokenEnv,
+        telegramApiBaseUrl: flags.telegramApiBaseUrl,
+        telegramTimeoutMs: flags.telegramTimeoutMs,
+      }),
+    },
+  };
+  const { token, source } = resolveTelegramToken(probeConfig, env);
+  if (!token) throw new Error(`Missing Telegram bot token (${source}). Pass --telegram-bot-token <token> or --telegram-bot-token-file <path>.`);
+
+  const waitMs = Number(flags.telegramChatWaitMs || 60000);
+  const pollMs = Number(flags.telegramChatPollMs || 2000);
+  io.stdout?.write?.("Open your Telegram bot and send /start. Waiting for the first incoming chat...\n");
+
+  const started = Date.now();
+  let lastError: any = null;
+  while (Date.now() - started <= waitMs) {
+    try {
+      const chatId = await discoverTelegramChatId({
+        token,
+        apiBaseUrl: flags.telegramApiBaseUrl,
+        timeoutMs: flags.telegramTimeoutMs,
+      });
+      if (chatId) return chatId;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(pollMs);
+  }
+
+  const suffix = lastError ? ` Last error: ${lastError.message || String(lastError)}` : "";
+  throw new Error(`Could not discover Telegram chat id. Send /start to the bot and re-run with --telegram-chat-id <id>.${suffix}`);
+}
+
+export async function discoverTelegramChatId({ token, apiBaseUrl = "https://api.telegram.org", timeoutMs = 30000 }: any) {
+  const base = String(apiBaseUrl || "https://api.telegram.org").replace(/\/+$/, "");
+  const controller = Number(timeoutMs) > 0 ? new AbortController() : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), Number(timeoutMs)) : null;
+  try {
+    const response = await fetch(`${base}/bot${token}/getUpdates?limit=20&timeout=0&allowed_updates=${encodeURIComponent(JSON.stringify(["message", "edited_message"]))}`, { signal: controller?.signal });
+    const text = await response.text();
+    if (!response.ok) throw new Error(`Telegram getUpdates failed with HTTP ${response.status}: ${text.slice(0, 300)}`);
+    const body = JSON.parse(text || "{}");
+    if (!body.ok || !Array.isArray(body.result)) throw new Error(`Telegram getUpdates returned an unexpected response: ${text.slice(0, 300)}`);
+    const update = body.result.find((item) => {
+      const message = item.message || item.edited_message;
+      return message?.chat?.id !== undefined && !message.from?.is_bot;
+    });
+    const chatId = update?.message?.chat?.id ?? update?.edited_message?.chat?.id;
+    return chatId === undefined ? "" : String(chatId);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function defaultTelegramTokenFile(env = process.env) {
+  return path.join(env.HOME || os.homedir(), ".relaymux", "secrets", "telegram-bot-token");
+}
+
+async function promptSecret(io, prompt) {
+  const rl = readline.createInterface({ input: io.stdin, output: io.stdout });
+  try {
+    return (await rl.question(prompt)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+function isInteractive(io) {
+  return Boolean(io.stdin?.isTTY && io.stdout?.isTTY);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 
 import { getIntegration, isIntegrationEnabled } from "./config.js";
 import { expandPath } from "./paths.js";
-import { splitMessage } from "./message-io.js";
+import { normalizeMessages, splitMessage } from "./message-io.js";
 
 export function resolveTelegramToken(config, env = process.env) {
   const telegram = getIntegration(config, "telegram");
@@ -19,6 +19,52 @@ export function resolveTelegramToken(config, env = process.env) {
   }
 
   return { token: "", source: tokenEnv ? `env:${tokenEnv}` : "missing" };
+}
+
+export function isTelegramReceiveEnabled(config) {
+  const telegram = getIntegration(config, "telegram");
+  const receive = telegram.receive || {};
+  return telegram.enabled === true && receive.enabled === true;
+}
+
+export async function receiveTelegramMessages(config, state: any = {}, env = process.env) {
+  if (!isTelegramReceiveEnabled(config)) return [];
+  const telegram = getIntegration(config, "telegram");
+  const chatId = String(telegram.chatId || "").trim();
+  if (!chatId || chatId === "TELEGRAM_CHAT_ID") {
+    throw new Error("Telegram receive requires config.integrations.telegram.chatId");
+  }
+
+  const { token, source } = resolveTelegramToken(config, env);
+  if (!token) {
+    throw new Error(`Telegram adapter token is missing (${source})`);
+  }
+
+  const updates = await getTelegramUpdates(telegram, token, state.lastTelegramUpdateId);
+  let maxUpdateId = Number(state.lastTelegramUpdateId || 0);
+  const messages: any[] = [];
+
+  for (const update of updates) {
+    const updateId = Number(update.update_id);
+    if (Number.isFinite(updateId) && updateId > maxUpdateId) maxUpdateId = updateId;
+    const message = update.message || update.edited_message;
+    if (!message || String(message.chat?.id || "") !== chatId) continue;
+    if (message.from?.is_bot) continue;
+    const text = String(message.text || message.caption || "");
+    const attachments = collectTelegramAttachments(message);
+    messages.push({
+      id: `telegram-${message.message_id || update.update_id}`,
+      text,
+      date: message.date ? new Date(Number(message.date) * 1000).toISOString() : "",
+      sender: [message.from?.first_name, message.from?.last_name].filter(Boolean).join(" ") || String(message.from?.id || ""),
+      isFromMe: false,
+      attachments,
+      raw: message,
+    });
+  }
+
+  if (maxUpdateId) state.lastTelegramUpdateId = maxUpdateId;
+  return normalizeMessages(messages);
 }
 
 export async function sendTelegramMessage(config, text, io: any = process, env = io.env || process.env) {
@@ -46,6 +92,46 @@ export async function sendTelegramMessage(config, text, io: any = process, env =
       ...(telegram.parseMode ? { parse_mode: String(telegram.parseMode) } : {}),
     });
   }
+}
+
+async function getTelegramUpdates(telegram, token, offsetUpdateId) {
+  const apiBaseUrl = String(telegram.apiBaseUrl || "https://api.telegram.org").replace(/\/+$/, "");
+  const receive = telegram.receive || {};
+  const timeoutMs = Number(receive.timeoutMs || telegram.timeoutMs || 30000);
+  const limit = Math.max(1, Math.min(Number(receive.syncLimit || 20), 100));
+  const params = new URLSearchParams({ limit: String(limit), timeout: "0", allowed_updates: JSON.stringify(["message", "edited_message"]) });
+  const offset = Number(offsetUpdateId || 0);
+  if (Number.isFinite(offset) && offset > 0) params.set("offset", String(offset + 1));
+  const controller = timeoutMs > 0 ? new AbortController() : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/bot${token}/getUpdates?${params.toString()}`, { signal: controller?.signal });
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(`Telegram getUpdates failed with HTTP ${response.status}: ${responseText.slice(0, 500)}`);
+    }
+    const body = JSON.parse(responseText || "{}");
+    if (!body.ok || !Array.isArray(body.result)) {
+      throw new Error(`Telegram getUpdates returned an unexpected response: ${responseText.slice(0, 500)}`);
+    }
+    return body.result;
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error(`Telegram getUpdates timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function collectTelegramAttachments(message) {
+  const attachments: any[] = [];
+  for (const key of ["photo", "document", "audio", "voice", "video", "video_note", "sticker", "animation"]) {
+    if (message[key]) attachments.push({ type: key, value: message[key] });
+  }
+  return attachments;
 }
 
 async function postTelegramSendMessage(telegram, token, body) {

--- a/test/setup-telegram.test.ts
+++ b/test/setup-telegram.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { discoverTelegramChatId, resolveTelegramTokenFile } from "../src/setup-telegram.js";
+
+test("resolveTelegramTokenFile stores a passed bot token privately", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-telegram-token-"));
+  const tokenFile = path.join(dir, "token");
+  const io = { stdout: { write() {} }, stdin: {}, env: { HOME: dir } };
+
+  const resolved = await resolveTelegramTokenFile({ telegramBotToken: "bot-token", telegramStoreTokenFile: tokenFile }, io, io.env);
+
+  assert.equal(resolved, tokenFile);
+  assert.equal(fs.readFileSync(tokenFile, "utf8"), "bot-token\n");
+  assert.equal((fs.statSync(tokenFile).mode & 0o777), 0o600);
+});
+
+test("discoverTelegramChatId reads the first human chat from getUpdates", async () => {
+  const server = http.createServer((req, res) => {
+    assert.match(req.url || "", /\/bottest-token\/getUpdates/);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({
+      ok: true,
+      result: [
+        { update_id: 1, message: { message_id: 1, from: { is_bot: true }, chat: { id: "skip" }, text: "bot" } },
+        { update_id: 2, message: { message_id: 2, from: { is_bot: false }, chat: { id: 12345 }, text: "/start" } },
+      ],
+    }));
+  });
+  await listen(server);
+  const address: any = server.address();
+
+  try {
+    const chatId = await discoverTelegramChatId({ token: "test-token", apiBaseUrl: `http://127.0.0.1:${address.port}`, timeoutMs: 1000 });
+    assert.equal(chatId, "12345");
+  } finally {
+    await close(server);
+  }
+});
+
+function listen(server) {
+  return new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+}
+
+function close(server) {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}


### PR DESCRIPTION
## Summary
Make relaymux Telegram-first: Telegram now supports inbound bot messages, and Telegram setup can be a single command that stores the token and discovers the chat after `/start`.

- `relaymux setup --telegram --telegram-bot-token <token>` stores the token, waits for a Telegram chat, writes config, and starts the background service.
- `relaymux setup --imsg` remains the minimal iMessage/SMS setup path and is documented as beta.

## Design
### Telegram adapter
- `src/telegram.ts` — adds `getUpdates` polling, maps Telegram updates into the existing normalized message shape, filters to the configured chat, ignores bot-authored messages, and tracks the last Telegram update id in daemon state.
- `src/config.ts` — adds default Telegram receive settings for polling interval, sync limit, and timeout.
- `src/setup-telegram.ts` — enables Telegram receive by default, stores passed bot tokens in `~/.relaymux/secrets/telegram-bot-token`, and discovers the chat id from Bot API updates after the user sends `/start`.
- `test/setup-telegram.test.ts` — covers private token-file storage and chat-id discovery from `getUpdates`.

### Setup UX
- `src/cli.ts` — makes Telegram setup resolution async, wires the one-command token/chat-id discovery flow, preserves existing Telegram config when updating, and updates help/dry-run text.
- `src/setup-imsg.ts` — existing `relaymux setup --imsg` behavior already discovers/presents recent chats when possible; README now presents it as the minimal beta iMessage path.

### Daemon message routing
- `src/daemon.ts` — generalizes inbound jobs so iMessage and Telegram follow the same queue/orchestrator/reply path while preserving reply-through-same-channel behavior.
- `src/daemon.ts` — isolates iMessage and Telegram poll failures so one adapter failing does not block the other.
- `src/message-io.ts` — makes incoming prompt text channel-aware while keeping iMessage as the default wording for compatibility.

### Documentation
- `README.md` — replaces the broad README with a Telegram-first install/setup/use flow, the one-command Telegram setup, troubleshooting pointers, and a short beta iMessage/SMS section.

## Validation
- `npm run validate` — passed; 99/99 tests passing.
- Installed locally with `./install.sh` and restarted the LaunchAgent while testing Telegram inbound manually before the setup UX additions.