### PR TITLE
Install relaymux without cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ iMessage/SMS support exists, but it is beta.
 
 ## Requirements
 
-You need Node.js 20+, npm, git, tmux, and a local agent CLI such as `pi`, `codex`, or `claude`.
+You need Node.js 20+, npm, `tmux`, and a local agent CLI such as `pi`, `codex`, or `claude`. The installer uses `curl` and `tar` by default; it only needs `git` as a fallback.
 
 ## Install
 
 ```bash
-git clone https://github.com/mupt-ai/relaymux.git
-cd relaymux
-./install.sh
-export PATH="$HOME/.local/bin:$PATH"
+curl -fsSL https://raw.githubusercontent.com/mupt-ai/relaymux/main/install.sh | bash
 ```
+
+The installer downloads a source tarball, builds relaymux locally, and writes the CLI shim into a writable directory already on your `PATH` when possible. You do not need to clone the repo.
 
 ## Set up Telegram
 

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-prefix="${PREFIX:-$HOME/.local}"
-bin_dir="${BIN_DIR:-$prefix/bin}"
+default_prefix="$HOME/.local"
+prefix="${PREFIX:-$default_prefix}"
+prefix_explicit=0
+[[ -n "${PREFIX:-}" ]] && prefix_explicit=1
+bin_dir="${BIN_DIR:-}"
 install_dir="${INSTALL_DIR:-$prefix/lib/relaymux}"
-repo_url="${RELAYMUX_REPO_URL:-https://github.com/avyayv/relaymux.git}"
+repo_url="${RELAYMUX_REPO_URL:-https://github.com/mupt-ai/relaymux.git}"
 ref="${RELAYMUX_REF:-main}"
+tarball_url="${RELAYMUX_TARBALL_URL:-https://github.com/mupt-ai/relaymux/archive/${ref}.tar.gz}"
 work_dir=""
 
 usage() {
@@ -14,14 +18,15 @@ Install relaymux with a local build and a shell shim.
 
 Usage:
   ./install.sh [--prefix <dir>] [--bin-dir <dir>] [--install-dir <dir>]
-  curl -fsSL https://raw.githubusercontent.com/avyayv/relaymux/main/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/mupt-ai/relaymux/main/install.sh | bash
 
 Environment:
-  PREFIX             Base install prefix. Default: ~/.local
-  BIN_DIR            Directory for the relaymux shim. Default: $PREFIX/bin
-  INSTALL_DIR        Directory for app files. Default: $PREFIX/lib/relaymux
-  RELAYMUX_REPO_URL  Git repo to clone when run outside a checkout.
-  RELAYMUX_REF       Git ref to install when cloning. Default: main
+  PREFIX                Base install prefix. Default: ~/.local
+  BIN_DIR               Directory for the relaymux shim. Default: first writable PATH dir, then ~/.local/bin
+  INSTALL_DIR           Directory for app files. Default: $PREFIX/lib/relaymux
+  RELAYMUX_REF          GitHub ref to install when run outside a checkout. Default: main
+  RELAYMUX_TARBALL_URL  Tarball URL to download when run outside a checkout.
+  RELAYMUX_REPO_URL     Git repo fallback if curl/tar are unavailable.
 USAGE
 }
 
@@ -29,7 +34,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --prefix)
       prefix="$2"
-      bin_dir="${BIN_DIR:-$prefix/bin}"
+      prefix_explicit=1
       install_dir="${INSTALL_DIR:-$prefix/lib/relaymux}"
       shift 2
       ;;
@@ -60,17 +65,55 @@ need() {
   fi
 }
 
+path_has_dir() {
+  case ":$PATH:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+choose_bin_dir() {
+  if [[ "$prefix_explicit" -eq 1 ]]; then
+    printf '%s\n' "$prefix/bin"
+    return
+  fi
+
+  if path_has_dir "$HOME/.local/bin"; then
+    printf '%s\n' "$HOME/.local/bin"
+    return
+  fi
+
+  for dir in /opt/homebrew/bin /usr/local/bin; do
+    if [[ -d "$dir" ]] && path_has_dir "$dir" && [[ -w "$dir" ]]; then
+      printf '%s\n' "$dir"
+      return
+    fi
+  done
+
+  printf '%s\n' "$HOME/.local/bin"
+}
+
+if [[ -z "$bin_dir" ]]; then
+  bin_dir="$(choose_bin_dir)"
+fi
+
 need node
 need npm
 
 if [[ -f package.json && -d src && -d bin ]]; then
   src_dir="$PWD"
 else
-  need git
   work_dir="$(mktemp -d)"
   trap '[[ -n "$work_dir" ]] && rm -rf "$work_dir"' EXIT
-  git clone --depth 1 --branch "$ref" "$repo_url" "$work_dir/relaymux" >/dev/null
   src_dir="$work_dir/relaymux"
+  mkdir -p "$src_dir"
+
+  if command -v curl >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then
+    curl -fsSL "$tarball_url" | tar -xz --strip-components 1 -C "$src_dir"
+  else
+    need git
+    git clone --depth 1 --branch "$ref" "$repo_url" "$src_dir" >/dev/null
+  fi
 fi
 
 cd "$src_dir"
@@ -90,12 +133,26 @@ chmod +x "$bin_dir/relaymux"
 cat <<EOF
 relaymux installed to $install_dir
 CLI shim written to $bin_dir/relaymux
+EOF
 
-If needed, add this to your shell profile:
+if path_has_dir "$bin_dir"; then
+  cat <<EOF
+
+Next:
+  relaymux --version
+EOF
+else
+  cat <<EOF
+
+Add this to your shell profile, then open a new shell:
   export PATH="$bin_dir:\$PATH"
 
 Next:
   relaymux --version
+EOF
+fi
+
+cat <<EOF
   relaymux setup
   relaymux status
 

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/avyayv/relaymux.git"
+    "url": "git+https://github.com/mupt-ai/relaymux.git"
   },
   "bugs": {
-    "url": "https://github.com/avyayv/relaymux/issues"
+    "url": "https://github.com/mupt-ai/relaymux/issues"
   },
-  "homepage": "https://github.com/avyayv/relaymux#readme",
+  "homepage": "https://github.com/mupt-ai/relaymux#readme",
   "devDependencies": {
     "@types/node": "^25.9.2",
     "tsx": "^4.22.4",

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -98,7 +98,7 @@ export function renderSystemdUserServiceUnit({
   const env = renderSystemdEnvironment(environment);
   return `[Unit]
 Description=relaymux background daemon
-Documentation=https://github.com/avyayv/relaymux
+Documentation=https://github.com/mupt-ai/relaymux
 After=network.target
 
 [Service]


### PR DESCRIPTION
## Summary
Make the documented install path a curl one-liner that does not require users to clone the repo or manually export PATH in the common case.

- Installer downloads a source tarball by default when run outside a checkout.
- Installer writes the shim to a writable directory already on PATH when possible.
- Git is now only a fallback if curl/tar are unavailable.
- Repository metadata URLs now point at `mupt-ai/relaymux`.

## Design
### Installer
- `install.sh` — changes the default repo URL to `mupt-ai/relaymux`, adds `RELAYMUX_TARBALL_URL`, and downloads/extracts a GitHub tarball when the script is run outside a checkout.
- `install.sh` — chooses a PATH-visible bin dir by default: existing `~/.local/bin` if it is already on PATH, then writable Homebrew/system local bin dirs, then `~/.local/bin` with a PATH note only as fallback.
- `install.sh` — keeps explicit `PREFIX`/`BIN_DIR`, the existing local-checkout path, and git fallback behavior.

### Documentation and metadata
- `README.md` — replaces the git-clone install instructions with the curl install command and states that cloning is not required.
- `package.json` — updates repository, bugs, and homepage links to `mupt-ai/relaymux`.
- `src/launch-agent.ts` — updates the generated systemd documentation URL.

## Validation
- Tested tarball install path with a locally packed source tarball via `RELAYMUX_TARBALL_URL=file://...`; installed shim returned `relaymux 0.1.0`.
- Tested PATH-visible install with a temp HOME where `~/.local/bin` was already on PATH; installer wrote the shim there and did not print a PATH export step.
- `npm run validate` — passed; 99/99 tests passing.