### PR TITLE
Simplify setup and tolerate missing agent CLIs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,10 +40,6 @@ export async function main(argv, io = defaultIo()) {
       return 0;
     }
 
-    if (parsed.command === "init") {
-      return handleInit(parsed.flags, io, platform);
-    }
-
     if (parsed.command === "setup") {
       return handleSetup(parsed.flags, io, platform);
     }
@@ -140,7 +136,7 @@ async function handleSetup(flags, io, platform = process.platform) {
   }
 
   if (!configInfo.exists || flags.force || wantsAdapter) {
-    await handleInit({
+    await writeSetupConfig({
       ...flags,
       installLaunchAgent: false,
     }, io, platform);
@@ -152,15 +148,20 @@ async function handleSetup(flags, io, platform = process.platform) {
     }
   }
 
-  if (shouldInstallLaunchAgent) {
-    restartLaunchAgent({
-      flags: { load: flags.load, watchdog: flags.watchdog },
-      configInfo,
-      binPath: process.argv[1],
-      io,
-      platform,
-    });
+  if (!shouldInstallLaunchAgent) {
+    io.stdout.write("Background service installation skipped because --no-launch-agent was passed.\n");
+    io.stdout.write(`Config: ${configInfo.path}\n`);
+    io.stdout.write("Next: relaymux restart-launch-agent\n");
+    return 0;
   }
+
+  restartLaunchAgent({
+    flags: { load: flags.load, watchdog: flags.watchdog },
+    configInfo,
+    binPath: process.argv[1],
+    io,
+    platform,
+  });
 
   const status = handleDoctor(configInfo, io, platform);
   const launchAgent = getLaunchAgentStatus(configInfo.config, { platform, env: io.env });
@@ -169,7 +170,10 @@ async function handleSetup(flags, io, platform = process.platform) {
     return 1;
   }
   if (status === 0) {
-    io.stdout.write("Setup complete. relaymux is ready.\n");
+    const placeholderOrchestrator = configInfo.config.orchestrator?.placeholder === true;
+    io.stdout.write(placeholderOrchestrator
+      ? "Setup complete. The background service is running, but no real orchestrator CLI is configured yet.\n"
+      : "Setup complete. relaymux is ready.\n");
     io.stdout.write(`Config: ${configInfo.path}\n`);
     io.stdout.write(`Logs: ${resolveLogDir(configInfo.config, io.env)}\n`);
     io.stdout.write("Next steps:\n");
@@ -188,15 +192,20 @@ async function handleSetup(flags, io, platform = process.platform) {
     } else {
       io.stdout.write("  1. Use the local CLI/API path: `relaymux ask <text>` or `relaymux notify --reply-mode none ...`.\n");
     }
-    io.stdout.write("  2. Run `relaymux status` to inspect the daemon and any tmux agent tabs.\n");
-    io.stdout.write("  3. Use `relaymux launch --repo <path> --agent pi --prompt <task>` for a manual first agent.\n");
+    if (placeholderOrchestrator) {
+      io.stdout.write("  2. Install pi or edit ~/.relaymux/config.json so orchestrator.command points at your agent CLI.\n");
+      io.stdout.write("  3. Run `relaymux restart-launch-agent` after changing the orchestrator.\n");
+    } else {
+      io.stdout.write("  2. Run `relaymux status` to inspect the daemon and any tmux agent tabs.\n");
+      io.stdout.write("  3. Use `relaymux launch --repo <path> --agent pi --prompt <task>` for a manual first agent.\n");
+    }
   } else {
     io.stderr.write("Setup completed, but doctor found missing requirements. Fix the missing checks above and re-run `relaymux doctor`.\n");
   }
   return status;
 }
 
-async function handleInit(flags, io, platform = process.platform) {
+async function writeSetupConfig(flags, io, platform = process.platform) {
   const wantsImsg = Boolean(flags.imsg || flags.preset === "imsg");
   const wantsTelegram = Boolean(flags.telegram || flags.preset === "telegram");
   const wantsAdapter = wantsImsg || wantsTelegram;
@@ -257,7 +266,7 @@ async function handleInit(flags, io, platform = process.platform) {
     io.stdout.write("Next: relaymux restart-launch-agent (starts the background service)\n");
     io.stdout.write("Then: relaymux status-launch-agent && relaymux status\n");
   } else {
-    io.stdout.write("Tip: add optional adapters later with `relaymux init --imsg` or `relaymux init --telegram`.\n");
+    io.stdout.write("Tip: add optional adapters later with `relaymux setup --imsg --no-launch-agent` or `relaymux setup --telegram --no-launch-agent`.\n");
   }
   if (flags.installLaunchAgent) {
     installLaunchAgent({
@@ -1057,9 +1066,6 @@ Usage:
   relaymux setup --telegram --telegram-bot-token <token>
   relaymux setup --imsg
   relaymux setup [--imsg|--telegram] [--chat-id <id>] [--telegram-chat-id <id>] [--no-launch-agent] [--dry-run]
-  relaymux init [--force] [--config <path>]
-  relaymux init --imsg [--chat-id <id>] [--install-launch-agent]
-  relaymux init --telegram [--telegram-chat-id <id>] [--install-launch-agent]
   relaymux install-launch-agent [--dry-run] [--no-load] [--no-watchdog]
   relaymux restart-launch-agent [--dry-run] [--no-load] [--no-watchdog]
   relaymux status-launch-agent [--json]
@@ -1073,7 +1079,7 @@ Usage:
   relaymux migrate-home [--dry-run] [--apply] [--symlink]
   relaymux doctor
 
-Setup/init options:
+Setup options:
   --imsg                    Enable the optional iMessage/SMS adapter and prompt for a chat when possible
   --telegram                Enable the optional Telegram adapter; waits for /start when chat id is missing
   --chat-id <id>            Messages chat id/phone for imsg history/send; omit to pick from recent chats

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -87,6 +87,15 @@ export function collectDoctorChecks(config, configInfo, env = process.env, optio
   }
 
   checks.push(commandCheck("orchestrator", config.orchestrator?.command?.[0], env));
+  if (config.orchestrator?.placeholder === true) {
+    checks.push({
+      name: "orchestrator-configured",
+      ok: false,
+      fatal: false,
+      severity: "warning",
+      detail: "placeholder orchestrator is configured; install pi or edit ~/.relaymux/config.json to point orchestrator.command at your agent CLI",
+    });
+  }
 
   const imessage = getIntegration(config, "imessage");
   if (isIntegrationEnabled(config, "imessage")) {

--- a/src/launch-agent.ts
+++ b/src/launch-agent.ts
@@ -117,7 +117,7 @@ WantedBy=default.target
 
 export function installLaunchAgent({ flags, configInfo, binPath, io, platform = process.platform }) {
   if (!configInfo.exists) {
-    throw new Error(`Config does not exist at ${configInfo.path}. Run relaymux init first.`);
+    throw new Error(`Config does not exist at ${configInfo.path}. Run relaymux setup first.`);
   }
 
   if (platform === "linux") {

--- a/src/setup-agents.ts
+++ b/src/setup-agents.ts
@@ -1,0 +1,60 @@
+import { findExecutable } from "./doctor.js";
+
+export function buildSetupAgents(options: any = {}, env = process.env) {
+  const agents: Record<string, any> = {
+    custom: {
+      description: "Placeholder agent used when no local coding-agent CLI is installed.",
+      command: ["/bin/sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""],
+      promptMode: "env",
+    },
+  };
+
+  const pi = options.piPath || findExecutable("pi", env);
+  const codex = options.codexPath || findExecutable("codex", env);
+  const claude = options.claudePath || findExecutable("claude", env);
+
+  if (pi) {
+    agents.pi = {
+      description: "Default Pi subagent launched in tmux.",
+      command: [pi, "{prompt}"],
+      promptMode: "arg",
+    };
+  }
+  if (codex) {
+    agents.codex = {
+      description: "Codex subagent. Edit flags to match your local install.",
+      command: [codex, "{prompt}"],
+      promptMode: "arg",
+    };
+  }
+  if (claude) {
+    agents.claude = {
+      description: "Claude subagent.",
+      command: [claude, "{prompt}"],
+      promptMode: "arg",
+    };
+  }
+
+  return agents;
+}
+
+export function buildSetupOrchestrator(options: any = {}, env = process.env) {
+  const sessionDir = options.sessionDir || (options.stateDir ? `${options.stateDir}/sessions` : "~/.relaymux/state/sessions");
+  const pi = options.piPath || findExecutable("pi", env);
+  const cwd = options.cwd || "~";
+  if (pi) {
+    return {
+      cwd,
+      command: [pi, "--print", "--continue", "--session-dir", sessionDir, "{prompt}"],
+      promptMode: "arg",
+    };
+  }
+
+  return {
+    description: "Placeholder orchestrator. Install pi or edit ~/.relaymux/config.json to use a real local agent CLI.",
+    placeholder: true,
+    cwd,
+    command: ["/bin/sh", "-lc", "printf '%s\\n' 'relaymux Telegram transport is running, but no orchestrator CLI is configured yet. Install pi or edit ~/.relaymux/config.json to point orchestrator.command at your agent.'"],
+    promptMode: "env",
+  };
+}

--- a/src/setup-imsg.ts
+++ b/src/setup-imsg.ts
@@ -5,6 +5,7 @@ import { defaultConfig, defaultImessageIntegration } from "./config.js";
 import { findExecutable } from "./doctor.js";
 import { expandPath } from "./paths.js";
 import { runCommand } from "./process.js";
+import { buildSetupAgents, buildSetupOrchestrator } from "./setup-agents.js";
 
 export function buildImsgConfig(options: any = {}, env = process.env) {
   const base = defaultConfig(env);
@@ -12,9 +13,6 @@ export function buildImsgConfig(options: any = {}, env = process.env) {
   const sessionDir = path.posix.join(stateDir, "sessions");
   const logDir = options.logDir || (options.stateDir ? path.posix.join(stateDir, "logs") : base.daemon.logDir);
   const imsg = options.imsgPath || findExecutable("imsg", env) || "imsg";
-  const pi = options.piPath || findExecutable("pi", env) || "pi";
-  const codex = options.codexPath || findExecutable("codex", env) || "codex";
-  const claude = options.claudePath || findExecutable("claude", env) || "claude";
   const chatId = options.chatId || options.recipient || "CHAT_ID_OR_PHONE";
   const cwd = options.cwd || "~";
 
@@ -64,27 +62,9 @@ export function buildImsgConfig(options: any = {}, env = process.env) {
     },
     orchestrator: {
       ...base.orchestrator,
-      cwd,
-      command: [pi, "--print", "--continue", "--session-dir", sessionDir, "{prompt}"],
-      promptMode: "arg",
+      ...buildSetupOrchestrator({ ...options, cwd, sessionDir }, env),
     },
-    agents: {
-      pi: {
-        description: "Default Pi subagent launched in tmux.",
-        command: [pi, "{prompt}"],
-        promptMode: "arg",
-      },
-      codex: {
-        description: "Codex subagent. Edit flags to match your local install.",
-        command: [codex, "{prompt}"],
-        promptMode: "arg",
-      },
-      claude: {
-        description: "Claude subagent.",
-        command: [claude, "{prompt}"],
-        promptMode: "arg",
-      },
-    },
+    agents: buildSetupAgents(options, env),
   };
 }
 

--- a/src/setup-telegram.ts
+++ b/src/setup-telegram.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import readline from "node:readline/promises";
 
 import { defaultConfig, defaultTelegramIntegration } from "./config.js";
-import { findExecutable } from "./doctor.js";
 import { expandPath } from "./paths.js";
+import { buildSetupAgents, buildSetupOrchestrator } from "./setup-agents.js";
 import { resolveTelegramToken } from "./telegram.js";
 
 export function buildTelegramIntegration(options: any = {}) {
@@ -49,9 +49,6 @@ export function buildTelegramConfig(options: any = {}, env = process.env) {
   const stateDir = options.stateDir || base.stateDir;
   const sessionDir = path.posix.join(stateDir, "sessions");
   const logDir = options.logDir || (options.stateDir ? path.posix.join(stateDir, "logs") : base.daemon.logDir);
-  const pi = options.piPath || findExecutable("pi", env) || "pi";
-  const codex = options.codexPath || findExecutable("codex", env) || "codex";
-  const claude = options.claudePath || findExecutable("claude", env) || "claude";
   const cwd = options.cwd || "~";
 
   return withTelegramIntegration({
@@ -67,27 +64,9 @@ export function buildTelegramConfig(options: any = {}, env = process.env) {
     },
     orchestrator: {
       ...base.orchestrator,
-      cwd,
-      command: [pi, "--print", "--continue", "--session-dir", sessionDir, "{prompt}"],
-      promptMode: "arg",
+      ...buildSetupOrchestrator({ ...options, cwd, sessionDir }, env),
     },
-    agents: {
-      pi: {
-        description: "Default Pi subagent launched in tmux.",
-        command: [pi, "{prompt}"],
-        promptMode: "arg",
-      },
-      codex: {
-        description: "Codex subagent. Edit flags to match your local install.",
-        command: [codex, "{prompt}"],
-        promptMode: "arg",
-      },
-      claude: {
-        description: "Claude subagent.",
-        command: [claude, "{prompt}"],
-        promptMode: "arg",
-      },
-    },
+    agents: buildSetupAgents(options, env),
   }, { ...options, defaultReplyMode: options.defaultReplyMode || "telegram" });
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -270,31 +270,31 @@ test("install-launch-agent rejects tmux supervisor mode", async () => {
   assert.match(harness.stderr, /tmux mode has been removed/);
 });
 
-test("init --imsg merges adapter into existing config without overwriting core settings", async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-init-merge-"));
+test("setup --imsg --no-launch-agent merges adapter into existing config without overwriting core settings", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-setup-merge-"));
   const configPath = path.join(dir, "config.json");
   const config = defaultConfig();
   config.session = "kept-session";
-  config.orchestrator.command = ["custom-orchestrator", "{prompt}"];
+  config.orchestrator.command = ["/bin/sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""];
   config.agents.local = { command: ["local-agent", "{prompt}"], promptMode: "arg" };
   writeConfig(configPath, config, { force: true });
 
   const harness = makeIo();
-  const code = await main(["--config", configPath, "init", "--imsg", "--chat-id", "chat-1"], harness.io);
+  const code = await main(["--config", configPath, "setup", "--imsg", "--chat-id", "chat-1", "--no-launch-agent"], harness.io);
   const updated = loadConfig({ configPath }).config;
 
   assert.equal(code, 0);
   assert.match(harness.stdout, /Updated .* with iMessage\/SMS adapter defaults/);
   assert.doesNotMatch(harness.stdout, /doctor &&/);
   assert.equal(updated.session, "kept-session");
-  assert.deepEqual(updated.orchestrator.command, ["custom-orchestrator", "{prompt}"]);
+  assert.deepEqual(updated.orchestrator.command, ["/bin/sh", "-lc", "printf '%s\\n' \"$RELAYMUX_PROMPT\""]);
   assert.deepEqual(updated.agents.local.command, ["local-agent", "{prompt}"]);
   assert.equal(updated.integrations.imessage.enabled, true);
   assert.equal(updated.integrations.imessage.chatId, "chat-1");
 });
 
-test("init --imsg is idempotent on an existing imsg config without prompting", async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-init-imsg-idempotent-"));
+test("setup --imsg --no-launch-agent is idempotent on an existing imsg config without prompting", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-setup-imsg-idempotent-"));
   const configPath = path.join(dir, "config.json");
   const config = defaultConfig();
   config.integrations.imessage = {
@@ -304,7 +304,7 @@ test("init --imsg is idempotent on an existing imsg config without prompting", a
   writeConfig(configPath, config, { force: true });
 
   const harness = makeIo();
-  const code = await main(["--config", configPath, "init", "--imsg"], harness.io);
+  const code = await main(["--config", configPath, "setup", "--imsg", "--no-launch-agent"], harness.io);
   const updated = loadConfig({ configPath }).config;
 
   assert.equal(code, 0);
@@ -326,7 +326,7 @@ test("setup --imsg guidance uses separate recovery commands", async () => {
   assert.equal(code, 0);
   assert.match(harness.stdout, /Updated|Created/);
   assert.match(harness.stdout, /Next: relaymux restart-launch-agent/);
-  assert.match(harness.stdout, /Logs:/);
+  assert.match(harness.stdout, /Background service installation skipped/);
   assert.doesNotMatch(harness.stdout, /doctor && relaymux restart-launch-agent && relaymux status/);
 });
 

--- a/test/setup-imsg.test.ts
+++ b/test/setup-imsg.test.ts
@@ -42,7 +42,8 @@ test("buildImsgConfig creates usable imsg defaults", () => {
   ]);
   assert.equal(config.daemon.tokenFile, "~/.state/relaymux-test/webhook-token");
   assert.equal(config.daemon.port, 49999);
-  assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);
+  assert.deepEqual(config.agents.pi.command, ["/usr/local/bin/pi", "{prompt}"]);
+  assert.ok(config.agents.custom);
 });
 
 test("formatChat shows id and label", () => {

--- a/test/setup-telegram.test.ts
+++ b/test/setup-telegram.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { discoverTelegramChatId, resolveTelegramTokenFile } from "../src/setup-telegram.js";
+import { buildTelegramConfig, discoverTelegramChatId, resolveTelegramTokenFile } from "../src/setup-telegram.js";
 
 test("resolveTelegramTokenFile stores a passed bot token privately", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-telegram-token-"));
@@ -40,6 +40,14 @@ test("discoverTelegramChatId reads the first human chat from getUpdates", async 
   } finally {
     await close(server);
   }
+});
+
+test("buildTelegramConfig uses a placeholder orchestrator when no agent CLI is installed", () => {
+  const config = buildTelegramConfig({ telegramChatId: "123", telegramBotTokenFile: "/tmp/token" }, { PATH: "" });
+
+  assert.equal(config.orchestrator.command[0], "/bin/sh");
+  assert.ok(config.orchestrator.description.includes("Placeholder orchestrator"));
+  assert.ok(config.agents.custom);
 });
 
 function listen(server) {


### PR DESCRIPTION
## Summary
Simplify setup by removing the user-facing `init` command, keep `setup` responsible for starting the background service, and make missing agent CLIs explicit instead of a crash.

- `relaymux setup --telegram` / `relaymux setup --imsg` are now the only public setup paths.
- Setup still installs/restarts the background service by default.
- If no orchestrator CLI is installed, setup starts the transport but clearly warns that no real orchestrator is configured yet.

## Design
### Setup command surface
- `src/cli.ts` — removes the public `init` command path and help text so users are not asked to choose between `init` and `setup`.
- `src/cli.ts` — keeps the config-writing routine as an internal setup helper used by `relaymux setup`.
- `src/cli.ts` — changes setup completion text when a placeholder orchestrator is configured: the daemon can run, but users must install/configure an orchestrator before relaymux is useful for real work.
- `src/launch-agent.ts` — updates missing-config guidance to point at `relaymux setup`.
- `test/cli.test.ts` — moves adapter merge/idempotency coverage to `setup --no-launch-agent`, which is now the config-only path.

### Missing agent CLI tolerance
- `src/setup-agents.ts` — adds shared helpers for setup-time agent/orchestrator config. If `pi` exists, it remains the noninteractive orchestrator. If not, setup uses a `/bin/sh` placeholder that tells the user to install/configure an orchestrator instead of making setup fail with a missing binary.
- `src/setup-agents.ts` — marks that placeholder with `orchestrator.placeholder = true` so doctor/setup can warn honestly.
- `src/doctor.ts` — reports placeholder orchestrators as warnings, not as a hidden success.
- `src/setup-agents.ts` — adds only detected `pi`, `codex`, and `claude` agent entries, plus a `custom` placeholder, so fresh machines do not get noisy missing-agent configs from setup.
- `src/setup-telegram.ts` — uses the shared setup helpers so Telegram setup succeeds on machines that do not have `pi`, `codex`, or `claude` installed yet.
- `src/setup-imsg.ts` — applies the same behavior to beta iMessage/SMS setup.

### Tests
- `test/setup-telegram.test.ts` — covers placeholder orchestrator behavior when no agent CLI is available.
- `test/setup-imsg.test.ts` — updates setup expectations for explicit `piPath` plus the always-available custom agent.

## Validation
- `npm run validate` — passed; 100/100 tests passing.