### PR TITLE
Add Flue cloud agent scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Manual notification test:
 relaymux notify --from test --reply-mode telegram --message "hello from relaymux"
 ```
 
+## Optional cloud-agent scaffold
+
+The default relaymux path is local-first. For advanced deployments where Telegram should live in a cloud process and the actual repo/CLI/tmux work should happen in a sandbox, relaymux can generate a starter Flue cloud-agent bundle:
+
+```bash
+relaymux cloud scaffold --flue --out ./relaymux-cloud-agent
+```
+
+See [docs/cloud-agent.md](docs/cloud-agent.md). This is a scaffold and protocol boundary, not a hosted production service.
+
 ## tmux is the workspace
 
 relaymux uses one shared `tmux` session named `agents` by default. Each launched agent gets its own tmux window. This is the core idea: Telegram starts and receives updates from work, but tmux keeps that work visible and recoverable locally.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,5 @@ Start with the [README quickstart](../README.md). The docs here hold the details
 
 - [Configuration](configuration.md): config shape, prompt passing, tmux sessions, and common launch patterns.
 - [Integrations](integrations.md): local API, `relaymux ask`, `relaymux notify`, scheduled prompts, iMessage/SMS, and Telegram.
+- [Cloud Agent](cloud-agent.md): optional Flue scaffold and sandbox hands protocol.
 - [Operations](operations.md): background service, watchdog, safety model, troubleshooting, and development commands.

--- a/docs/cloud-agent.md
+++ b/docs/cloud-agent.md
@@ -1,0 +1,117 @@
+# Cloud Agent
+
+relaymux is local-first by default. The cloud-agent path is an optional advanced topology for keeping Telegram configuration in a cloud process while repository, CLI, filesystem, and tmux actions stay inside a sandbox.
+
+```text
+Telegram
+  -> Flue cloud agent
+  -> authenticated sandbox hands endpoint
+  -> relaymux daemon/orchestrator in the sandbox
+  -> tmux child window
+  -> sandbox completion callback
+  -> Telegram
+```
+
+This first slice defines the boundary and generates a minimal Flue bundle. It does not deploy a hosted service and does not include a production sandbox hands server.
+
+## Scaffold
+
+Generate the starter bundle:
+
+```bash
+relaymux cloud scaffold --flue --out ./relaymux-cloud-agent
+```
+
+The scaffold writes:
+
+- `flue.yml`: Flue runtime metadata with env placeholders.
+- `package.json`: Node 20 smoke scripts.
+- `src/cloud-agent.mjs`: Telegram webhook receiver and sandbox client.
+- `README.md`: bundle-local setup notes.
+
+Run a local syntax check:
+
+```bash
+cd ./relaymux-cloud-agent
+npm install
+npm run check
+```
+
+## Configuration Shape
+
+The local relaymux config includes a disabled-by-default `cloudAgent` section:
+
+```json
+{
+  "cloudAgent": {
+    "enabled": false,
+    "provider": "flue",
+    "role": "chat",
+    "telegram": {
+      "botTokenEnv": "TELEGRAM_BOT_TOKEN",
+      "webhookSecretEnv": "RELAYMUX_TELEGRAM_WEBHOOK_SECRET"
+    },
+    "sandbox": {
+      "protocol": "relaymux-sandbox-hands-v1",
+      "baseUrlEnv": "RELAYMUX_SANDBOX_BASE_URL",
+      "authTokenEnv": "RELAYMUX_SANDBOX_TOKEN",
+      "completionCallbackTokenEnv": "RELAYMUX_CLOUD_CALLBACK_TOKEN"
+    }
+  }
+}
+```
+
+These are env var names, not secret values. Keep Telegram tokens in the cloud secret store. Keep sandbox auth tokens in both the cloud secret store and the sandbox runtime secret store.
+
+## Sandbox Hands Protocol
+
+The scaffold calls the sandbox with bearer auth:
+
+```http
+POST /relaymux/v1/ask
+Authorization: Bearer <RELAYMUX_SANDBOX_TOKEN>
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "protocol": "relaymux-sandbox-hands-v1",
+  "operation": "ask",
+  "source": "telegram",
+  "text": "Open an agent in ~/code/my-app and inspect the failing tests.",
+  "replyMode": "none",
+  "wait": true,
+  "idempotencyKey": "telegram:<chat-id>:<message-id>",
+  "metadata": {
+    "telegram": {
+      "chatId": "<chat-id>",
+      "messageId": "<message-id>",
+      "updateId": "<update-id>"
+    }
+  }
+}
+```
+
+Expected response:
+
+```json
+{
+  "ok": true,
+  "queued": false,
+  "requestId": "sandbox-request-id",
+  "reply": "Started a child agent in tmux session agents."
+}
+```
+
+Future sandbox hands can also expose `operation: "launch"` for direct child-agent launches and call the cloud agent's `POST /relaymux/v1/completion` endpoint when a sandboxed `relaymux notify` event should be sent back to Telegram.
+
+## Security Notes
+
+- Do not expose the sandbox hands endpoint publicly without bearer auth.
+- Keep the existing relaymux daemon on loopback inside the sandbox. Put any network-facing bridge in front of it with a narrow protocol.
+- Do not put literal Telegram tokens, sandbox tokens, cookies, or repository secrets in config files, prompts, logs, or scaffold output.
+- Use stable idempotency keys for Telegram update retries and completion retries.
+- Treat the cloud agent as the chat/model process and the sandbox as the only place allowed to touch repos, CLIs, files, or tmux.
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,10 @@ An agent is a command template in `~/.relaymux/config.json`. If you configure `p
 
 The orchestrator is also a command, but it has a different job from an agent. The orchestrator handles inbound requests from `relaymux ask` or optional message adapters. Agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply on stdout.
 
+## Cloud Agent Config
+
+`cloudAgent` is disabled by default and only describes the optional cloud-agent boundary. The first supported provider is `flue`; secret-bearing fields are env var names such as `TELEGRAM_BOT_TOKEN`, `RELAYMUX_SANDBOX_BASE_URL`, and `RELAYMUX_SANDBOX_TOKEN`, never literal token values. Generate the starter bundle with `relaymux cloud scaffold --flue --out <dir>` and see [Cloud Agent](cloud-agent.md) for the sandbox hands protocol.
+
 ## Prompt Passing
 
 If a command contains `{prompt}` or `{promptFile}`, relaymux substitutes those values. Agent command templates can also use run context such as `{agent}`, `{name}`, `{repo}`, `{workdir}`, `{runId}`, and `{session}`. If the command does not contain a prompt placeholder, `promptMode` decides what to do with the prompt:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -108,7 +108,7 @@ relaymux notify \
 
 ## Telegram
 
-The Telegram adapter is optional outbound notification support through `sendMessage`. It does not poll Telegram for inbound messages.
+The Telegram adapter is optional inbound and outbound support through the Telegram Bot API. Local relaymux polls `getUpdates` when receive is enabled and sends replies with `sendMessage`.
 
 Create a bot with BotFather, get a chat id for the chat you want to notify, and store the token outside the public config. A token file works well with the background service because it does not depend on your interactive shell environment:
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,6 +6,7 @@ const BOOLEAN_FLAGS = new Set([
   "create-worktree",
   "dry-run",
   "force",
+  "flue",
   "help",
   "history",
   "hold",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 
 import { parseArgv } from "./args.js";
+import { cloudHelpText, handleCloud } from "./cloud-cli.js";
 import { buildAgentInvocation, buildTmuxShellCommand, buildTmuxShellScript, quoteArgv, renderTemplate, shellExportBlock } from "./command.js";
 import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
@@ -35,6 +36,10 @@ export async function main(argv, io = defaultIo()) {
       io.stdout.write(scheduleHelpText());
       return 0;
     }
+    if (parsed.flags.help && parsed.command === "cloud") {
+      io.stdout.write(cloudHelpText());
+      return 0;
+    }
     if (parsed.flags.help || parsed.command === "help") {
       io.stdout.write(helpText());
       return 0;
@@ -42,6 +47,9 @@ export async function main(argv, io = defaultIo()) {
 
     if (parsed.command === "setup") {
       return handleSetup(parsed.flags, io, platform);
+    }
+    if (parsed.command === "cloud") {
+      return handleCloud(parsed.flags, parsed.positionals, io);
     }
 
     const configInfo = loadConfig({ configPath: parsed.flags.config, env: io.env });
@@ -1074,6 +1082,7 @@ Usage:
   relaymux ask <text> [--no-wait] [--reply-mode imessage|telegram|none]
   relaymux schedule add --name <name> --prompt <text> --cron "0 9 * * *" [--reply-mode none|imessage|telegram] [--scheduler auto|launchd|cron]
   relaymux schedule list|remove [--name <name>]
+  relaymux cloud scaffold --flue --out <dir>
   relaymux status [--json] [--session <name>]
   relaymux notify [--run-id <id>] [--reply-mode imessage|telegram|none] [--message <text>]
   relaymux migrate-home [--dry-run] [--apply] [--symlink]
@@ -1140,6 +1149,11 @@ Schedule options:
   --prompt-file <path>       Read scheduled prompt text from a file
   --reply-mode <mode>        Scheduled ask reply mode: none, imessage, or telegram
   --no-load                  Write schedule files without installing/loading the OS job
+
+Cloud options:
+  --flue                    Generate a Flue cloud-agent scaffold
+  --out <dir>               Output directory for cloud scaffold
+  --force                   Overwrite generated scaffold files
 
 Useful commands:
   tmux attach -t <session>       attach to the shared or named agent session

--- a/src/cloud-cli.ts
+++ b/src/cloud-cli.ts
@@ -1,0 +1,49 @@
+import { scaffoldCloudAgent } from "./cloud-scaffold.js";
+
+export function handleCloud(flags, positionals, io) {
+  const action = String(positionals[0] || "help");
+  switch (action) {
+    case "scaffold": {
+      const result = scaffoldCloudAgent({
+        outDir: flags.out,
+        force: Boolean(flags.force),
+        flue: Boolean(flags.flue),
+      });
+      io.stdout.write(`Created Flue cloud-agent scaffold at ${result.root}\n`);
+      for (const file of result.files) {
+        io.stdout.write(`  ${file}\n`);
+      }
+      io.stdout.write("Next: wire the generated env placeholders in Flue and point the sandbox hands service at a private authenticated endpoint.\n");
+      return 0;
+    }
+    case "help":
+      io.stdout.write(cloudHelpText());
+      return 0;
+    default:
+      throw new Error(`Unknown cloud command "${action}". Use relaymux cloud help.`);
+  }
+}
+
+export function cloudHelpText() {
+  return `relaymux cloud - advanced cloud-agent scaffolding
+
+relaymux cloud is optional. Local relaymux remains the default path: Telegram or
+iMessage can still talk directly to the local background daemon and tmux tabs.
+
+Usage:
+  relaymux cloud scaffold --flue --out <dir> [--force]
+  relaymux cloud help
+
+Options:
+  --flue        Generate the Flue cloud-agent scaffold
+  --out <dir>   Output directory for the generated bundle
+  --force       Overwrite generated files in an existing directory
+
+The scaffold uses env var placeholders for all secrets:
+  TELEGRAM_BOT_TOKEN
+  RELAYMUX_TELEGRAM_WEBHOOK_SECRET
+  RELAYMUX_SANDBOX_BASE_URL
+  RELAYMUX_SANDBOX_TOKEN
+  RELAYMUX_CLOUD_CALLBACK_TOKEN
+`;
+}

--- a/src/cloud-protocol.ts
+++ b/src/cloud-protocol.ts
@@ -1,0 +1,178 @@
+export const RELAYMUX_CLOUD_AGENT_PROTOCOL = "relaymux-cloud-agent-v1";
+export const RELAYMUX_SANDBOX_HANDS_PROTOCOL = "relaymux-sandbox-hands-v1";
+
+export const RELAYMUX_CLOUD_AGENT_ENV = {
+  telegramBotToken: "TELEGRAM_BOT_TOKEN",
+  telegramWebhookSecret: "RELAYMUX_TELEGRAM_WEBHOOK_SECRET",
+  sandboxBaseUrl: "RELAYMUX_SANDBOX_BASE_URL",
+  sandboxAuthToken: "RELAYMUX_SANDBOX_TOKEN",
+  cloudCallbackToken: "RELAYMUX_CLOUD_CALLBACK_TOKEN",
+};
+
+export const SANDBOX_HAND_OPERATIONS = new Set(["ask", "launch", "notify"]);
+
+export type SandboxHandOperation = "ask" | "launch" | "notify";
+export type SandboxReplyMode = "none" | "imessage" | "telegram";
+export type CloudMetadata = Record<string, unknown>;
+
+export type SandboxCallback = {
+  url: string;
+  authTokenEnv?: string;
+};
+
+export type SandboxAskRequestInput = {
+  text?: string;
+  message?: string;
+  source?: string;
+  replyMode?: SandboxReplyMode;
+  wait?: boolean;
+  idempotencyKey?: string;
+  metadata?: CloudMetadata;
+  callback?: SandboxCallback;
+};
+
+export type SandboxLaunchRequestInput = {
+  repo?: string;
+  agent?: string;
+  name?: string;
+  prompt?: string;
+  text?: string;
+  message?: string;
+  idempotencyKey?: string;
+  metadata?: CloudMetadata;
+  notify?: {
+    callback?: SandboxCallback;
+    idempotencyKey?: string;
+    replyMode?: SandboxReplyMode;
+  };
+};
+
+export type SandboxNotifyRequestInput = {
+  from?: string;
+  source?: string;
+  text?: string;
+  message?: string;
+  idempotencyKey?: string;
+  metadata?: CloudMetadata;
+};
+
+export function buildSandboxAskRequest(input: SandboxAskRequestInput = {}) {
+  const text = requireNonEmptyString(input.text ?? input.message, "text");
+  return {
+    protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+    operation: "ask",
+    text,
+    source: normalizeSource(input.source),
+    replyMode: normalizeReplyMode(input.replyMode),
+    wait: input.wait !== false,
+    idempotencyKey: normalizeOptionalString(input.idempotencyKey),
+    metadata: normalizeMetadata(input.metadata),
+    callback: normalizeCallback(input.callback),
+  };
+}
+
+export function buildSandboxLaunchRequest(input: SandboxLaunchRequestInput = {}) {
+  return {
+    protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+    operation: "launch",
+    repo: requireNonEmptyString(input.repo, "repo"),
+    agent: requireNonEmptyString(input.agent, "agent"),
+    name: normalizeOptionalString(input.name),
+    prompt: requireNonEmptyString(input.prompt ?? input.text ?? input.message, "prompt"),
+    idempotencyKey: normalizeOptionalString(input.idempotencyKey),
+    metadata: normalizeMetadata(input.metadata),
+    notify: normalizeNotify(input.notify),
+  };
+}
+
+export function buildSandboxNotifyRequest(input: SandboxNotifyRequestInput = {}) {
+  return {
+    protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+    operation: "notify",
+    from: requireNonEmptyString(input.from ?? input.source, "from"),
+    text: requireNonEmptyString(input.text ?? input.message, "text"),
+    idempotencyKey: normalizeOptionalString(input.idempotencyKey),
+    metadata: normalizeMetadata(input.metadata),
+  };
+}
+
+export function normalizeSandboxEnvelope(body: unknown, expectedOperation?: SandboxHandOperation) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("sandbox hand request must be a JSON object");
+  }
+  const raw = body as Record<string, unknown>;
+  const protocol = String(raw.protocol || "");
+  if (protocol !== RELAYMUX_SANDBOX_HANDS_PROTOCOL) {
+    throw new Error(`sandbox hand protocol must be ${RELAYMUX_SANDBOX_HANDS_PROTOCOL}`);
+  }
+
+  const operation = String(raw.operation || "");
+  if (!isSandboxHandOperation(operation)) {
+    throw new Error("sandbox hand operation must be ask, launch, or notify");
+  }
+  if (expectedOperation && operation !== expectedOperation) {
+    throw new Error(`sandbox hand operation must be ${expectedOperation}`);
+  }
+
+  return { ...raw, protocol, operation };
+}
+
+function normalizeSource(value: string | undefined) {
+  return String(value || "relaymux-cloud-agent").slice(0, 200);
+}
+
+function normalizeReplyMode(value: SandboxReplyMode | undefined) {
+  const replyMode = String(value || "none");
+  if (!["none", "imessage", "telegram"].includes(replyMode)) {
+    throw new Error("replyMode must be none, imessage, or telegram");
+  }
+  return replyMode as SandboxReplyMode;
+}
+
+function normalizeMetadata(value: CloudMetadata | undefined) {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("metadata must be a JSON object");
+  }
+  return value;
+}
+
+function normalizeCallback(value: SandboxCallback | undefined) {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("callback must be a JSON object");
+  }
+  const url = requireNonEmptyString(value.url, "callback.url");
+  return {
+    url,
+    authTokenEnv: normalizeOptionalString(value.authTokenEnv) || RELAYMUX_CLOUD_AGENT_ENV.cloudCallbackToken,
+  };
+}
+
+function normalizeNotify(value: SandboxLaunchRequestInput["notify"] | undefined) {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("notify must be a JSON object");
+  }
+  return {
+    callback: value.callback ? normalizeCallback(value.callback) : undefined,
+    idempotencyKey: normalizeOptionalString(value.idempotencyKey),
+    replyMode: normalizeReplyMode(value.replyMode),
+  };
+}
+
+function requireNonEmptyString(value: unknown, field: string) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
+function normalizeOptionalString(value: unknown) {
+  if (value === undefined || value === null || value === "") return undefined;
+  return String(value);
+}
+
+function isSandboxHandOperation(value: string): value is SandboxHandOperation {
+  return SANDBOX_HAND_OPERATIONS.has(value);
+}

--- a/src/cloud-scaffold.ts
+++ b/src/cloud-scaffold.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  RELAYMUX_CLOUD_AGENT_ENV,
+  RELAYMUX_CLOUD_AGENT_PROTOCOL,
+  RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+} from "./cloud-protocol.js";
+import { ensureDirectory, expandPath } from "./paths.js";
+
+export type CloudScaffoldOptions = {
+  outDir?: string;
+  force?: boolean;
+  flue?: boolean;
+};
+
+type CloudScaffoldFile = {
+  path: string;
+  content: string;
+  mode?: number;
+};
+
+export function scaffoldCloudAgent({ outDir, force = false, flue = false }: CloudScaffoldOptions = {}) {
+  if (!flue) {
+    throw new Error("cloud scaffold currently supports only --flue");
+  }
+  if (!outDir) {
+    throw new Error("Missing --out <dir>");
+  }
+
+  const root = expandPath(String(outDir));
+  const files = cloudScaffoldFiles();
+  if (fs.existsSync(root) && fs.readdirSync(root).length > 0 && !force) {
+    throw new Error(`Output directory is not empty: ${root}. Use --force to overwrite generated files.`);
+  }
+
+  ensureDirectory(root);
+  const written: string[] = [];
+  for (const file of files) {
+    const target = path.join(root, file.path);
+    if (fs.existsSync(target) && !force) {
+      throw new Error(`Refusing to overwrite ${target}. Use --force.`);
+    }
+    ensureDirectory(path.dirname(target));
+    fs.writeFileSync(target, file.content, { mode: file.mode || 0o644 });
+    written.push(target);
+  }
+
+  return { root, files: written };
+}
+
+export function cloudScaffoldFiles(): CloudScaffoldFile[] {
+  return [
+    { path: "README.md", content: renderBundleReadme() },
+    { path: "package.json", content: renderPackageJson() },
+    { path: "flue.yml", content: renderFlueYaml() },
+    { path: "src/cloud-agent.mjs", content: renderCloudAgent() },
+  ];
+}
+
+function renderPackageJson() {
+  return `${JSON.stringify({
+    name: "relaymux-flue-cloud-agent",
+    private: true,
+    type: "module",
+    scripts: {
+      start: "node src/cloud-agent.mjs",
+      check: "node --check src/cloud-agent.mjs",
+    },
+    engines: {
+      node: ">=20",
+    },
+  }, null, 2)}\n`;
+}
+
+function renderFlueYaml() {
+  return [
+    "schema_version: 1",
+    "name: relaymux-cloud-agent",
+    "runtime:",
+    "  command: npm start",
+    "  port: 8787",
+    "  health_path: /health",
+    "env:",
+    `  ${RELAYMUX_CLOUD_AGENT_ENV.telegramBotToken}: \${${RELAYMUX_CLOUD_AGENT_ENV.telegramBotToken}}`,
+    `  ${RELAYMUX_CLOUD_AGENT_ENV.telegramWebhookSecret}: \${${RELAYMUX_CLOUD_AGENT_ENV.telegramWebhookSecret}}`,
+    `  ${RELAYMUX_CLOUD_AGENT_ENV.sandboxBaseUrl}: \${${RELAYMUX_CLOUD_AGENT_ENV.sandboxBaseUrl}}`,
+    `  ${RELAYMUX_CLOUD_AGENT_ENV.sandboxAuthToken}: \${${RELAYMUX_CLOUD_AGENT_ENV.sandboxAuthToken}}`,
+    `  ${RELAYMUX_CLOUD_AGENT_ENV.cloudCallbackToken}: \${${RELAYMUX_CLOUD_AGENT_ENV.cloudCallbackToken}}`,
+    "",
+  ].join("\n");
+}
+
+function renderBundleReadme() {
+  return [
+    "# relaymux Flue cloud agent scaffold",
+    "",
+    "This bundle is a starting point for the optional cloud-agent topology:",
+    "",
+    "```text",
+    "Telegram -> Flue cloud agent -> authenticated sandbox hands -> relaymux/tmux",
+    "                                 sandbox completion callback -> Telegram",
+    "```",
+    "",
+    "It is intentionally small. It does not deploy relaymux or expose command execution by itself; it only receives Telegram webhook payloads and calls a sandbox hands endpoint that must enforce its own auth and isolation.",
+    "",
+    "## Environment",
+    "",
+    "| Name | Purpose |",
+    "| --- | --- |",
+    `| \`${RELAYMUX_CLOUD_AGENT_ENV.telegramBotToken}\` | Telegram Bot API token in the cloud runtime. |`,
+    `| \`${RELAYMUX_CLOUD_AGENT_ENV.telegramWebhookSecret}\` | Optional Telegram webhook secret checked against \`X-Telegram-Bot-Api-Secret-Token\`. |`,
+    `| \`${RELAYMUX_CLOUD_AGENT_ENV.sandboxBaseUrl}\` | HTTPS base URL for the sandbox hands service. |`,
+    `| \`${RELAYMUX_CLOUD_AGENT_ENV.sandboxAuthToken}\` | Bearer token used when the cloud agent calls sandbox hands. |`,
+    `| \`${RELAYMUX_CLOUD_AGENT_ENV.cloudCallbackToken}\` | Optional bearer token required on sandbox completion callbacks. |`,
+    "",
+    "Do not put literal tokens in `flue.yml`; keep the placeholders wired to the Flue environment/secret store.",
+    "",
+    "## Endpoints",
+    "",
+    "- `GET /health`: cloud-agent health check.",
+    "- `POST /telegram`: Telegram webhook receiver. Configure Telegram to send updates here.",
+    "- `POST /relaymux/v1/completion`: callback target for sandbox hands to send final updates back to Telegram.",
+    "",
+    "The cloud agent calls `POST <RELAYMUX_SANDBOX_BASE_URL>/relaymux/v1/ask` with `Authorization: Bearer <RELAYMUX_SANDBOX_TOKEN>` and protocol `relaymux-sandbox-hands-v1`.",
+    "",
+    "Run locally for smoke checks:",
+    "",
+    "```bash",
+    "npm install",
+    "npm run check",
+    "npm start",
+    "```",
+    "",
+  ].join("\n");
+}
+
+function renderCloudAgent() {
+  return `import http from "node:http";
+
+const CLOUD_PROTOCOL = ${JSON.stringify(RELAYMUX_CLOUD_AGENT_PROTOCOL)};
+const SANDBOX_PROTOCOL = ${JSON.stringify(RELAYMUX_SANDBOX_HANDS_PROTOCOL)};
+const PORT = Number(process.env.PORT || process.env.RELAYMUX_CLOUD_AGENT_PORT || 8787);
+const TELEGRAM_TOKEN = process.env.${RELAYMUX_CLOUD_AGENT_ENV.telegramBotToken} || "";
+const TELEGRAM_WEBHOOK_SECRET = process.env.${RELAYMUX_CLOUD_AGENT_ENV.telegramWebhookSecret} || "";
+const SANDBOX_BASE_URL = process.env.${RELAYMUX_CLOUD_AGENT_ENV.sandboxBaseUrl} || "";
+const SANDBOX_TOKEN = process.env.${RELAYMUX_CLOUD_AGENT_ENV.sandboxAuthToken} || "";
+const CALLBACK_TOKEN = process.env.${RELAYMUX_CLOUD_AGENT_ENV.cloudCallbackToken} || "";
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || "/", "http://relaymux-cloud-agent.local");
+    if (req.method === "GET" && url.pathname === "/health") {
+      writeJson(res, 200, { ok: true, protocol: CLOUD_PROTOCOL, sandboxProtocol: SANDBOX_PROTOCOL });
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/telegram") {
+      if (!telegramWebhookAuthorized(req)) {
+        writeJson(res, 401, { ok: false, error: "unauthorized" });
+        return;
+      }
+      await handleTelegram(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/relaymux/v1/completion") {
+      if (!callbackAuthorized(req)) {
+        writeJson(res, 401, { ok: false, error: "unauthorized" });
+        return;
+      }
+      await handleCompletion(req, res);
+      return;
+    }
+
+    writeJson(res, 404, { ok: false, error: "not found" });
+  } catch (error) {
+    writeJson(res, 500, { ok: false, error: error.message || String(error) });
+  }
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log("relaymux Flue cloud agent listening on port " + PORT);
+});
+
+async function handleTelegram(req, res) {
+  assertConfigured();
+  const update = await readJson(req);
+  const message = update.message || update.edited_message;
+  const text = String(message?.text || message?.caption || "").trim();
+  const chatId = message?.chat?.id;
+  const messageId = message?.message_id || update.update_id || Date.now();
+  if (!chatId || !text || message?.from?.is_bot) {
+    writeJson(res, 200, { ok: true, ignored: true });
+    return;
+  }
+
+  const sandboxResult = await postSandbox("/relaymux/v1/ask", {
+    protocol: SANDBOX_PROTOCOL,
+    operation: "ask",
+    source: "telegram",
+    text,
+    replyMode: "none",
+    wait: true,
+    idempotencyKey: "telegram:" + chatId + ":" + messageId,
+    metadata: {
+      telegram: {
+        chatId: String(chatId),
+        messageId: String(messageId),
+        updateId: update.update_id === undefined ? "" : String(update.update_id),
+      },
+    },
+  });
+
+  const reply = String(sandboxResult.reply || (sandboxResult.queued ? "Queued in sandbox." : "Sandbox accepted the request."));
+  await sendTelegramMessage(chatId, reply);
+  writeJson(res, 200, { ok: true });
+}
+
+async function handleCompletion(req, res) {
+  const body = await readJson(req);
+  const text = String(body.text || body.message || "").trim();
+  const chatId = body.chatId || body.metadata?.telegram?.chatId;
+  if (!text) throw new Error("completion text is required");
+  if (!chatId) throw new Error("completion metadata.telegram.chatId is required");
+  await sendTelegramMessage(chatId, text);
+  writeJson(res, 200, { ok: true });
+}
+
+async function postSandbox(path, body) {
+  const url = SANDBOX_BASE_URL.replace(/\\/+$/, "") + path;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer " + SANDBOX_TOKEN,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!response.ok) throw new Error("sandbox returned HTTP " + response.status + ": " + text.slice(0, 500));
+  return payload;
+}
+
+async function sendTelegramMessage(chatId, text) {
+  if (!TELEGRAM_TOKEN) throw new Error("TELEGRAM_BOT_TOKEN is required");
+  const response = await fetch("https://api.telegram.org/bot" + TELEGRAM_TOKEN + "/sendMessage", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text: String(text).slice(0, 3900) }),
+  });
+  const responseText = await response.text();
+  if (!response.ok) throw new Error("Telegram sendMessage failed with HTTP " + response.status + ": " + responseText.slice(0, 500));
+}
+
+function assertConfigured() {
+  if (!SANDBOX_BASE_URL) throw new Error("RELAYMUX_SANDBOX_BASE_URL is required");
+  if (!SANDBOX_TOKEN) throw new Error("RELAYMUX_SANDBOX_TOKEN is required");
+}
+
+function telegramWebhookAuthorized(req) {
+  if (!TELEGRAM_WEBHOOK_SECRET) return true;
+  return String(req.headers["x-telegram-bot-api-secret-token"] || "") === TELEGRAM_WEBHOOK_SECRET;
+}
+
+function callbackAuthorized(req) {
+  if (!CALLBACK_TOKEN) return true;
+  return String(req.headers.authorization || "") === "Bearer " + CALLBACK_TOKEN;
+}
+
+async function readJson(req) {
+  let raw = "";
+  for await (const chunk of req) raw += chunk;
+  if (!raw.trim()) throw new Error("JSON body is required");
+  return JSON.parse(raw);
+}
+
+function writeJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  res.end(JSON.stringify(payload));
+}
+`;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,29 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { RELAYMUX_CLOUD_AGENT_ENV, RELAYMUX_SANDBOX_HANDS_PROTOCOL } from "./cloud-protocol.js";
 import { defaultRelaymuxHome, defaultRelaymuxHomeConfigValue, expandPath } from "./paths.js";
+
+export type CloudAgentConfig = {
+  enabled: boolean;
+  provider: "flue";
+  role: "chat";
+  telegram: {
+    botTokenEnv: string;
+    webhookSecretEnv: string;
+  };
+  sandbox: {
+    protocol: string;
+    baseUrlEnv: string;
+    authTokenEnv: string;
+    completionCallbackTokenEnv: string;
+  };
+  flue: {
+    scaffoldCommand: string;
+    bundlePort: number;
+    healthPath: string;
+  };
+};
 
 export function defaultImessageIntegration() {
   return {
@@ -52,6 +74,29 @@ export function defaultTelegramIntegration() {
   };
 }
 
+export function defaultCloudAgentConfig(): CloudAgentConfig {
+  return {
+    enabled: false,
+    provider: "flue",
+    role: "chat",
+    telegram: {
+      botTokenEnv: RELAYMUX_CLOUD_AGENT_ENV.telegramBotToken,
+      webhookSecretEnv: RELAYMUX_CLOUD_AGENT_ENV.telegramWebhookSecret,
+    },
+    sandbox: {
+      protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+      baseUrlEnv: RELAYMUX_CLOUD_AGENT_ENV.sandboxBaseUrl,
+      authTokenEnv: RELAYMUX_CLOUD_AGENT_ENV.sandboxAuthToken,
+      completionCallbackTokenEnv: RELAYMUX_CLOUD_AGENT_ENV.cloudCallbackToken,
+    },
+    flue: {
+      scaffoldCommand: "relaymux cloud scaffold --flue --out ./relaymux-cloud-agent",
+      bundlePort: 8787,
+      healthPath: "/health",
+    },
+  };
+}
+
 export function defaultConfig(env = process.env) {
   const homeDir = defaultRelaymuxHomeConfigValue(env);
   const stateDir = path.posix.join(homeDir, "state");
@@ -74,6 +119,7 @@ export function defaultConfig(env = process.env) {
       tailLines: 80,
       tailBytes: 4000,
     },
+    cloudAgent: defaultCloudAgentConfig(),
     integrations: {},
     daemon: {
       enabled: true,
@@ -252,6 +298,7 @@ function normalizeConfig(config, override) {
   }
 
   config.integrations = config.integrations || {};
+  config.cloudAgent = normalizeCloudAgent(config.cloudAgent, override.cloudAgent);
 
   if (hasOwnPath(override, ["integrations", "imessage"])) {
     config.integrations.imessage = normalizeIntegration(defaultImessageIntegration(), override.integrations.imessage);
@@ -269,6 +316,43 @@ function normalizeConfig(config, override) {
   }
 
   return config;
+}
+
+function normalizeCloudAgent(current, override) {
+  const defaults = defaultCloudAgentConfig();
+  if (override === false) return { ...defaults, enabled: false };
+  const merged = mergeConfig(defaults, isPlainObject(current) ? current : {});
+  const raw = isPlainObject(override) ? mergeConfig(merged, override) : merged;
+  return {
+    enabled: raw.enabled === true,
+    provider: "flue",
+    role: "chat",
+    telegram: {
+      botTokenEnv: stringOrDefault(raw.telegram?.botTokenEnv, defaults.telegram.botTokenEnv),
+      webhookSecretEnv: stringOrDefault(raw.telegram?.webhookSecretEnv, defaults.telegram.webhookSecretEnv),
+    },
+    sandbox: {
+      protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+      baseUrlEnv: stringOrDefault(raw.sandbox?.baseUrlEnv, defaults.sandbox.baseUrlEnv),
+      authTokenEnv: stringOrDefault(raw.sandbox?.authTokenEnv, defaults.sandbox.authTokenEnv),
+      completionCallbackTokenEnv: stringOrDefault(raw.sandbox?.completionCallbackTokenEnv, defaults.sandbox.completionCallbackTokenEnv),
+    },
+    flue: {
+      scaffoldCommand: stringOrDefault(raw.flue?.scaffoldCommand, defaults.flue.scaffoldCommand),
+      bundlePort: positiveIntegerOrDefault(raw.flue?.bundlePort, defaults.flue.bundlePort),
+      healthPath: stringOrDefault(raw.flue?.healthPath, defaults.flue.healthPath),
+    },
+  };
+}
+
+function stringOrDefault(value, fallback) {
+  const text = String(value || "").trim();
+  return text || fallback;
+}
+
+function positiveIntegerOrDefault(value, fallback) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
 }
 
 function normalizeIntegration(defaults, override) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -82,6 +83,42 @@ test("supervise-tmux daemon mode is retired by default", async () => {
 
   assert.equal(code, 1);
   assert.match(harness.stderr, /outside tmux/);
+});
+
+test("cloud help documents the Flue scaffold without requiring config", async () => {
+  const harness = makeIo();
+  const code = await main(["cloud", "--help"], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /relaymux cloud/);
+  assert.match(harness.stdout, /cloud scaffold --flue --out <dir>/);
+  assert.match(harness.stdout, /RELAYMUX_SANDBOX_TOKEN/);
+});
+
+test("cloud scaffold --flue writes a syntax-checkable bundle with env placeholders", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-cloud-scaffold-"));
+  const configPath = path.join(dir, "bad-config.json");
+  const outDir = path.join(dir, "bundle");
+  fs.writeFileSync(configPath, "{not-json");
+  const harness = makeIo();
+  const code = await main(["--config", configPath, "cloud", "scaffold", "--flue", "--out", outDir], harness.io);
+
+  assert.equal(code, 0);
+  assert.match(harness.stdout, /Created Flue cloud-agent scaffold/);
+
+  const flue = fs.readFileSync(path.join(outDir, "flue.yml"), "utf8");
+  assert.match(flue, /\$\{TELEGRAM_BOT_TOKEN\}/);
+  assert.match(flue, /\$\{RELAYMUX_SANDBOX_TOKEN\}/);
+  assert.match(flue, /command: npm start/);
+
+  const bundleReadme = fs.readFileSync(path.join(outDir, "README.md"), "utf8");
+  assert.match(bundleReadme, /relaymux-sandbox-hands-v1/);
+  assert.match(bundleReadme, /Do not put literal tokens/);
+
+  const check = spawnSync(process.execPath, ["--check", path.join(outDir, "src", "cloud-agent.mjs")], {
+    encoding: "utf8",
+  });
+  assert.equal(check.status, 0, check.stderr || check.stdout);
 });
 
 test("launch dry-run defaults to the shared configured session", async () => {

--- a/test/cloud-protocol.test.ts
+++ b/test/cloud-protocol.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RELAYMUX_SANDBOX_HANDS_PROTOCOL,
+  buildSandboxAskRequest,
+  buildSandboxLaunchRequest,
+  buildSandboxNotifyRequest,
+  normalizeSandboxEnvelope,
+} from "../src/cloud-protocol.js";
+
+test("buildSandboxAskRequest defaults to quiet sandbox execution", () => {
+  const request = buildSandboxAskRequest({
+    text: "inspect the failing tests",
+    source: "telegram",
+    idempotencyKey: "telegram:1:2",
+    metadata: { telegram: { chatId: "1" } },
+  });
+
+  assert.equal(request.protocol, RELAYMUX_SANDBOX_HANDS_PROTOCOL);
+  assert.equal(request.operation, "ask");
+  assert.equal(request.replyMode, "none");
+  assert.equal(request.wait, true);
+  assert.equal(request.idempotencyKey, "telegram:1:2");
+  assert.deepEqual(request.metadata, { telegram: { chatId: "1" } });
+});
+
+test("buildSandboxLaunchRequest captures direct launch requests", () => {
+  const request = buildSandboxLaunchRequest({
+    repo: "~/code/app",
+    agent: "pi",
+    name: "fix-tests",
+    prompt: "fix the tests",
+    notify: {
+      callback: { url: "https://cloud.example.test/relaymux/v1/completion" },
+      idempotencyKey: "launch-1",
+    },
+  });
+
+  assert.equal(request.operation, "launch");
+  assert.equal(request.repo, "~/code/app");
+  assert.equal(request.agent, "pi");
+  assert.equal(request.notify.callback.authTokenEnv, "RELAYMUX_CLOUD_CALLBACK_TOKEN");
+});
+
+test("buildSandboxNotifyRequest captures completion callbacks", () => {
+  const request = buildSandboxNotifyRequest({
+    from: "fix-tests",
+    text: "done",
+    idempotencyKey: "done-1",
+  });
+
+  assert.equal(request.operation, "notify");
+  assert.equal(request.from, "fix-tests");
+  assert.equal(request.text, "done");
+});
+
+test("normalizeSandboxEnvelope rejects wrong protocol and operations", () => {
+  assert.throws(
+    () => normalizeSandboxEnvelope({ protocol: "other", operation: "ask" }),
+    /relaymux-sandbox-hands-v1/,
+  );
+  assert.throws(
+    () => normalizeSandboxEnvelope({ protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL, operation: "shell" }),
+    /operation/,
+  );
+  assert.equal(
+    normalizeSandboxEnvelope({ protocol: RELAYMUX_SANDBOX_HANDS_PROTOCOL, operation: "ask" }, "ask").operation,
+    "ask",
+  );
+});
+

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -19,11 +19,44 @@ test("writeDefaultConfig creates a loadable config", () => {
   assert.equal(config.launchNotifications.replyMode, "none");
   assert.equal(config.daemon.host, "127.0.0.1");
   assert.equal(config.daemon.launchMode, "direct");
+  assert.equal(config.cloudAgent.enabled, false);
+  assert.equal(config.cloudAgent.provider, "flue");
+  assert.equal(config.cloudAgent.sandbox.protocol, "relaymux-sandbox-hands-v1");
+  assert.equal(config.cloudAgent.sandbox.authTokenEnv, "RELAYMUX_SANDBOX_TOKEN");
   assert.equal(config.tmux.sessionMode, "shared");
   assert.ok(config.orchestrator.command);
   assert.ok(config.agents.codex);
   assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);
   assert.equal(config.launchNotifications.onExit, "never");
+});
+
+test("loadConfig merges optional cloud agent config without accepting literal secrets", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-cloud-config-"));
+  const configPath = path.join(dir, "config.json");
+  fs.writeFileSync(configPath, JSON.stringify({
+    cloudAgent: {
+      enabled: true,
+      telegram: {
+        botTokenEnv: "CUSTOM_TELEGRAM_TOKEN_ENV",
+        botToken: "literal-secret",
+      },
+      sandbox: {
+        baseUrlEnv: "CUSTOM_SANDBOX_URL_ENV",
+        authToken: "literal-secret",
+      },
+    },
+  }));
+
+  const { config } = loadConfig({ configPath });
+
+  assert.equal(config.cloudAgent.enabled, true);
+  assert.equal(config.cloudAgent.provider, "flue");
+  assert.equal(config.cloudAgent.telegram.botTokenEnv, "CUSTOM_TELEGRAM_TOKEN_ENV");
+  assert.equal(config.cloudAgent.telegram.webhookSecretEnv, "RELAYMUX_TELEGRAM_WEBHOOK_SECRET");
+  assert.equal(config.cloudAgent.telegram.botToken, undefined);
+  assert.equal(config.cloudAgent.sandbox.baseUrlEnv, "CUSTOM_SANDBOX_URL_ENV");
+  assert.equal(config.cloudAgent.sandbox.authTokenEnv, "RELAYMUX_SANDBOX_TOKEN");
+  assert.equal(config.cloudAgent.sandbox.authToken, undefined);
 });
 
 test("loadConfig treats legacy top-level imessage as enabled integration", () => {


### PR DESCRIPTION
## Summary
Adds the first optional Flue cloud-agent slice for relaymux: a disabled-by-default cloud config shape, a `relaymux cloud scaffold --flue` command, and a versioned sandbox hands protocol.

- Keeps the existing local daemon/tmux workflow as the default.
- Generates a minimal Flue cloud-agent bundle with env placeholders instead of literal secrets.
- Documents the Telegram -> Flue cloud agent -> sandbox hands -> relaymux/tmux boundary.

## Design
### Cloud Command And Scaffold
- `src/cloud-cli.ts` — adds the advanced `relaymux cloud scaffold --flue --out <dir>` command without growing the main CLI body.
- `src/cloud-scaffold.ts` — renders the Flue bundle files: `flue.yml`, `package.json`, `README.md`, and `src/cloud-agent.mjs`.
- `src/args.ts` and `src/cli.ts` — route `--flue` and the cloud command while keeping local setup/ask/launch behavior unchanged.

### Protocol And Config Boundary
- `src/cloud-protocol.ts` — defines `relaymux-cloud-agent-v1`, `relaymux-sandbox-hands-v1`, env placeholder names, and typed ask/launch/notify request helpers.
- `src/config.ts` — adds disabled-by-default `cloudAgent` config using env var names for Telegram and sandbox secrets, with normalization that drops literal secret fields.

### Docs And Tests
- `docs/cloud-agent.md` — documents the optional architecture, scaffold, sandbox hands protocol, and security boundaries.
- `README.md`, `docs/README.md`, `docs/configuration.md`, and `docs/integrations.md` — add discoverability while keeping cloud-agent docs advanced/optional.
- `test/cli.test.ts`, `test/config.test.ts`, and `test/cloud-protocol.test.ts` — cover CLI scaffold behavior, cloud config normalization, and protocol helper validation.

## Validation
`npm install` passed with no vulnerabilities.

`npm run validate` passed: lint, 107 tests, and build all succeeded.

Focused scaffold smoke passed:

```bash
rm -rf /tmp/relaymux-cloud-agent-flue-smoke
node ./dist/bin/relaymux.js cloud scaffold --flue --out /tmp/relaymux-cloud-agent-flue-smoke
node --check /tmp/relaymux-cloud-agent-flue-smoke/src/cloud-agent.mjs
```

`git diff --check` passed.
