### PR TITLE
Remove Workout References

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1145,7 +1145,7 @@ Useful commands:
   tmux attach -t <session>       attach to the shared or named agent session
   tmux kill-session -t <session> kill only that tmux session; background daemon/adapters keep running
 
-Default home layout: ~/.relaymux/{config.json,state,logs,tasks,reports,research,workouts}.
+Default home layout: ~/.relaymux/{config.json,state,logs,tasks,reports,research}.
 Config defaults to ${defaultConfigPath()} (legacy ~/.config/relaymux/config.json is still read if the new config does not exist).
 `;
 }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { defaultConfigPath, legacyDefaultConfigPath, legacyDefaultStateDir } from "./config.js";
 import { defaultRelaymuxHome, expandPath, ensureDirectory } from "./paths.js";
 
-const HOME_SUBDIRS = ["state", "logs", "tasks", "reports", "research", "workouts"];
+const HOME_SUBDIRS = ["state", "logs", "tasks", "reports", "research"];
 const STATE_RELAYMUX_NAMES = new Set([
   "daemon-state.json",
   "events.jsonl",
@@ -161,7 +161,7 @@ export function formatHomeMigrationInventory(inventory, { applying = false, forc
   lines.push(`relaymux home: ${inventory.homeDir}`);
   lines.push(`target config: ${inventory.configPath}`);
   lines.push(`mode: ${applying ? "apply" : "dry-run/inventory"}${force ? "; force overwrite" : ""}${symlink ? "; replace migrated sources with symlinks" : ""}`);
-  lines.push("managed layout: config.json, state/, logs/, tasks/, reports/, research/, workouts/");
+  lines.push("managed layout: config.json, state/, logs/, tasks/, reports/, research/");
 
   if (!inventory.items.length) {
     lines.push("No relaymux-owned legacy files found in known locations.");

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -14,7 +14,7 @@ Delegating with relaymux:
 - If the user asks for a separate/new/named tmux session, add --session <name>.
 - If the user asks for per-worktree sessions, add --session-mode per-worktree.
 - Prefer a focused prompt file for multi-line delegated instructions.
-- Put relaymux-generated prompt files, task scratch, research notes, reports, and workout logs under the relaymux managed home shown in runtime context unless the user provides an explicit path.
+- Put relaymux-generated prompt files, task scratch, research notes, and reports under the relaymux managed home shown in runtime context unless the user provides an explicit path.
 - Do not move or rewrite existing personal canonical files just because they look related; inventory and ask before migrating them.
 - Give each subagent exact scope, files or areas to inspect first when known, acceptance criteria, and validation commands.
 - Ask subagents to report meaningful completion or blockers with relaymux notify.
@@ -44,7 +44,7 @@ export function buildRuntimePromptContext({ configPath, homeDir, stateDir, sessi
     : "creates a tab/window in a per-worktree session because this config explicitly opts into per-worktree mode";
   return `Runtime context:
 - relaymux config: ${configPath}
-- relaymux managed home: ${homeDir} (state ${stateDir}; logs ${homeDir}/logs; task scratch ${homeDir}/tasks; research ${homeDir}/research; workouts ${homeDir}/workouts)
+- relaymux managed home: ${homeDir} (state ${stateDir}; logs ${homeDir}/logs; task scratch ${homeDir}/tasks; research ${homeDir}/research)
 - background service: direct/background process outside tmux when installed
 - tmux model: ${grouping}; agents appear as tabs/windows, never panes/splits
 - local completion webhook: ${webhookUrl}


### PR DESCRIPTION
## Summary
Remove the obsolete workout category from relaymux managed-home docs, prompts, and layout creation.

## Design
### Managed home layout
- `src/migration.ts` — removes `workouts` from `HOME_SUBDIRS`, so new/migrated relaymux homes no longer create `~/.relaymux/workouts`.
- `src/migration.ts` — updates migration inventory output so the managed layout only lists `config.json`, `state/`, `logs/`, `tasks/`, `reports/`, and `research/`.

### User-facing text
- `src/prompt.ts` — removes workout-log guidance from the orchestrator prompt and runtime managed-home context.
- `src/cli.ts` — updates CLI help text to omit `workouts` from the default home layout.

## Validation
- `npm install` — completed; added 7 packages, audited 8 packages, 0 vulnerabilities.
- `npm run validate` — passed lint, 100 tests, and build.
- `git diff --check` — passed with no output.
- `rg -n -i "workout|workouts" . --glob '!node_modules/**' --glob '!dist/**' --glob '!.git/**'` — no matches.
