### PR TITLE
Reduce relaymux message latency

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -44,6 +44,7 @@ Use a stable `--idempotency-key` for one logical update so retries do not send d
 | `telegram` | The daemon passes the update to the orchestrator, then sends the orchestrator's user-visible reply through the optional Telegram adapter. |
 
 Use `--reply-mode imessage` or `--reply-mode telegram` only when that adapter is configured and you want a user-visible update.
+Completion updates always pass through the orchestrator first so it can observe, compress, and decide what user-visible adapter update to send.
 
 ## Scheduled Prompts
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -80,6 +80,15 @@ relaymux doctor
 
 You may need to grant the terminal or automation host the macOS permissions required by your message tool, such as Full Disk Access or Messages automation permission.
 
+Daemon logs include compact latency lines for debugging slow turns:
+
+```text
+latency job_done type=incoming requestId=... queueWaitMs=12 orchestratorMs=9040 adapterSendMs=520 totalMs=9568
+latency poll adapter=imessage durationMs=1180 messages=20 fresh=1 queueLength=1 processing=true
+```
+
+The latency lines intentionally include ids, durations, adapter names, and queue counts, but not prompt text, adapter message text, chat ids, tokens, or secrets.
+
 If Telegram sending fails, verify the chat id, token source, and token file permissions:
 
 ```bash

--- a/src/daemon-jobs.ts
+++ b/src/daemon-jobs.ts
@@ -1,0 +1,125 @@
+import { performance } from "node:perf_hooks";
+
+export function stampQueuedJob(job, nowMs = Date.now()) {
+  const queuedAt = new Date(nowMs).toISOString();
+  job.queuedAt = job.queuedAt || job.enqueuedAt || queuedAt;
+  job.enqueuedAt = job.enqueuedAt || job.queuedAt;
+  const existingMs = Number(job.queuedAtMs || Date.parse(job.queuedAt || job.enqueuedAt || ""));
+  job.queuedAtMs = Number.isFinite(existingMs) ? existingMs : nowMs;
+  return job;
+}
+
+export function selectNextJobIndex(queue) {
+  let selectedIndex = -1;
+  let selectedPriority = Infinity;
+  for (let index = 0; index < queue.length; index += 1) {
+    const priority = jobPriority(queue[index]);
+    if (priority < selectedPriority) {
+      selectedIndex = index;
+      selectedPriority = priority;
+    }
+  }
+  return selectedIndex;
+}
+
+export function jobPriority(job) {
+  const type = jobType(job);
+  if (type === "incoming") return 0;
+  if (type === "request") return 1;
+  if (type === "webhook") return 2;
+  return 3;
+}
+
+export function jobType(job) {
+  if (job?.type === "incoming" || job?.type === "imessage") return "incoming";
+  if (job?.type === "request") return "request";
+  if (job?.type === "webhook") return "webhook";
+  return String(job?.type || "unknown");
+}
+
+export function summarizeQueuedJobs(queue) {
+  const summary = {};
+  for (const job of queue) {
+    const type = jobType(job);
+    summary[type] = (summary[type] || 0) + 1;
+  }
+  return summary;
+}
+
+export function formatLatencyLogLine(event, fields = {}) {
+  const parts = [`latency ${formatLogValue(event)}`];
+  for (const [key, value] of Object.entries(fields)) {
+    if (isSensitiveLogField(key)) continue;
+    if (value === undefined || value === null || value === "") continue;
+    parts.push(`${formatLogKey(key)}=${formatLogValue(value)}`);
+  }
+  return parts.join(" ");
+}
+
+export function startJobMetrics(job, queueLength) {
+  const startedAtMs = Date.now();
+  const queuedAtMs = Number(job.queuedAtMs || Date.parse(job.queuedAt || job.enqueuedAt || job.receivedAt || ""));
+  const safeQueuedAtMs = Number.isFinite(queuedAtMs) ? queuedAtMs : startedAtMs;
+  return {
+    type: jobType(job),
+    requestId: job.requestId,
+    ids: job.ids,
+    replyMode: job.replyMode,
+    queuedAt: job.queuedAt || job.enqueuedAt || job.receivedAt || new Date(safeQueuedAtMs).toISOString(),
+    startedAt: new Date(startedAtMs).toISOString(),
+    queueLength,
+    queueWaitMs: Math.max(0, startedAtMs - safeQueuedAtMs),
+    totalStartedAt: performance.now(),
+    orchestratorMs: 0,
+    adapterSendMs: 0,
+  };
+}
+
+export function startLatencyFields(metrics) {
+  return {
+    type: metrics.type,
+    requestId: metrics.requestId,
+    ids: metrics.ids,
+    replyMode: metrics.replyMode,
+    queuedAt: metrics.queuedAt,
+    startedAt: metrics.startedAt,
+    queueWaitMs: metrics.queueWaitMs,
+    queueLength: metrics.queueLength,
+  };
+}
+
+export function finishLatencyFields(metrics, status) {
+  return {
+    ...startLatencyFields(metrics),
+    status,
+    orchestratorMs: metrics.orchestratorMs,
+    adapterSendMs: metrics.adapterSendMs,
+    totalMs: elapsedMs(metrics.totalStartedAt),
+  };
+}
+
+export async function timedStage(metrics, field, fn) {
+  const startedAt = performance.now();
+  try {
+    return await fn();
+  } finally {
+    metrics[field] += elapsedMs(startedAt);
+  }
+}
+
+export function elapsedMs(startedAt) {
+  return Math.max(0, Math.round(performance.now() - startedAt));
+}
+
+function formatLogKey(key) {
+  return String(key || "field").replace(/[^A-Za-z0-9_.-]+/g, "_");
+}
+
+function isSensitiveLogField(key) {
+  return ["body", "message", "prompt", "text"].includes(String(key || "").toLowerCase());
+}
+
+function formatLogValue(value) {
+  const raw = Array.isArray(value) ? value.join(",") : String(value);
+  return raw.replace(/[\s=]+/g, "_").slice(0, 240);
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,6 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 
+import {
+  elapsedMs,
+  finishLatencyFields,
+  formatLatencyLogLine,
+  jobType,
+  selectNextJobIndex,
+  stampQueuedJob,
+  startJobMetrics,
+  startLatencyFields,
+  summarizeQueuedJobs,
+  timedStage,
+} from "./daemon-jobs.js";
 import { createCompletionWebhookServer } from "./webhook.js";
 import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorPrompt, runOrchestrator } from "./orchestrator.js";
 import { formatIncomingForPrompt, isImessageReceiveEnabled, isIncomingUserMessage, receiveMessages, sendMessage } from "./message-io.js";
@@ -23,6 +36,7 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
   const queuedIncomingIds = new Set();
   let processing = false;
   let scheduled = false;
+  let polling = false;
 
   const log = (...args) => io.stdout.write(`[${new Date().toISOString()}] ${args.join(" ")}\n`);
   const warn = (...args) => io.stderr.write(`[${new Date().toISOString()}] ${args.join(" ")}\n`);
@@ -31,8 +45,10 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
   function queueStatus() {
     return {
       queueLength: queue.length,
+      queueByType: summarizeQueuedJobs(queue),
       processing,
       scheduled,
+      polling,
       queuedIncomingIds: queuedIncomingIds.size,
       initialized: state.initialized,
       lastProcessedAt: state.lastProcessedAt,
@@ -53,19 +69,19 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     if (!messages.length) return;
     const ids = messages.map((message) => String(message.id));
     for (const id of ids) queuedIncomingIds.add(id);
-    queue.push({ type: "incoming", adapter, replyMode, requestId: `${adapter}-${Date.now().toString(36)}`, messages, ids, enqueuedAt: new Date().toISOString() });
+    queue.push(stampQueuedJob({ type: "incoming", adapter, replyMode, requestId: `${adapter}-${Date.now().toString(36)}`, messages, ids }));
     log(`queued incoming ${adapter} message(s): ${ids.join(",")}`);
     scheduleProcessQueue();
   }
 
   function enqueueWebhook(job) {
-    queue.push(job);
+    queue.push(stampQueuedJob(job));
     log(`queued local completion ${job.requestId} from ${job.source}; replyMode=${job.replyMode}`);
     scheduleProcessQueue();
   }
 
   function enqueueTerminalRequest(job) {
-    queue.push(job);
+    queue.push(stampQueuedJob(job));
     log(`queued terminal request ${job.requestId} from ${job.source}; replyMode=${job.replyMode}; wait=${job.wait ? "yes" : "no"}`);
     scheduleProcessQueue();
   }
@@ -77,6 +93,9 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
 
   async function processIncomingJob(job) {
     log(`processing incoming ${job.adapter || "message"} message(s): ${job.ids.join(",")}`);
+    const metrics = startJobMetrics(job, queue.length);
+    log(formatLatencyLogLine("job_start", startLatencyFields(metrics)));
+    let status = "ok";
     let marked = false;
     const markSeen = () => {
       if (marked) return;
@@ -91,69 +110,83 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
         configPath: configInfo.path,
         incomingText: formatIncomingForPrompt(job.messages, job.adapter),
       });
-      const reply = await runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId });
-      await sendReply(config, job.replyMode || "imessage", reply, io);
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
+      await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode || "imessage", reply, io));
       markSeen();
       log(`replied to ${job.ids.join(",")} via ${job.replyMode || "imessage"}`);
     } catch (error) {
+      status = "error";
       warn(`failed processing incoming ${job.ids.join(",")}:`, describeError(error));
       try {
-        await sendReply(config, job.replyMode || "imessage", `relaymux orchestrator hit an error: ${error.message || String(error)}`, io);
+        await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode || "imessage", `relaymux orchestrator hit an error: ${error.message || String(error)}`, io));
       } catch (sendError) {
         warn("also failed to send error message:", describeError(sendError));
       }
       markSeen();
     } finally {
       for (const id of job.ids) queuedIncomingIds.delete(id);
+      log(formatLatencyLogLine("job_done", finishLatencyFields(metrics, status)));
     }
   }
 
   async function processWebhookJob(job) {
     log(`processing local completion ${job.requestId} from ${job.source}`);
+    const metrics = startJobMetrics(job, queue.length);
+    log(formatLatencyLogLine("job_start", startLatencyFields(metrics)));
+    let status = "ok";
     try {
       const prompt = buildWebhookOrchestratorPrompt({ config, configPath: configInfo.path, job });
-      const reply = await runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId });
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
       if (job.replyMode === "none") {
         log(`processed quiet completion ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
       } else {
-        await sendReply(config, job.replyMode, reply, io);
+        await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode, reply, io));
         log(`sent ${job.replyMode} completion reply for ${job.requestId}`);
       }
     } catch (error) {
+      status = "error";
       warn(`failed processing local completion ${job.requestId}:`, describeError(error));
       if (job.replyMode !== "none") {
         try {
-          await sendReply(config, job.replyMode, `relaymux orchestrator hit an error processing ${job.source}: ${error.message || String(error)}`, io);
+          await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode, `relaymux orchestrator hit an error processing ${job.source}: ${error.message || String(error)}`, io));
         } catch (sendError) {
           warn("also failed to send completion error message:", describeError(sendError));
         }
       }
+    } finally {
+      log(formatLatencyLogLine("job_done", finishLatencyFields(metrics, status)));
     }
   }
 
   async function processTerminalRequestJob(job) {
     log(`processing terminal request ${job.requestId} from ${job.source}`);
+    const metrics = startJobMetrics(job, queue.length);
+    log(formatLatencyLogLine("job_start", startLatencyFields(metrics)));
+    let status = "ok";
     try {
       const prompt = buildTerminalOrchestratorPrompt({ config, configPath: configInfo.path, job });
-      const reply = await runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId });
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
       if (job.replyMode === "none") {
         log(`processed terminal request ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
       } else {
-        await sendReply(config, job.replyMode, reply, io);
+        await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode, reply, io));
         log(`sent ${job.replyMode} terminal request reply for ${job.requestId}`);
       }
       job.deferred?.resolve({ ok: true, queued: false, reply });
     } catch (error) {
+      status = "error";
       const message = `relaymux orchestrator hit an error processing ${job.source}: ${error.message || String(error)}`;
       warn(`failed processing terminal request ${job.requestId}:`, describeError(error));
       if (job.replyMode !== "none") {
         try {
-          await sendReply(config, job.replyMode, message, io);
+          await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode, message, io));
         } catch (sendError) {
           warn("also failed to send terminal request error message:", describeError(sendError));
         }
       }
       job.deferred?.resolve({ ok: false, queued: false, error: message });
+    } finally {
+      log(formatLatencyLogLine("job_done", finishLatencyFields(metrics, status)));
     }
   }
 
@@ -162,7 +195,11 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     processing = true;
     try {
       while (queue.length > 0) {
-        const job = queue.shift();
+        const nextIndex = selectNextJobIndex(queue);
+        const job = nextIndex <= 0 ? queue.shift() : queue.splice(nextIndex, 1)[0];
+        if (nextIndex > 0) {
+          log(formatLatencyLogLine("queue_priority", { selectedType: jobType(job), skippedJobs: nextIndex, queueLength: queue.length + 1 }));
+        }
         if (job.type === "incoming" || job.type === "imessage") await processIncomingJob(job);
         else if (job.type === "webhook") await processWebhookJob(job);
         else if (job.type === "request") await processTerminalRequestJob(job);
@@ -175,27 +212,41 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
   }
 
   async function pollOnce() {
-    if (processing || queue.length > 0) return;
-    const seen = new Set((state.seenIncomingIds || []).map(String));
-    if (inboundImessageEnabled) {
-      try {
-        const recent = await receiveMessages(config);
-        const fresh = freshIncoming(recent, seen, queuedIncomingIds);
-        if (fresh.length) enqueueIncoming("imessage", fresh, "imessage");
-      } catch (error) {
-        warn("iMessage poll failed:", describeError(error));
+    if (polling) return;
+    polling = true;
+    try {
+      if (inboundImessageEnabled) {
+        const pollStarted = performance.now();
+        try {
+          const recent = await receiveMessages(config);
+          const fresh = freshIncoming(recent, seenIncomingIds(state), queuedIncomingIds);
+          logPollLatency("imessage", pollStarted, recent.length, fresh.length);
+          if (fresh.length) enqueueIncoming("imessage", fresh, "imessage");
+        } catch (error) {
+          warn("iMessage poll failed:", describeError(error));
+        }
       }
-    }
-    if (inboundTelegramEnabled) {
-      try {
-        const recent = await receiveTelegramMessages(config, state, io.env || process.env);
-        saveState();
-        const fresh = freshIncoming(recent, seen, queuedIncomingIds);
-        if (fresh.length) enqueueIncoming("telegram", fresh, "telegram");
-      } catch (error) {
-        warn("Telegram poll failed:", describeError(error));
+      if (inboundTelegramEnabled) {
+        const pollStarted = performance.now();
+        try {
+          const recent = await receiveTelegramMessages(config, state, io.env || process.env);
+          saveState();
+          const fresh = freshIncoming(recent, seenIncomingIds(state), queuedIncomingIds);
+          logPollLatency("telegram", pollStarted, recent.length, fresh.length);
+          if (fresh.length) enqueueIncoming("telegram", fresh, "telegram");
+        } catch (error) {
+          warn("Telegram poll failed:", describeError(error));
+        }
       }
+    } finally {
+      polling = false;
     }
+  }
+
+  function logPollLatency(adapter, startedAt, messages, fresh) {
+    const durationMs = elapsedMs(startedAt);
+    if (!fresh && durationMs < 1000) return;
+    log(formatLatencyLogLine("poll", { adapter, durationMs, messages, fresh, queueLength: queue.length, processing }));
   }
 
   const inboundImessageEnabled = isImessageReceiveEnabled(config);
@@ -303,6 +354,10 @@ function rememberSeen(state, ids) {
   for (const id of ids) seen.add(String(id));
   state.seenIncomingIds = Array.from(seen).slice(-1000);
   state.lastProcessedAt = new Date().toISOString();
+}
+
+function seenIncomingIds(state) {
+  return new Set((state.seenIncomingIds || []).map(String));
 }
 
 function freshIncoming(messages, seen, queuedIncomingIds) {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatLatencyLogLine,
+  jobPriority,
+  selectNextJobIndex,
+  stampQueuedJob,
+  summarizeQueuedJobs,
+} from "../src/daemon-jobs.js";
+
+test("selectNextJobIndex prioritizes incoming work without changing FIFO within a priority", () => {
+  const queue = [
+    { type: "webhook", requestId: "wh1" },
+    { type: "request", requestId: "req1" },
+    { type: "incoming", requestId: "in1" },
+    { type: "incoming", requestId: "in2" },
+  ];
+
+  assert.equal(selectNextJobIndex(queue), 2);
+  queue.splice(2, 1);
+  assert.equal(selectNextJobIndex(queue), 2);
+  queue.splice(2, 1);
+  assert.equal(selectNextJobIndex(queue), 1);
+});
+
+test("jobPriority keeps incoming above terminal requests above completion webhooks", () => {
+  assert.equal(jobPriority({ type: "incoming" }), 0);
+  assert.equal(jobPriority({ type: "imessage" }), 0);
+  assert.equal(jobPriority({ type: "request" }), 1);
+  assert.equal(jobPriority({ type: "webhook" }), 2);
+  assert.equal(jobPriority({ type: "other" }), 3);
+});
+
+test("stampQueuedJob records queue timestamps without clobbering an existing queuedAt", () => {
+  const job: Record<string, unknown> = { type: "webhook", queuedAt: "2026-01-01T00:00:00.000Z" };
+
+  stampQueuedJob(job, Date.UTC(2026, 0, 1, 0, 0, 5));
+
+  assert.equal(job.queuedAt, "2026-01-01T00:00:00.000Z");
+  assert.equal(job.enqueuedAt, "2026-01-01T00:00:00.000Z");
+  assert.equal(job.queuedAtMs, Date.UTC(2026, 0, 1, 0, 0, 0));
+});
+
+test("stampQueuedJob preserves legacy enqueuedAt when queuedAt is absent", () => {
+  const job: Record<string, unknown> = { type: "incoming", enqueuedAt: "2026-01-01T00:00:02.000Z" };
+
+  stampQueuedJob(job, Date.UTC(2026, 0, 1, 0, 0, 5));
+
+  assert.equal(job.queuedAt, "2026-01-01T00:00:02.000Z");
+  assert.equal(job.queuedAtMs, Date.UTC(2026, 0, 1, 0, 0, 2));
+});
+
+test("summarizeQueuedJobs returns safe queue counts by type", () => {
+  assert.deepEqual(summarizeQueuedJobs([
+    { type: "webhook" },
+    { type: "request" },
+    { type: "imessage" },
+    { type: "incoming" },
+  ]), {
+    webhook: 1,
+    request: 1,
+    incoming: 2,
+  });
+});
+
+test("formatLatencyLogLine emits compact key-value fields", () => {
+  assert.equal(
+    formatLatencyLogLine("job done", {
+      type: "incoming",
+      ids: ["1", "2"],
+      requestId: "imessage-abc",
+      queueWaitMs: 12,
+      message: "never log this text",
+      empty: "",
+    }),
+    "latency job_done type=incoming ids=1,2 requestId=imessage-abc queueWaitMs=12",
+  );
+});


### PR DESCRIPTION
## Summary
Measure and reduce relaymux message latency by making daemon latency visible, allowing inbound polls to continue while jobs run, and prioritizing newly queued incoming messages over lower-priority local work.

- Baseline from `/Users/avyay/.relaymux/logs/daemon.out.log`: 336 measured jobs averaged 43.813s; incoming messages averaged 44.998s with p50 23.768s and p90 96.817s overall.
- Incoming adapter jobs are now selected before terminal requests and completion webhooks when queued.
- Completion notifications still pass through the orchestrator so it can observe and compress updates; this PR does not remove orchestrator latency for completions.

## Design
### Daemon Scheduling And Instrumentation
- `src/daemon.ts` — adds per-job `latency job_start` / `latency job_done` lines with queue wait, orchestrator, adapter-send, and total durations while filtering content-like fields out of latency logs.
- `src/daemon.ts` — keeps inbound polling active during job processing with a polling lock, logs slow/fresh poll timings, and exposes queue counts plus polling state in `/health` status.
- `src/daemon.ts` — selects queued work by priority: incoming adapter messages first, terminal requests second, completion webhooks third. The orchestrator remains single-flight; this avoids a concurrency rewrite while preventing local completions from sitting ahead of user messages.
- `src/daemon.ts` — refreshes seen incoming ids after each adapter receive completes, which fixes a smoke-tested race where a slow poll could requeue an incoming id after it had already been processed.
- `src/daemon-jobs.ts` — contains the pure queue-priority and latency-formatting helpers so `daemon.ts` stays focused on daemon orchestration.

### Docs And Tests
- `test/daemon.test.ts` — covers queue priority, timestamp stamping, queue summaries, and content-filtered latency log formatting.
- `docs/operations.md` — documents the new latency log shape and explicitly notes that ids/durations/counts are logged without prompt text, adapter message text, chat ids, tokens, or secrets.
- `docs/integrations.md` — clarifies that completion updates always pass through the orchestrator before any adapter reply.
- Local reports were updated outside the repo at `/Users/avyay/.relaymux/research/relaymux-latency-20260616/latency-report.md`, `/Users/avyay/.relaymux/research/relaymux-smoke-20260616/report.md`, and `/Users/avyay/.relaymux/research/relaymux-pr19-latency-review-20260616/thermonuclear.md`.

## Validation
- `npm run validate` passed: `tsc --noEmit`, 106 node tests passed, and `npm run build` completed.
- `git diff --check` passed.
- `rg -n -i "direct-reply|directReply" . --glob '!node_modules/**' --glob '!dist/**' --glob '!.git/**'` returned no matches.
- Shadow daemon smoke confirmed completion notifications with `replyMode=imessage` still invoke the orchestrator and emit `latency job_done` with orchestrator timing.
- Shadow daemon smoke confirmed polling continues while a completion is processing, incoming jobs jump queued completions, and repeated receive results are not requeued after the duplicate-requeue race fix.
- PR #19 checks passed after the latest push: two `test` jobs succeeded.
