### PR TITLE
Link imsg CLI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ tmux attach -t agents
 
 ## iMessage/SMS beta
 
-iMessage/SMS depends on a working local `imsg` command. The minimal setup is:
+iMessage/SMS depends on a working local [`imsg`](https://github.com/openclaw/imsg) command. The minimal setup is:
 
 ```bash
 relaymux setup --imsg


### PR DESCRIPTION
## Summary
Clarifies iMessage/SMS beta setup by linking the local `imsg` CLI dependency to its canonical GitHub repo.

## Design
### README
- `README.md` — Links the `imsg` command in the iMessage/SMS beta section to `https://github.com/openclaw/imsg`, matching `gh repo view steipete/imsg`.

## Validation
- `git diff --check` — passed.
- `npm run validate` — passed; 109 tests passed.
- `rg -n "imsg|openclaw|steipete" README.md` — confirmed the README contains the `imsg` link.