### PR TITLE
Enforce iMessage inbound chat allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ relaymux will try to show recent chats. Pick one, then text that chat to use rel
 relaymux setup --imsg --chat-id '<chat-id-or-phone-number>'
 ```
 
+Inbound iMessage/SMS handling is restricted to the configured chat id. The receive command must be scoped with `{chatId}`; if command output includes a chat, conversation, or thread id, relaymux only accepts messages whose id exactly matches the configured chat. Older command output without an explicit chat id is accepted only when the receive command is scoped this way.
+
 ## Troubleshooting
 
 ```bash

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -99,6 +99,8 @@ relaymux status
 
 `relaymux setup --imsg` creates or updates `~/.relaymux/config.json`, tries to discover recent `imsg` chats when `--chat-id` is omitted, installs/restarts the background service unless `--no-launch-agent` is passed, and prints next steps. Re-running `relaymux init --imsg` or `relaymux setup --imsg` adds or updates the adapter on the existing config; `--force` is only for replacing the whole config.
 
+Inbound iMessage/SMS access is allowlisted by the configured chat id. Receive commands must include the `{chatId}` template so polling is scoped to `config.integrations.imessage.chatId`. relaymux also inspects parsed command output: if a message exposes a chat, conversation, or thread id, the id must exactly match the configured chat id or the message is ignored before it reaches the orchestrator. Legacy command output that has no explicit chat id is accepted only under the scoped `{chatId}` receive command.
+
 After setup, text the configured chat with a small request. Use a chat where your request appears as an incoming message to the Mac's Messages account; messages marked by Messages as sent by that Mac are ignored so relaymux does not respond to its own replies.
 
 Manual user-visible completion:

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -46,6 +46,7 @@ export function normalizeMessage(message, index = 0) {
     text,
     createdAt: String(createdAt || ""),
     sender: String(message.sender ?? message.from ?? message.handle ?? ""),
+    chatId: extractMessageChatId(message).value,
     isFromMe,
     attachments: Array.isArray(message.attachments) ? message.attachments : [],
   };
@@ -97,6 +98,10 @@ export function buildAdapterArgv(commandConfig, context) {
   return commandConfig.argv.map((part) => renderTemplate(part, context));
 }
 
+export function isReceiveCommandScopedToChat(commandConfig) {
+  return Array.isArray(commandConfig?.argv) && commandConfig.argv.some((part) => String(part).includes("{chatId}"));
+}
+
 export function isImessageReceiveEnabled(config) {
   const imessage = getIntegration(config, "imessage");
   const receive = imessage.receive || {};
@@ -110,13 +115,18 @@ export async function receiveMessages(config) {
   if (receive.backend !== "command") throw new Error(`unsupported iMessage receive backend: ${receive.backend || "missing"}`);
 
   const commandConfig = receive.command || {};
-  const argv = buildAdapterArgv(commandConfig, messageContext(config, { limit: imessage.syncLimit || 5 }));
+  const chatId = configuredImessageChatId(imessage);
+  const commandScopedToChat = isReceiveCommandScopedToChat(commandConfig);
+  if (!commandScopedToChat) {
+    throw new Error("iMessage receive command argv must include {chatId} so inbound polling is scoped to config.integrations.imessage.chatId");
+  }
+  const argv = buildAdapterArgv(commandConfig, messageContext(config, { chatId, limit: imessage.syncLimit || 5 }));
   const result = await runCommandAsync(argv[0], argv.slice(1), {
     cwd: expandPath(commandConfig.cwd || "~"),
     timeoutMs: Number(commandConfig.timeoutMs || 30000),
     maxBuffer: Number(commandConfig.maxBufferBytes || 10 * 1024 * 1024),
   });
-  return normalizeMessages(parseMessageOutput(result.stdout));
+  return normalizeMessages(filterImessageMessagesForChat(parseMessageOutput(result.stdout), chatId, { commandScopedToChat }));
 }
 
 export async function sendMessage(config: any, text: string, io: any = process) {
@@ -164,6 +174,78 @@ export function messageContext(config, extra = {}) {
     text: "",
     ...extra,
   };
+}
+
+export function filterImessageMessagesForChat(messages, configuredChatId, { commandScopedToChat = false } = {}) {
+  const chatId = String(configuredChatId || "").trim();
+  if (!chatId || chatId === "CHAT_ID_OR_PHONE") return [];
+
+  return messages.filter((message) => {
+    const messageChatId = extractMessageChatId(message);
+    if (messageChatId.exposed) return messageChatId.value === chatId;
+    return commandScopedToChat;
+  });
+}
+
+function configuredImessageChatId(imessage) {
+  const chatId = String(imessage.chatId || "").trim();
+  if (!chatId || chatId === "CHAT_ID_OR_PHONE") {
+    throw new Error("iMessage receive requires config.integrations.imessage.chatId");
+  }
+  return chatId;
+}
+
+function extractMessageChatId(message) {
+  const topLevelFields = [
+    "chatId",
+    "chatID",
+    "chat_id",
+    "chatIdentifier",
+    "chat_identifier",
+    "chatGuid",
+    "chatGUID",
+    "chat_guid",
+    "conversationId",
+    "conversationID",
+    "conversation_id",
+    "conversationIdentifier",
+    "conversation_identifier",
+    "conversationGuid",
+    "conversationGUID",
+    "conversation_guid",
+    "threadId",
+    "threadID",
+    "thread_id",
+    "threadIdentifier",
+    "thread_identifier",
+    "threadGuid",
+    "threadGUID",
+    "thread_guid",
+  ];
+  for (const key of topLevelFields) {
+    if (hasOwn(message, key)) return { exposed: true, value: stringifyChatId(message[key]) };
+  }
+
+  for (const key of ["chat", "conversation", "thread"]) {
+    if (!hasOwn(message, key)) continue;
+    const value = message[key];
+    if (value === null || value === undefined) return { exposed: true, value: "" };
+    if (typeof value !== "object") return { exposed: true, value: stringifyChatId(value) };
+    for (const nestedKey of ["id", "chatId", "chatID", "chat_id", "guid", "identifier", "rowid"]) {
+      if (hasOwn(value, nestedKey)) return { exposed: true, value: stringifyChatId(value[nestedKey]) };
+    }
+    return { exposed: true, value: "" };
+  }
+
+  return { exposed: false, value: "" };
+}
+
+function stringifyChatId(value) {
+  return value === undefined || value === null ? "" : String(value).trim();
+}
+
+function hasOwn(value, key) {
+  return value !== null && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function fallbackMessageId({ text, createdAt, index }) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -46,6 +46,7 @@ test("loadConfig treats legacy top-level imessage as enabled integration", () =>
 
   assert.equal(config.integrations.imessage.enabled, true);
   assert.equal(config.integrations.imessage.chatId, "chat-1");
+  assert.ok(config.integrations.imessage.receive.command.argv.includes("{chatId}"));
   assert.equal(config.launchNotifications.replyMode, "imessage");
 });
 

--- a/test/message-io.test.ts
+++ b/test/message-io.test.ts
@@ -5,8 +5,10 @@ import { defaultConfig } from "../src/config.js";
 import {
   buildAdapterArgv,
   commandSafeMessageText,
+  filterImessageMessagesForChat,
   formatIncomingForPrompt,
   isIncomingUserMessage,
+  isReceiveCommandScopedToChat,
   normalizeMessages,
   parseMessageOutput,
   receiveMessages,
@@ -42,6 +44,11 @@ test("buildAdapterArgv renders command placeholders", () => {
   );
 });
 
+test("isReceiveCommandScopedToChat requires an explicit chatId template", () => {
+  assert.equal(isReceiveCommandScopedToChat({ argv: ["imsg", "history", "--chat-id", "{chatId}", "--json"] }), true);
+  assert.equal(isReceiveCommandScopedToChat({ argv: ["imsg", "history", "--json"] }), false);
+});
+
 test("commandSafeMessageText protects dash-leading replies from option parsing", () => {
   assert.equal(commandSafeMessageText("hello"), "hello");
   assert.equal(commandSafeMessageText("- bullet"), "\u200B- bullet");
@@ -57,7 +64,81 @@ test("receiveMessages is a no-op when iMessage adapter is disabled", async () =>
   assert.deepEqual(await receiveMessages(defaultConfig({ PATH: "" })), []);
 });
 
+test("receiveMessages accepts a matching configured chat id", async () => {
+  const messages = await receiveMessages(imessageReceiveConfig([
+    { id: "m1", text: "from configured chat", is_from_me: false, chat_id: "chat-allowed" },
+  ]));
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].id, "m1");
+  assert.equal(messages[0].chatId, "chat-allowed");
+});
+
+test("receiveMessages drops mismatched explicit chat ids", async () => {
+  const messages = await receiveMessages(imessageReceiveConfig([
+    { id: "m1", text: "keep", is_from_me: false, conversation_id: "chat-allowed" },
+    { id: "m2", text: "drop", is_from_me: false, conversation_id: "chat-other" },
+  ]));
+
+  assert.deepEqual(messages.map((message) => message.id), ["m1"]);
+});
+
+test("receiveMessages accepts untagged command output only when argv is scoped by chatId", async () => {
+  const messages = await receiveMessages(imessageReceiveConfig([
+    { id: "m1", text: "legacy command output", is_from_me: false },
+  ]));
+
+  assert.deepEqual(messages.map((message) => message.id), ["m1"]);
+});
+
+test("receiveMessages fails closed when receive is enabled without a configured chat id", async () => {
+  await assert.rejects(
+    receiveMessages(imessageReceiveConfig([{ id: "m1", text: "nope", is_from_me: false }], { chatId: "" })),
+    /iMessage receive requires config\.integrations\.imessage\.chatId/,
+  );
+});
+
+test("receiveMessages rejects unscoped receive commands", async () => {
+  await assert.rejects(
+    receiveMessages(imessageReceiveConfig([{ id: "m1", text: "nope", is_from_me: false, chat_id: "chat-allowed" }], {
+      argvIncludesChatId: false,
+    })),
+    /iMessage receive command argv must include \{chatId\}/,
+  );
+});
+
+test("filterImessageMessagesForChat drops untagged messages unless command output is scoped", () => {
+  assert.deepEqual(
+    filterImessageMessagesForChat([{ id: "m1", text: "hi" }], "chat-allowed", { commandScopedToChat: false }),
+    [],
+  );
+  assert.deepEqual(
+    filterImessageMessagesForChat([{ id: "m1", text: "hi" }], "chat-allowed", { commandScopedToChat: true }),
+    [{ id: "m1", text: "hi" }],
+  );
+});
+
 test("splitMessage chunks long text", () => {
   assert.deepEqual(splitMessage("hello", 10), ["hello"]);
   assert.ok(splitMessage("one two three four", 8).length > 1);
 });
+
+function imessageReceiveConfig(stdoutMessages, options: any = {}) {
+  const stdout = JSON.stringify(stdoutMessages);
+  const config: any = defaultConfig({ PATH: "" });
+  const argv = [process.execPath, "-e", `process.stdout.write(${JSON.stringify(stdout)})`];
+  if (options.argvIncludesChatId !== false) argv.push("{chatId}");
+  config.integrations.imessage = {
+    enabled: true,
+    chatId: options.chatId ?? "chat-allowed",
+    receive: {
+      backend: "command",
+      command: {
+        argv,
+        cwd: "~",
+        timeoutMs: 5000,
+      },
+    },
+  };
+  return config;
+}


### PR DESCRIPTION
## Summary
Fail closed on iMessage/SMS inbound polling unless the adapter is scoped to the configured chat id, and drop parsed messages that expose a different chat/conversation/thread id before they can reach the orchestrator.

- Require enabled iMessage receive configs to have a real `config.integrations.imessage.chatId`.
- Require receive command argv to include `{chatId}` for the legacy untagged-output compatibility path.
- Preserve legacy top-level `imessage.chatId` normalization and document the allowlist invariant.

## Design
### iMessage Receive Security
- `src/message-io.ts` — validates the configured chat id before running the receive command, requires scoped `{chatId}` argv, trims the chat id passed into the command context, and filters parsed output by explicit chat/conversation/thread id fields before normalization.
- `src/message-io.ts` — retains compatibility for command output without a chat id only when the command is scoped with `{chatId}`; messages with explicit mismatched ids are silently dropped.

### Tests And Docs
- `test/message-io.test.ts` — covers matching chat ids, mismatched drops, missing chat id fail-closed behavior, unscoped receive command rejection, and the scoped legacy-output exception.
- `test/config.test.ts` — asserts legacy top-level `imessage.chatId` normalizes into an enabled scoped receive integration.
- `README.md` and `docs/integrations.md` — document that the configured chat id is the inbound authority and that explicit mismatched command output is ignored.

## Validation
- `npm run lint` — passed.
- `npm test` — passed, 116 tests.
- `npm run build` — passed.
- `npm run validate` — passed; reran lint, 116 tests, and build.
