### PR TITLE
Add first-party relaymux SQLite store

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Telegram is the main supported interface. iMessage/SMS support exists, but it is
 
 ## Requirements
 
-You need Node.js 20+, npm, `tmux`, and a local agent CLI such as `pi`, `codex`, or `claude`. The installer uses `curl` and `tar` by default; it only needs `git` as a fallback.
+You need Node.js 20+, npm, `tmux`, and a local agent CLI such as `pi`, `codex`, or `claude`. The installer uses `curl` and `tar` by default; it only needs `git` as a fallback. SQLite support uses the system `sqlite3` CLI for `relaymux db` commands; normal launch, status, notify, and adapter commands do not require it.
 
 ## Install
 
@@ -103,3 +103,11 @@ relaymux status --history
 ```
 
 Logs live in `~/.relaymux/logs`. Config lives at `~/.relaymux/config.json`.
+
+relaymux also owns a first-party SQLite database at `~/.relaymux/relaymux.sqlite3` by default. Initialize or inspect it with:
+
+```bash
+relaymux db path
+relaymux db init
+relaymux db status
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,12 +7,30 @@ relaymux stores private config, run records, prompts, logs, and local API token 
 ```text
 ~/.relaymux/
   config.json     # private config, written mode 0600
+  relaymux.sqlite3 # first-party relaymux SQLite database
   state/          # run records, prompts, scripts, schedules, daemon state, local API token
   logs/           # background service stdout/stderr logs
   tasks/          # optional task scratch space
   reports/        # optional reports
   research/       # optional research notes
 ```
+
+## SQLite Store
+
+relaymux owns one canonical SQLite database at `<relaymux home>/relaymux.sqlite3`; with the default home this is `~/.relaymux/relaymux.sqlite3`. The path comes from `RELAYMUX_HOME` when set, otherwise the normal relaymux home, not the current working directory.
+
+The first-party schema is managed by relaymux migrations and uses the `relaymux_` table prefix. Current managed tables are:
+
+| Table | Purpose |
+| --- | --- |
+| `relaymux_schema_migrations` | Applied relaymux DB migrations. |
+| `relaymux_metadata` | Small key/value metadata for the relaymux DB. |
+| `relaymux_runs` | Generic run records for first-party local state. |
+| `relaymux_events` | Generic run/event records for first-party local state. |
+
+Use `relaymux db path`, `relaymux db init`, `relaymux db status`, and `relaymux db schema` to inspect or initialize the database. These commands use the system `sqlite3` CLI; relaymux does not install a native SQLite npm dependency.
+
+Local extension or domain-specific tables can live in the same database, but relaymux only owns and migrates the `relaymux_` tables. Use a distinct table prefix for extension data.
 
 ## Core Config
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -13,7 +13,7 @@ relaymux uninstall-launch-agent
 rm -rf ~/.local/lib/relaymux ~/.local/bin/relaymux
 ```
 
-Optionally remove local state and config after checking for data you want to keep:
+Optionally remove local state, config, and the relaymux SQLite database after checking for data you want to keep:
 
 ```bash
 rm -rf ~/.relaymux
@@ -114,6 +114,17 @@ If the notify token has loose permissions:
 chmod 600 ~/.relaymux/state/webhook-token
 relaymux doctor
 ```
+
+If you want to initialize or inspect the first-party SQLite store:
+
+```bash
+relaymux db path
+relaymux db init
+relaymux db status
+relaymux db schema
+```
+
+`relaymux db init` and live DB status checks require the system `sqlite3` CLI. `relaymux doctor` reports whether it is available, but missing SQLite is warning-only unless you run a DB command.
 
 For a no-adapter smoke test from a clone:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { parseArgv } from "./args.js";
 import { buildAgentInvocation, buildTmuxShellCommand, buildTmuxShellScript, quoteArgv, renderTemplate, shellExportBlock } from "./command.js";
 import { assertNoFatalCommandFindings } from "./command-validation.js";
 import { collectDoctorChecks } from "./doctor.js";
+import { expectedSchemaSql, initRelaymuxDb, relaymuxDbPath, relaymuxDbStatus } from "./db.js";
 import { defaultConfig, defaultConfigPath, getIntegration, isIntegrationEnabled, loadConfig, resolveLogDir, resolveStateDir, writeConfig } from "./config.js";
 import { runDaemon } from "./daemon.js";
 import { backgroundServicePath, getLaunchAgentStatus, getLaunchAgentWatchdogStatus, installLaunchAgent, printLaunchAgentStatus, restartLaunchAgent, uninstallLaunchAgent } from "./launch-agent.js";
@@ -50,6 +51,8 @@ export async function main(argv, io = defaultIo()) {
     switch (parsed.command) {
       case "migrate-home":
         return handleMigrateHome(parsed.flags, configInfo, io);
+      case "db":
+        return handleDb(parsed.flags, parsed.positionals, io);
       case "launch":
         return handleLaunch(parsed.flags, configInfo, stateDir, io);
       case "status":
@@ -350,6 +353,90 @@ function handleMigrateHome(flags, configInfo, io) {
     io.stdout.write(formatHomeMigrationResults(results));
   }
   return 0;
+}
+
+function handleDb(flags, positionals, io) {
+  const subcommand = positionals[0] || "status";
+  const dbPath = relaymuxDbPath(io.env);
+
+  if (subcommand === "path") {
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify({ path: dbPath }, null, 2)}\n`);
+    } else {
+      io.stdout.write(`${dbPath}\n`);
+    }
+    return 0;
+  }
+
+  if (subcommand === "schema") {
+    io.stdout.write(expectedSchemaSql());
+    return 0;
+  }
+
+  if (subcommand === "init") {
+    const result = initRelaymuxDb({ dbPath, env: io.env });
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(dbCommandResult(result), null, 2)}\n`);
+      return 0;
+    }
+
+    io.stdout.write(`DB: ${result.dbPath}\n`);
+    io.stdout.write(`sqlite3: ${result.sqlitePath}\n`);
+    if (result.applied.length === 0) {
+      io.stdout.write(`Schema: up to date at version ${result.currentVersion}\n`);
+    } else {
+      io.stdout.write(`Applied ${result.applied.length} migration(s): ${formatMigrationList(result.applied)}\n`);
+      io.stdout.write(`Schema: version ${result.currentVersion}\n`);
+    }
+    return 0;
+  }
+
+  if (subcommand === "status") {
+    const status = relaymuxDbStatus({ dbPath, env: io.env });
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+    } else {
+      io.stdout.write(formatDbStatus(status));
+    }
+    return status.sqlite.available && !status.error ? 0 : 1;
+  }
+
+  throw new Error(`Unknown db command "${subcommand}". Use path, init, status, or schema.`);
+}
+
+function dbCommandResult(result) {
+  return {
+    dbPath: result.dbPath,
+    sqlitePath: result.sqlitePath,
+    applied: result.applied,
+    migrations: result.migrations,
+    currentVersion: result.currentVersion,
+    expectedVersion: result.expectedVersion,
+  };
+}
+
+function formatDbStatus(status) {
+  const lines = [
+    `DB: ${status.dbPath}`,
+    `sqlite3: ${status.sqlite.available ? status.sqlite.path : "missing"}`,
+    `exists: ${status.exists ? "yes" : "no"}`,
+    `initialized: ${status.initialized ? "yes" : "no"}`,
+    `schema: current ${status.currentVersion}, expected ${status.expectedVersion}, pending ${status.pending.length}`,
+  ];
+  if (status.migrations.length > 0) {
+    lines.push(`migrations: ${formatMigrationList(status.migrations)}`);
+  }
+  if (status.pending.length > 0) {
+    lines.push(`pending: ${formatMigrationList(status.pending)}`);
+  }
+  if (status.error) {
+    lines.push(`error: ${status.error}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function formatMigrationList(migrations) {
+  return migrations.map((migration) => `v${migration.version} ${migration.name}`).join(", ");
 }
 
 function handleLaunch(flags, configInfo, stateDir, io) {
@@ -809,7 +896,7 @@ function handleStatus(flags, configInfo, stateDir, io, platform = process.platfo
 
   const launchAgent: any = daemon.launchAgent;
   const launchAgentText = formatBackgroundServiceSummary(launchAgent, platform);
-  io.stdout.write(`Home: ${daemon.homeDir}; config ${daemon.configPath}; state ${daemon.stateDir}; logs ${daemon.logDir}\n`);
+  io.stdout.write(`Home: ${daemon.homeDir}; config ${daemon.configPath}; state ${daemon.stateDir}; logs ${daemon.logDir}; db ${daemon.dbPath}\n`);
   const watchdog: any = daemon.launchAgentWatchdog;
   const watchdogText = formatBackgroundWatchdogSummary(watchdog, platform);
   io.stdout.write(`Background service: ${daemon.enabled ? "enabled" : "disabled"}; mode ${daemon.launchMode}/background (no tmux); ${launchAgentText}; ${watchdogText}; webhook ${daemon.webhook.endpoints.message}; token ${daemon.webhook.tokenFileExists ? daemon.webhook.tokenFileMode : "missing"}\n`);
@@ -856,6 +943,7 @@ function daemonStatus(config, configPath, env = process.env, platform = process.
   return {
     enabled: config.daemon?.enabled !== false,
     homeDir: path.dirname(defaultConfigPath(env)),
+    dbPath: relaymuxDbPath(env),
     configPath,
     stateDir: resolveStateDir(config, env),
     logDir: resolveLogDir(config, env),
@@ -1076,6 +1164,8 @@ Usage:
   relaymux schedule list|remove [--name <name>]
   relaymux status [--json] [--session <name>]
   relaymux notify [--run-id <id>] [--reply-mode imessage|telegram|none] [--message <text>]
+  relaymux db path|init|status [--json]
+  relaymux db schema
   relaymux migrate-home [--dry-run] [--apply] [--symlink]
   relaymux doctor
 
@@ -1134,6 +1224,12 @@ Request/notify/status options:
   --metadata-json <json>     For notify: optional metadata object
   --history                  For status: include old run records whose tmux tabs are gone
 
+DB options:
+  relaymux db path            Print the canonical relaymux SQLite path
+  relaymux db init            Create/update the first-party relaymux SQLite schema; requires sqlite3
+  relaymux db status          Report sqlite3 availability, DB existence, and migration state
+  relaymux db schema          Print the expected first-party relaymux schema SQL
+
 Schedule options:
   --cron <expr>              Five-field cron schedule for relaymux schedule add
   --scheduler <backend>      auto, launchd, or cron (default auto)
@@ -1145,7 +1241,7 @@ Useful commands:
   tmux attach -t <session>       attach to the shared or named agent session
   tmux kill-session -t <session> kill only that tmux session; background daemon/adapters keep running
 
-Default home layout: ~/.relaymux/{config.json,state,logs,tasks,reports,research}.
+Default home layout: ~/.relaymux/{config.json,relaymux.sqlite3,state,logs,tasks,reports,research}.
 Config defaults to ${defaultConfigPath()} (legacy ~/.config/relaymux/config.json is still read if the new config does not exist).
 `;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { defaultRelaymuxDatabasePath, ensureDirectory } from "./paths.js";
+import { runCommand } from "./process.js";
+
+export const RELAYMUX_DB_MIGRATIONS = [
+  {
+    version: 1,
+    name: "core_metadata",
+    statements: [
+      `CREATE TABLE IF NOT EXISTS relaymux_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+)`,
+    ],
+  },
+  {
+    version: 2,
+    name: "runs_events",
+    statements: [
+      `CREATE TABLE IF NOT EXISTS relaymux_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TEXT NOT NULL,
+  agent TEXT,
+  name TEXT,
+  session TEXT,
+  session_mode TEXT,
+  session_source TEXT,
+  target TEXT,
+  window_target TEXT,
+  repo TEXT,
+  workdir TEXT,
+  prompt_file TEXT,
+  script_file TEXT,
+  command TEXT,
+  payload_json TEXT NOT NULL DEFAULT '{}'
+)`,
+      "CREATE INDEX IF NOT EXISTS relaymux_runs_started_at_idx ON relaymux_runs(started_at)",
+      "CREATE INDEX IF NOT EXISTS relaymux_runs_agent_idx ON relaymux_runs(agent)",
+      `CREATE TABLE IF NOT EXISTS relaymux_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT,
+  time TEXT NOT NULL,
+  event TEXT NOT NULL,
+  message TEXT,
+  exit_code INTEGER,
+  payload_json TEXT NOT NULL DEFAULT '{}'
+)`,
+      "CREATE INDEX IF NOT EXISTS relaymux_events_run_id_idx ON relaymux_events(run_id)",
+      "CREATE INDEX IF NOT EXISTS relaymux_events_time_idx ON relaymux_events(time)",
+    ],
+  },
+];
+
+export function relaymuxDbPath(env = process.env) {
+  return defaultRelaymuxDatabasePath(env);
+}
+
+export function findSqliteCli(env = process.env) {
+  return findExecutable("sqlite3", env);
+}
+
+export function initRelaymuxDb(options: any = {}) {
+  const env = options.env || process.env;
+  const dbPath = options.dbPath || relaymuxDbPath(env);
+  const sqlitePath = resolveSqlitePath(options, env);
+  const runner = options.runCommand || runCommand;
+
+  ensureDirectory(path.dirname(dbPath));
+  runSqlite(sqlitePath, dbPath, bootstrapSql(), { runner, env });
+
+  const before = readAppliedMigrations({ dbPath, sqlitePath, runner, env });
+  const appliedByVersion = new Map<number, any>(before.map((migration) => [migration.version, migration]));
+  const applied: any[] = [];
+
+  for (const migration of RELAYMUX_DB_MIGRATIONS) {
+    const existing = appliedByVersion.get(migration.version);
+    if (existing) {
+      if (existing.name !== migration.name) {
+        throw new Error(`SQLite migration version ${migration.version} is named ${existing.name}, expected ${migration.name}`);
+      }
+      continue;
+    }
+
+    runSqlite(sqlitePath, dbPath, migrationSql(migration), { runner, env });
+    applied.push({ version: migration.version, name: migration.name });
+  }
+
+  writeSchemaVersionMetadata({ dbPath, sqlitePath, runner, env });
+  const migrations = readAppliedMigrations({ dbPath, sqlitePath, runner, env });
+  return {
+    dbPath,
+    sqlitePath,
+    applied,
+    migrations,
+    currentVersion: currentVersion(migrations),
+    expectedVersion: expectedVersion(),
+  };
+}
+
+export function relaymuxDbStatus(options: any = {}) {
+  const env = options.env || process.env;
+  const dbPath = options.dbPath || relaymuxDbPath(env);
+  const sqlitePath = options.sqlitePath || findSqliteCli(env);
+  const exists = fs.existsSync(dbPath);
+  const status: any = {
+    dbPath,
+    sqlite: {
+      available: Boolean(sqlitePath),
+      path: sqlitePath || "",
+    },
+    exists,
+    initialized: false,
+    migrations: [],
+    currentVersion: 0,
+    expectedVersion: expectedVersion(),
+    pending: RELAYMUX_DB_MIGRATIONS.map(({ version, name }) => ({ version, name })),
+    error: "",
+  };
+
+  if (!sqlitePath || !exists) {
+    return status;
+  }
+
+  const runner = options.runCommand || runCommand;
+  try {
+    const hasTable = queryScalar(sqlitePath, dbPath, "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'relaymux_schema_migrations';", { runner, env });
+    if (hasTable !== "relaymux_schema_migrations") {
+      return status;
+    }
+
+    const migrations = readAppliedMigrations({ dbPath, sqlitePath, runner, env });
+    const appliedVersions = new Set(migrations.map((migration) => migration.version));
+    status.initialized = true;
+    status.migrations = migrations;
+    status.currentVersion = currentVersion(migrations);
+    status.pending = RELAYMUX_DB_MIGRATIONS
+      .filter((migration) => !appliedVersions.has(migration.version))
+      .map(({ version, name }) => ({ version, name }));
+  } catch (error) {
+    status.error = error.message;
+  }
+
+  return status;
+}
+
+export function expectedSchemaSql() {
+  const chunks = [bootstrapSql().trim()];
+  for (const migration of RELAYMUX_DB_MIGRATIONS) {
+    chunks.push(`-- migration ${migration.version}: ${migration.name}`);
+    chunks.push(migration.statements.map((statement) => `${statement};`).join("\n"));
+  }
+  return `${chunks.join("\n\n")}\n`;
+}
+
+function resolveSqlitePath(options, env) {
+  const sqlitePath = options.sqlitePath || findSqliteCli(env);
+  if (!sqlitePath) {
+    throw new Error(`sqlite3 CLI not found on PATH; install sqlite3 to use relaymux db commands. DB path: ${relaymuxDbPath(env)}`);
+  }
+  return sqlitePath;
+}
+
+function bootstrapSql() {
+  return [
+    ".bail on",
+    "PRAGMA journal_mode = WAL;",
+    `CREATE TABLE IF NOT EXISTS relaymux_schema_migrations (
+  version INTEGER PRIMARY KEY CHECK (version > 0),
+  name TEXT NOT NULL UNIQUE,
+  applied_at TEXT NOT NULL
+);`,
+  ].join("\n");
+}
+
+function migrationSql(migration) {
+  return [
+    ".bail on",
+    "PRAGMA foreign_keys = ON;",
+    "BEGIN IMMEDIATE;",
+    ...migration.statements.map((statement) => `${statement};`),
+    `INSERT INTO relaymux_schema_migrations(version, name, applied_at)
+VALUES (${migration.version}, '${escapeSql(migration.name)}', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));`,
+    "COMMIT;",
+  ].join("\n");
+}
+
+function writeSchemaVersionMetadata({ dbPath, sqlitePath, runner, env }) {
+  runSqlite(sqlitePath, dbPath, [
+    ".bail on",
+    `INSERT INTO relaymux_metadata(key, value, updated_at)
+VALUES ('schema_version', '${expectedVersion()}', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at;`,
+  ].join("\n"), { runner, env });
+}
+
+function readAppliedMigrations({ dbPath, sqlitePath, runner, env }) {
+  const output = query(sqlitePath, dbPath, [
+    ".mode tabs",
+    "SELECT version, name, applied_at FROM relaymux_schema_migrations ORDER BY version;",
+  ].join("\n"), { runner, env });
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [version, name, appliedAt] = line.split("\t");
+      return {
+        version: Number(version),
+        name,
+        appliedAt,
+      };
+    })
+    .filter((migration) => Number.isFinite(migration.version) && migration.name);
+}
+
+function queryScalar(sqlitePath, dbPath, sql, options) {
+  return query(sqlitePath, dbPath, sql, options).trim();
+}
+
+function query(sqlitePath, dbPath, sql, { runner, env }) {
+  return runSqlite(sqlitePath, dbPath, sql, { runner, env }).stdout;
+}
+
+function runSqlite(sqlitePath, dbPath, sql, { runner, env }) {
+  const result = runner(sqlitePath, ["-batch", dbPath], {
+    input: sql,
+    env,
+    allowFailure: true,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.status !== 0 || result.error) {
+    const detail = result.stderr?.trim() || result.error?.message || `sqlite3 exited with ${result.status}`;
+    throw new Error(detail);
+  }
+  return result;
+}
+
+function currentVersion(migrations) {
+  return migrations.reduce((max, migration) => Math.max(max, migration.version), 0);
+}
+
+function expectedVersion() {
+  return RELAYMUX_DB_MIGRATIONS[RELAYMUX_DB_MIGRATIONS.length - 1]?.version || 0;
+}
+
+function escapeSql(value) {
+  return String(value).replace(/'/g, "''");
+}
+
+function findExecutable(command, env) {
+  if (!command) return null;
+  if (command.includes(path.sep)) {
+    try {
+      fs.accessSync(command, fs.constants.X_OK);
+      return command;
+    } catch {
+      return null;
+    }
+  }
+
+  for (const dir of String(env.PATH || "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, command);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep searching PATH.
+    }
+  }
+  return null;
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -8,6 +8,7 @@ import { runCommand } from "./process.js";
 import { backgroundServicePath, getLaunchAgentStatus, getLaunchAgentWatchdogStatus, launchAgentPath, launchAgentWatchdogPath } from "./launch-agent.js";
 import { defaultRelaymuxHome } from "./paths.js";
 import { webhookStatus } from "./webhook.js";
+import { findSqliteCli, relaymuxDbPath } from "./db.js";
 
 export function findExecutable(command, env = process.env) {
   if (!command) {
@@ -65,6 +66,17 @@ export function collectDoctorChecks(config, configInfo, env = process.env, optio
     name: "relaymux-home",
     ok: true,
     detail: `${defaultRelaymuxHome(env)}; default config ${defaultConfigPath(env)}; state ${resolveStateDir(config, env)}; logs ${resolveLogDir(config, env)}`,
+  });
+
+  const sqlitePath = findSqliteCli(env);
+  checks.push({
+    name: "sqlite3",
+    ok: Boolean(sqlitePath),
+    fatal: false,
+    severity: sqlitePath ? undefined : "warning",
+    detail: sqlitePath
+      ? `${sqlitePath}; relaymux DB ${relaymuxDbPath(env)}`
+      : `not found on PATH; relaymux db init/status need sqlite3; relaymux DB ${relaymuxDbPath(env)}`,
   });
 
   const legacyPath = legacyDefaultConfigPath(env);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -10,6 +10,10 @@ export function defaultRelaymuxHomeConfigValue(env = process.env) {
   return env.RELAYMUX_HOME ? expandPath(env.RELAYMUX_HOME) : "~/.relaymux";
 }
 
+export function defaultRelaymuxDatabasePath(env = process.env) {
+  return path.join(defaultRelaymuxHome(env), "relaymux.sqlite3");
+}
+
 export function expandPath(value, cwd = process.cwd()) {
   if (!value) {
     return value;

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { main } from "../src/cli.js";
+import { expectedSchemaSql, initRelaymuxDb, relaymuxDbPath, relaymuxDbStatus } from "../src/db.js";
+
+function makeIo(env: Record<string, string> = {}) {
+  let stdout = "";
+  let stderr = "";
+  const baseEnv = { ...process.env };
+  delete baseEnv.RELAYMUX_SESSION;
+  return {
+    io: {
+      env: { ...baseEnv, ...env },
+      stdin: { isTTY: false },
+      stdout: { isTTY: false, write: (chunk) => { stdout += String(chunk); } },
+      stderr: { write: (chunk) => { stderr += String(chunk); } },
+    },
+    get stdout() { return stdout; },
+    get stderr() { return stderr; },
+  };
+}
+
+function makeFakeSqliteRunner() {
+  let tableExists = false;
+  const applied = new Map<number, string>();
+  const calls: string[] = [];
+  const stdios: any[] = [];
+
+  const runner = (_command, _args, options) => {
+    const sql = String(options.input || "");
+    calls.push(sql);
+    stdios.push(options.stdio);
+
+    if (sql.includes("CREATE TABLE IF NOT EXISTS relaymux_schema_migrations")) {
+      tableExists = true;
+    }
+
+    if (sql.includes("SELECT name FROM sqlite_master")) {
+      return {
+        status: 0,
+        stdout: tableExists ? "relaymux_schema_migrations\n" : "",
+        stderr: "",
+      };
+    }
+
+    if (sql.includes("SELECT version, name, applied_at FROM relaymux_schema_migrations")) {
+      const rows = [...applied.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([version, name]) => `${version}\t${name}\t2026-06-18T00:00:00.000Z`)
+        .join("\n");
+      return { status: 0, stdout: rows ? `${rows}\n` : "", stderr: "" };
+    }
+
+    const migrationMatch = sql.match(/INSERT INTO relaymux_schema_migrations\(version, name, applied_at\)\s+VALUES \((\d+), '([^']+)'/);
+    if (migrationMatch) {
+      applied.set(Number(migrationMatch[1]), migrationMatch[2]);
+    }
+
+    return { status: 0, stdout: "", stderr: "" };
+  };
+
+  return { runner, calls, stdios };
+}
+
+test("relaymux DB path lives under RELAYMUX_HOME", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-db-home-"));
+  const home = path.join(root, "home");
+
+  assert.equal(relaymuxDbPath({ RELAYMUX_HOME: home }), path.join(home, "relaymux.sqlite3"));
+});
+
+test("SQLite migrations are idempotent through the sqlite runner boundary", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-db-migrate-"));
+  const dbPath = path.join(root, "relaymux.sqlite3");
+  const { runner, calls, stdios } = makeFakeSqliteRunner();
+
+  const first = initRelaymuxDb({ dbPath, sqlitePath: "/fake/sqlite3", runCommand: runner, env: { PATH: "" } });
+  const second = initRelaymuxDb({ dbPath, sqlitePath: "/fake/sqlite3", runCommand: runner, env: { PATH: "" } });
+
+  assert.deepEqual(first.applied.map((migration) => migration.name), ["core_metadata", "runs_events"]);
+  assert.deepEqual(second.applied, []);
+  assert.equal(first.currentVersion, 2);
+  assert.equal(second.currentVersion, 2);
+  assert.ok(calls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS relaymux_metadata")));
+  assert.ok(calls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS relaymux_runs")));
+  assert.ok(calls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS relaymux_events")));
+  assert.ok(stdios.every((stdio) => Array.isArray(stdio) && stdio[0] === "pipe"));
+});
+
+test("DB status reports pending migrations for an existing uninitialized DB", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-db-status-"));
+  const dbPath = path.join(root, "relaymux.sqlite3");
+  fs.writeFileSync(dbPath, "");
+  const { runner } = makeFakeSqliteRunner();
+
+  const status = relaymuxDbStatus({ dbPath, sqlitePath: "/fake/sqlite3", runCommand: runner, env: { PATH: "" } });
+
+  assert.equal(status.exists, true);
+  assert.equal(status.initialized, false);
+  assert.deepEqual(status.pending.map((migration) => migration.name), ["core_metadata", "runs_events"]);
+});
+
+test("expected schema includes first-party relaymux tables", () => {
+  const schema = expectedSchemaSql();
+
+  assert.match(schema, /relaymux_schema_migrations/);
+  assert.match(schema, /relaymux_metadata/);
+  assert.match(schema, /relaymux_runs/);
+  assert.match(schema, /relaymux_events/);
+});
+
+test("relaymux db path is script-friendly and does not require sqlite3", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-db-cli-"));
+  const home = path.join(root, "home");
+  const harness = makeIo({ RELAYMUX_HOME: home, PATH: "" });
+  const code = await main(["db", "path"], harness.io);
+
+  assert.equal(code, 0);
+  assert.equal(harness.stdout.trim(), path.join(home, "relaymux.sqlite3"));
+  assert.equal(harness.stderr, "");
+});
+
+test("relaymux db init fails explicitly when sqlite3 is missing", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-db-cli-missing-"));
+  const harness = makeIo({ RELAYMUX_HOME: path.join(root, "home"), PATH: "" });
+  const code = await main(["db", "init"], harness.io);
+
+  assert.equal(code, 1);
+  assert.match(harness.stderr, /sqlite3 CLI not found on PATH/);
+});
+
+test("relaymux db status reports missing sqlite3 without creating the DB", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-db-cli-status-"));
+  const home = path.join(root, "home");
+  const dbPath = path.join(home, "relaymux.sqlite3");
+  const harness = makeIo({ RELAYMUX_HOME: home, PATH: "" });
+  const code = await main(["db", "status"], harness.io);
+
+  assert.equal(code, 1);
+  assert.match(harness.stdout, /sqlite3: missing/);
+  assert.match(harness.stdout, new RegExp(dbPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.equal(fs.existsSync(dbPath), false);
+});

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -14,6 +14,20 @@ test("doctor does not check optional message adapters by default", () => {
   assert.equal(names.includes("telegram-token"), false);
 });
 
+test("doctor reports sqlite3 as a nonfatal DB dependency", () => {
+  const config = defaultConfig({ PATH: "", RELAYMUX_HOME: "/tmp/relaymux-home" });
+  const checks = collectDoctorChecks(config, { exists: false, path: "/tmp/relaymux-config.json" }, {
+    PATH: "",
+    RELAYMUX_HOME: "/tmp/relaymux-home",
+  });
+  const sqliteCheck = checks.find((check) => check.name === "sqlite3");
+
+  assert.equal(sqliteCheck?.ok, false);
+  assert.equal(sqliteCheck?.fatal, false);
+  assert.equal(sqliteCheck?.severity, "warning");
+  assert.match(sqliteCheck?.detail || "", /relaymux\.sqlite3/);
+});
+
 test("doctor checks Telegram only when enabled without printing token contents", () => {
   const config = {
     ...defaultConfig({ PATH: "" }),


### PR DESCRIPTION
## Summary
Adds first-party relaymux ownership of a canonical local SQLite database at `<relaymux home>/relaymux.sqlite3`, with migrations and small script-friendly `relaymux db` commands.

- Keeps normal launch/status/notify behavior on existing JSONL files; SQLite is only required for DB commands.
- Reports SQLite availability in `doctor` as a nonfatal warning.
- Documents the `relaymux_` table ownership boundary for extension/domain tables.

## Design
### SQLite Store
- `src/paths.ts` — adds the canonical default DB path under relaymux home, derived from `RELAYMUX_HOME`/default home rather than cwd.
- `src/db.ts` — adds the first-party DB module, sqlite3 CLI discovery, migration application/status helpers, and expected schema SQL.
- `src/db.ts` — creates `relaymux_schema_migrations`, `relaymux_metadata`, `relaymux_runs`, and `relaymux_events`; migrations are idempotent and update metadata with the expected schema version.

### CLI And Doctor
- `src/cli.ts` — adds `relaymux db path`, `relaymux db init`, `relaymux db status`, and `relaymux db schema`; `db path` and `db schema` do not require sqlite3.
- `src/cli.ts` — includes the DB path in normal `relaymux status` output without probing SQLite.
- `src/doctor.ts` — reports sqlite3 availability and the DB path as warning-only when missing, so setup and existing commands are not blocked.

### Docs And Tests
- `README.md`, `docs/configuration.md`, `docs/operations.md` — document the canonical DB, sqlite3 CLI dependency, DB commands, and extension table boundary.
- `test/db.test.ts` — covers path resolution, mocked migration idempotency, schema output, CLI path behavior, and missing-sqlite DB command behavior.
- `test/doctor.test.ts` — covers the nonfatal doctor SQLite check.

## Validation
- `npm ci` — passed, 7 packages installed, 0 vulnerabilities.
- `npm run lint` — passed.
- `npm test` — passed, 124 tests.
- `npm run build` — passed.
- `npm run validate` — passed; runs lint, tests, and build, with 124 tests passing.
- Temp-home smoke: `RELAYMUX_HOME=$(mktemp -d ...) node ./dist/bin/relaymux.js db init`, `relaymux db status`, and `sqlite3 <db> .tables` — passed; created schema version 2 with `relaymux_schema_migrations`, `relaymux_metadata`, `relaymux_runs`, and `relaymux_events`.
