### PR TITLE
Use relaymux AGENTS.md for orchestrator instructions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@ relaymux stores private config, run records, prompts, logs, and local API token 
 
 ```text
 ~/.relaymux/
+  AGENTS.md       # primary local orchestrator instructions when present
+  SOUL.md         # optional local personality notes when present
   config.json     # private config, written mode 0600
   relaymux.sqlite3 # first-party relaymux SQLite database
   state/          # run records, prompts, scripts, schedules, daemon state, local API token
@@ -63,6 +65,7 @@ Command arrays are argv templates. `{prompt}` and `{promptFile}` are substituted
     "promptMode": "arg",
     "defaultSystemPrompt": true,
     "systemPromptFile": "",
+    "personalityPromptFile": "",
     "extraSystemPrompt": ""
   },
   "agents": {
@@ -81,11 +84,15 @@ An agent is a command template in `~/.relaymux/config.json`. If you configure `p
 
 The orchestrator is also a command, but it has a different job from an agent. The orchestrator handles inbound requests from `relaymux ask` or optional message adapters. Agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply on stdout.
 
-relaymux owns the generic orchestrator operating instructions in the source repo. By default, every orchestrator request includes those repo-managed instructions: stay local-first, be concise, delegate work that may take more than about 10 seconds with `relaymux launch`, use the configured shared tmux session, prefer prompt files for longer delegated tasks, ask subagents to call `relaymux notify` with idempotency keys, keep quiet updates on `--reply-mode none`, use `relaymux schedule` for recurring prompts, inspect real tmux/repo/test state before claiming completion, and never put secrets in prompts, logs, PRs, or replies.
+relaymux includes a small built-in orchestration baseline by default: stay local-first, be concise, delegate work that may take more than about 10 seconds with `relaymux launch`, use the configured shared tmux session, prefer prompt files for longer delegated tasks, ask subagents to call `relaymux notify` with idempotency keys, keep quiet updates on `--reply-mode none`, use `relaymux schedule` for recurring prompts, inspect real tmux/repo/test state before claiming completion, and never put secrets in prompts, logs, PRs, or replies.
 
 Inline handling is meant only for truly tiny replies, lightweight read-only inspection, or explicit user requests to stay inline. Repo code changes, PR fixes, debugging/deploy work, deep research, CI loops, docs rewrites, long validation, and multi-file edits should normally become visible relaymux subagent runs.
 
-Your config owns local details: adapter tokens and chat IDs, exact agent CLI commands, local working directories, session names, private preferences, and repo-specific overrides. `orchestrator.systemPromptFile` and `orchestrator.extraSystemPrompt` are additive escape hatches for those local preferences; they are not required for best-practice operation. Set `orchestrator.defaultSystemPrompt` to `false` only if you want to fully replace relaymux's repo-managed orchestration guidance.
+Your relaymux home owns local orchestrator instructions. By default, relaymux appends `<relaymux home>/AGENTS.md` when that file exists; set `orchestrator.systemPromptFile` only when you want an explicit configured instructions file instead of the home `AGENTS.md`. relaymux never reads Pi's global `AGENTS.md` under `~/.pi/agent` for orchestrator instructions.
+
+`<relaymux home>/SOUL.md` is optional personality material. It is appended only when present, or when `orchestrator.personalityPromptFile` points to an explicit file. `AGENTS.md` can mention or include `SOUL.md`, but relaymux does not create or require `SOUL.md`.
+
+Your config owns local details: adapter tokens and chat IDs, exact agent CLI commands, local working directories, session names, private preferences, and repo-specific overrides. `orchestrator.extraSystemPrompt` remains an additive escape hatch for short local preferences. Set `orchestrator.defaultSystemPrompt` to `false` only if you want to remove relaymux's built-in orchestration baseline.
 
 Example local override:
 
@@ -93,7 +100,8 @@ Example local override:
 {
   "orchestrator": {
     "defaultSystemPrompt": true,
-    "systemPromptFile": "~/.relaymux/orchestrator.local.md",
+    "systemPromptFile": "~/.relaymux/AGENTS.md",
+    "personalityPromptFile": "~/.relaymux/SOUL.md",
     "extraSystemPrompt": "Use the custom agent first for documentation-only requests."
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,6 @@ relaymux stores private config, run records, prompts, logs, and local API token 
 ```text
 ~/.relaymux/
   AGENTS.md       # primary local orchestrator instructions when present
-  SOUL.md         # optional local personality notes when present
   config.json     # private config, written mode 0600
   relaymux.sqlite3 # first-party relaymux SQLite database
   state/          # run records, prompts, scripts, schedules, daemon state, local API token
@@ -65,7 +64,6 @@ Command arrays are argv templates. `{prompt}` and `{promptFile}` are substituted
     "promptMode": "arg",
     "defaultSystemPrompt": true,
     "systemPromptFile": "",
-    "personalityPromptFile": "",
     "extraSystemPrompt": ""
   },
   "agents": {
@@ -90,8 +88,6 @@ Inline handling is meant only for truly tiny replies, lightweight read-only insp
 
 Your relaymux home owns local orchestrator instructions. By default, relaymux appends `<relaymux home>/AGENTS.md` when that file exists; set `orchestrator.systemPromptFile` only when you want an explicit configured instructions file instead of the home `AGENTS.md`. relaymux never reads Pi's global `AGENTS.md` under `~/.pi/agent` for orchestrator instructions.
 
-`<relaymux home>/SOUL.md` is optional personality material. It is appended only when present, or when `orchestrator.personalityPromptFile` points to an explicit file. `AGENTS.md` can mention or include `SOUL.md`, but relaymux does not create or require `SOUL.md`.
-
 Your config owns local details: adapter tokens and chat IDs, exact agent CLI commands, local working directories, session names, private preferences, and repo-specific overrides. `orchestrator.extraSystemPrompt` remains an additive escape hatch for short local preferences. Set `orchestrator.defaultSystemPrompt` to `false` only if you want to remove relaymux's built-in orchestration baseline.
 
 Example local override:
@@ -101,7 +97,6 @@ Example local override:
   "orchestrator": {
     "defaultSystemPrompt": true,
     "systemPromptFile": "~/.relaymux/AGENTS.md",
-    "personalityPromptFile": "~/.relaymux/SOUL.md",
     "extraSystemPrompt": "Use the custom agent first for documentation-only requests."
   }
 }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -25,7 +25,7 @@ relaymux ask "Open an agent in ~/code/my-app to inspect the failing test."
 
 `relaymux ask` requires the relaymux daemon to be running. `relaymux setup` installs the daemon as a per-user LaunchAgent on macOS or a systemd user service on Linux, and `relaymux restart-launch-agent` reloads it after config changes (the command name is kept for CLI compatibility).
 
-Every local API, adapter, and scheduled request is wrapped with relaymux's built-in orchestration baseline unless `orchestrator.defaultSystemPrompt` is set to `false`. relaymux then appends `<relaymux home>/AGENTS.md` when present, or `orchestrator.systemPromptFile` when configured, and optional personality notes from `<relaymux home>/SOUL.md` or `orchestrator.personalityPromptFile`.
+Every local API, adapter, and scheduled request is wrapped with relaymux's built-in orchestration baseline unless `orchestrator.defaultSystemPrompt` is set to `false`. relaymux then appends `<relaymux home>/AGENTS.md` when present, or `orchestrator.systemPromptFile` when configured.
 
 Those defaults bias the orchestrator toward launching visible relaymux subagents for repo changes, debugging, research, CI, docs, validation, and other work that may take more than about 10 seconds.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -25,7 +25,7 @@ relaymux ask "Open an agent in ~/code/my-app to inspect the failing test."
 
 `relaymux ask` requires the relaymux daemon to be running. `relaymux setup` installs the daemon as a per-user LaunchAgent on macOS or a systemd user service on Linux, and `relaymux restart-launch-agent` reloads it after config changes (the command name is kept for CLI compatibility).
 
-Every local API, adapter, and scheduled request is wrapped with relaymux's repo-managed default orchestrator instructions unless `orchestrator.defaultSystemPrompt` is set to `false`. Local `systemPromptFile` and `extraSystemPrompt` values are appended after those defaults for private preferences or repo-specific guidance.
+Every local API, adapter, and scheduled request is wrapped with relaymux's built-in orchestration baseline unless `orchestrator.defaultSystemPrompt` is set to `false`. relaymux then appends `<relaymux home>/AGENTS.md` when present, or `orchestrator.systemPromptFile` when configured, and optional personality notes from `<relaymux home>/SOUL.md` or `orchestrator.personalityPromptFile`.
 
 Those defaults bias the orchestrator toward launching visible relaymux subagents for repo changes, debugging, research, CI, docs, validation, and other work that may take more than about 10 seconds.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,7 @@ export function defaultConfig(env = process.env) {
       maxBufferBytes: 10 * 1024 * 1024,
       defaultSystemPrompt: true,
       systemPromptFile: "",
+      personalityPromptFile: "",
       extraSystemPrompt: "",
     },
     agents: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,6 @@ export function defaultConfig(env = process.env) {
       maxBufferBytes: 10 * 1024 * 1024,
       defaultSystemPrompt: true,
       systemPromptFile: "",
-      personalityPromptFile: "",
       extraSystemPrompt: "",
     },
     agents: {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -5,7 +5,7 @@ import { randomUUID } from "node:crypto";
 import { buildAgentInvocation } from "./command.js";
 import { DEFAULT_ORCHESTRATOR_SYSTEM_PROMPT, buildRuntimePromptContext } from "./prompt.js";
 import { resolveStateDir, resolveTokenFile } from "./config.js";
-import { defaultRelaymuxHome, expandPath, ensureDirectory, readTextFile } from "./paths.js";
+import { defaultRelaymuxHome, expandPath, ensureDirectory, pathExists, readTextFile } from "./paths.js";
 import { runCommandAsync } from "./async-process.js";
 
 export function buildIncomingOrchestratorPrompt({ config, configPath, incomingText }) {
@@ -52,9 +52,11 @@ export function buildTerminalOrchestratorPrompt({ config, configPath, job }) {
 
 export function buildFullPrompt({ config, configPath, title, body }) {
   const daemon = config.daemon || {};
+  const homeDir = resolveRelaymuxHome(config);
   const system = [
     config.orchestrator?.defaultSystemPrompt === false ? "" : DEFAULT_ORCHESTRATOR_SYSTEM_PROMPT,
-    readOptionalPromptFile(config.orchestrator?.systemPromptFile),
+    readInstructionsPromptFile(config.orchestrator?.systemPromptFile, homeDir),
+    readPersonalityPromptFile(config.orchestrator?.personalityPromptFile, homeDir),
     config.orchestrator?.extraSystemPrompt,
   ].filter((part) => String(part || "").trim()).join("\n\n");
   const host = formatHostForUrl(daemon.host || "127.0.0.1");
@@ -63,7 +65,7 @@ export function buildFullPrompt({ config, configPath, title, body }) {
     configPath,
     session: config.session || "agents",
     sessionMode: config.tmux?.sessionMode || "shared",
-    homeDir: defaultRelaymuxHome(),
+    homeDir,
     stateDir: resolveStateDir(config),
     tokenFile: resolveTokenFile(config),
     webhookUrl,
@@ -128,9 +130,31 @@ function writeOrchestratorPrompt(stateDir, requestId, prompt) {
   return file;
 }
 
-function readOptionalPromptFile(file) {
+function readInstructionsPromptFile(file, homeDir) {
+  if (file) return readRequiredPromptFile(file);
+  return readExistingPromptFile(path.join(homeDir, "AGENTS.md"));
+}
+
+function readPersonalityPromptFile(file, homeDir) {
+  if (file) return readRequiredPromptFile(file);
+  return readExistingPromptFile(path.join(homeDir, "SOUL.md"));
+}
+
+function readRequiredPromptFile(file) {
   if (!file) return "";
   return readTextFile(expandPath(file));
+}
+
+function readExistingPromptFile(file) {
+  return pathExists(file) ? readTextFile(file) : "";
+}
+
+function resolveRelaymuxHome(config) {
+  const stateDir = resolveStateDir(config);
+  if (path.basename(stateDir) === "state") {
+    return path.dirname(stateDir);
+  }
+  return defaultRelaymuxHome();
 }
 
 function sanitizeFilePart(value) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -23,6 +23,7 @@ test("writeDefaultConfig creates a loadable config", () => {
   assert.ok(config.orchestrator.command);
   assert.equal(config.orchestrator.defaultSystemPrompt, true);
   assert.equal(config.orchestrator.systemPromptFile, "");
+  assert.equal(config.orchestrator.personalityPromptFile, "");
   assert.equal(config.orchestrator.extraSystemPrompt, "");
   assert.ok(config.agents.codex);
   assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -23,7 +23,7 @@ test("writeDefaultConfig creates a loadable config", () => {
   assert.ok(config.orchestrator.command);
   assert.equal(config.orchestrator.defaultSystemPrompt, true);
   assert.equal(config.orchestrator.systemPromptFile, "");
-  assert.equal(config.orchestrator.personalityPromptFile, "");
+  assert.equal(Object.prototype.hasOwnProperty.call(config.orchestrator, "personalityPromptFile"), false);
   assert.equal(config.orchestrator.extraSystemPrompt, "");
   assert.ok(config.agents.codex);
   assert.equal(config.agents.codex.command.includes("--reasoning-effort"), false);
@@ -31,6 +31,12 @@ test("writeDefaultConfig creates a loadable config", () => {
   const written = fs.readFileSync(configPath, "utf8");
   assert.doesNotMatch(written, /You are a local relaymux orchestrator/);
   assert.doesNotMatch(written, /SOUL\.md/);
+});
+
+test("public docs do not mention SOUL.md", () => {
+  for (const file of ["README.md", "docs/README.md", "docs/configuration.md", "docs/integrations.md", "docs/operations.md"]) {
+    assert.doesNotMatch(fs.readFileSync(file, "utf8"), /SOUL\.md/, file);
+  }
 });
 
 test("loadConfig treats legacy top-level imessage as enabled integration", () => {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -41,11 +41,32 @@ test("orchestrator requests include repo-managed best practices by default", () 
   assert.match(prompt, /# Terminal request/);
 });
 
+test("orchestrator requests include relaymux home AGENTS.md when present", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-agents-"));
+  const home = path.join(dir, "home");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "AGENTS.md"), "Local relaymux AGENTS instructions.");
+  const config = defaultConfig({ RELAYMUX_HOME: home });
+
+  const prompt = buildTerminalOrchestratorPrompt({
+    config,
+    configPath: path.join(home, "config.json"),
+    job: terminalJob(),
+  });
+
+  assert.match(prompt, /You are a local relaymux orchestrator/);
+  assert.match(prompt, /Local relaymux AGENTS instructions/);
+  assert.ok(prompt.indexOf("You are a local relaymux orchestrator") < prompt.indexOf("Local relaymux AGENTS instructions"));
+});
+
 test("orchestrator prompt file and extra prompt remain additive", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-custom-"));
+  const home = path.join(dir, "home");
   const customPromptFile = path.join(dir, "custom-system-prompt.md");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "AGENTS.md"), "Home AGENTS prompt should not appear.");
   fs.writeFileSync(customPromptFile, "Local custom system prompt.");
-  const config = defaultConfig({ RELAYMUX_HOME: path.join(dir, "home") });
+  const config = defaultConfig({ RELAYMUX_HOME: home });
   config.orchestrator.systemPromptFile = customPromptFile;
   config.orchestrator.extraSystemPrompt = "Extra local prompt.";
 
@@ -58,8 +79,70 @@ test("orchestrator prompt file and extra prompt remain additive", () => {
   assert.match(prompt, /You are a local relaymux orchestrator/);
   assert.match(prompt, /Local custom system prompt/);
   assert.match(prompt, /Extra local prompt/);
+  assert.doesNotMatch(prompt, /Home AGENTS prompt should not appear/);
   assert.ok(prompt.indexOf("You are a local relaymux orchestrator") < prompt.indexOf("Local custom system prompt"));
   assert.ok(prompt.indexOf("Local custom system prompt") < prompt.indexOf("Extra local prompt"));
+});
+
+test("orchestrator includes SOUL.md only when present or explicitly configured", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-soul-"));
+  const home = path.join(dir, "home");
+  const config = defaultConfig({ RELAYMUX_HOME: home });
+
+  let prompt = buildTerminalOrchestratorPrompt({
+    config,
+    configPath: path.join(home, "config.json"),
+    job: terminalJob(),
+  });
+  assert.doesNotMatch(prompt, /Local personality prompt/);
+
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "SOUL.md"), "Local personality prompt.");
+  prompt = buildTerminalOrchestratorPrompt({
+    config,
+    configPath: path.join(home, "config.json"),
+    job: terminalJob(),
+  });
+  assert.match(prompt, /Local personality prompt/);
+
+  const configuredSoul = path.join(dir, "configured-personality.md");
+  fs.writeFileSync(configuredSoul, "Configured personality prompt.");
+  config.orchestrator.personalityPromptFile = configuredSoul;
+  prompt = buildTerminalOrchestratorPrompt({
+    config,
+    configPath: path.join(home, "config.json"),
+    job: terminalJob(),
+  });
+  assert.match(prompt, /Configured personality prompt/);
+  assert.doesNotMatch(prompt, /Local personality prompt/);
+});
+
+test("orchestrator does not read global Pi AGENTS.md", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-no-pi-agents-"));
+  const home = path.join(dir, "home");
+  const userHome = path.join(dir, "user-home");
+  const piAgentDir = path.join(userHome, ".pi", "agent");
+  fs.mkdirSync(piAgentDir, { recursive: true });
+  fs.writeFileSync(path.join(piAgentDir, "AGENTS.md"), "Global Pi AGENTS marker.");
+  const config = defaultConfig({ RELAYMUX_HOME: home });
+  const oldHome = process.env.HOME;
+
+  try {
+    process.env.HOME = userHome;
+    const prompt = buildTerminalOrchestratorPrompt({
+      config,
+      configPath: path.join(home, "config.json"),
+      job: terminalJob(),
+    });
+
+    assert.doesNotMatch(prompt, /Global Pi AGENTS marker/);
+  } finally {
+    if (oldHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = oldHome;
+    }
+  }
 });
 
 test("orchestrator default system prompt can be disabled", () => {

--- a/test/setup-telegram.test.ts
+++ b/test/setup-telegram.test.ts
@@ -49,6 +49,7 @@ test("buildTelegramConfig uses a placeholder orchestrator when no agent CLI is i
   assert.ok(config.orchestrator.description.includes("Placeholder orchestrator"));
   assert.equal(config.orchestrator.defaultSystemPrompt, true);
   assert.equal(config.orchestrator.systemPromptFile, "");
+  assert.equal(config.orchestrator.personalityPromptFile, "");
   assert.equal(config.orchestrator.extraSystemPrompt, "");
   assert.doesNotMatch(JSON.stringify(config), /You are a local relaymux orchestrator/);
   assert.ok(config.agents.custom);

--- a/test/setup-telegram.test.ts
+++ b/test/setup-telegram.test.ts
@@ -49,7 +49,7 @@ test("buildTelegramConfig uses a placeholder orchestrator when no agent CLI is i
   assert.ok(config.orchestrator.description.includes("Placeholder orchestrator"));
   assert.equal(config.orchestrator.defaultSystemPrompt, true);
   assert.equal(config.orchestrator.systemPromptFile, "");
-  assert.equal(config.orchestrator.personalityPromptFile, "");
+  assert.equal(Object.prototype.hasOwnProperty.call(config.orchestrator, "personalityPromptFile"), false);
   assert.equal(config.orchestrator.extraSystemPrompt, "");
   assert.doesNotMatch(JSON.stringify(config), /You are a local relaymux orchestrator/);
   assert.ok(config.agents.custom);


### PR DESCRIPTION
## Summary
Use relaymux-home `AGENTS.md` as the public local orchestrator source of truth without coupling to Pi's global instructions.

- Append `<relaymux home>/AGENTS.md` by default when present, unless `orchestrator.systemPromptFile` is explicitly configured.
- Keep the internal optional personality-file behavior unadvertised and out of generated defaults.
- Document that relaymux does not read `~/.pi/agent/AGENTS.md` for orchestrator prompts.

## Design
### Prompt Loading
- `src/orchestrator.ts` — resolves the relaymux home from the configured state layout, adds default home `AGENTS.md` loading, keeps explicit config paths as overrides for home defaults, and preserves the internal optional personality-file append path.

### Coverage
- `test/orchestrator.test.ts` — covers home `AGENTS.md`, explicit `systemPromptFile` replacing home `AGENTS.md`, internal optional personality-file behavior, and a guard that a global Pi `~/.pi/agent/AGENTS.md` marker is not read.
- `test/config.test.ts` — verifies default generated config does not expose the internal personality hook and public README/docs do not mention the hidden personality filename.
- `test/setup-telegram.test.ts` — pins setup-generated Telegram config so it does not expose the internal personality hook.

### Docs
- `docs/configuration.md` — describes relaymux home `AGENTS.md` as primary local orchestrator instructions and the no-Pi-global-AGENTS boundary.
- `docs/integrations.md` — updates request-wrapping docs to reflect built-in baseline plus local `AGENTS.md` only.

## Validation
- `npx tsx --test test/config.test.ts test/setup-telegram.test.ts test/orchestrator.test.ts` passed: 16 tests.
- `npm run lint` passed.
- `npm test` passed: 128 tests.
- `npm run build` passed.
- `npm run validate` passed: lint, 128 tests, build.
