### PR TITLE
Add notify suicide cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Manual notification test:
 relaymux notify --from test --reply-mode telegram --message "hello from relaymux"
 ```
 
+Disposable worker tabs can add `--suicide` to close only the current tmux window after the notification succeeds.
+
 ## tmux is the workspace
 
 relaymux uses one shared `tmux` session named `agents` by default. Each launched agent gets its own tmux window. This is the core idea: Telegram or iMessage starts and receives updates from work, but tmux keeps that work visible and recoverable locally.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -39,6 +39,8 @@ relaymux notify \
 
 Use a stable `--idempotency-key` for one logical update so retries do not send duplicates. Keys are remembered in the daemon state under `~/.relaymux/state`.
 
+For disposable tmux worker tabs, add `--suicide` to `relaymux notify`. relaymux sends or queues the notification first, then closes only the current tmux window. If notification fails, or if the command is not running inside tmux, relaymux leaves windows alone.
+
 ## Reply Modes
 
 | `replyMode` | Behavior |

--- a/src/args.ts
+++ b/src/args.ts
@@ -18,6 +18,7 @@ const BOOLEAN_FLAGS = new Set([
   "once",
   "print-command",
   "restart",
+  "suicide",
   "symlink",
   "telegram",
   "version",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -907,7 +907,7 @@ Usage:
   relaymux schedule add --name <name> --prompt <text> --cron "0 9 * * *" [--reply-mode none|imessage|telegram] [--scheduler auto|launchd|cron]
   relaymux schedule list|remove [--name <name>]
   relaymux status [--json] [--session <name>]
-  relaymux notify [--run-id <id>] [--reply-mode imessage|telegram|none] [--message <text>]
+  relaymux notify [--run-id <id>] [--reply-mode imessage|telegram|none] [--message <text>] [--suicide]
   relaymux db path|init|status [--json]
   relaymux db schema
   relaymux migrate-home [--dry-run] [--apply] [--symlink]
@@ -966,6 +966,7 @@ Request/notify/status options:
   --from <name>              For notify: source/subagent name
   --idempotency-key <key>    For notify: suppress duplicate completion webhook retries
   --metadata-json <json>     For notify: optional metadata object
+  --suicide                  For notify: after success, close only the current tmux window
   --history                  For status: include old run records whose tmux tabs are gone
 
 DB options:

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,11 +3,20 @@ import fs from "node:fs";
 import { recordEvent } from "./state.js";
 import { renderTemplate } from "./command.js";
 import { runCommand } from "./process.js";
+import { killCurrentWindow } from "./tmux.js";
 import { formatHostForUrl, webhookConfig } from "./webhook.js";
 import { expandPath } from "./paths.js";
 import { isReplyMode, replyModesText } from "./reply-modes.js";
 
-export async function handleNotify({ flags, positionals, config, stateDir, io }) {
+export async function handleNotify({ flags, positionals, config, stateDir, io, tmux = defaultNotifyTmux(io) }) {
+  await performNotify({ flags, positionals, config, stateDir, io });
+
+  if (flags.suicide) {
+    await suicideCurrentTmuxWindow({ io, tmux });
+  }
+}
+
+async function performNotify({ flags, positionals, config, stateDir, io }) {
   const runId = flags.runId || process.env.RELAYMUX_RUN_ID;
   const message = flags.message || flags.text || positionals.join(" ");
   const replyMode = flags.replyMode;
@@ -46,6 +55,44 @@ export async function handleNotify({ flags, positionals, config, stateDir, io })
   }
 
   io.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+function defaultNotifyTmux(io) {
+  return {
+    killCurrentWindow: () => killCurrentWindow({ env: io.env || process.env }),
+  };
+}
+
+async function suicideCurrentTmuxWindow({ io, tmux }) {
+  await flushOutput(io);
+
+  try {
+    const result = await tmux.killCurrentWindow();
+    if (!result?.killed) {
+      const detail = result?.target
+        ? `failed to kill current tmux window ${result.target}: ${result.error || "unknown error"}`
+        : `could not resolve the current tmux window: ${result?.error || "unknown error"}`;
+      io.stderr.write(`relaymux notify: --suicide requested but ${detail}; leaving window open\n`);
+    }
+  } catch (error) {
+    io.stderr.write(`relaymux notify: --suicide requested but current tmux window cleanup failed: ${error.message}; leaving window open\n`);
+  }
+}
+
+async function flushOutput(io) {
+  await Promise.all([
+    flushWritable(io.stdout),
+    flushWritable(io.stderr),
+  ]);
+}
+
+function flushWritable(stream) {
+  if (!stream || typeof stream.write !== "function" || stream.write.length < 2) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    stream.write("", resolve);
+  });
 }
 
 export async function dispatchNotifiers(config, event, io) {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -79,6 +79,62 @@ export function killWindowByName({ session, name }) {
   return result.status === 0;
 }
 
+export function resolveCurrentWindowTarget({ env = process.env }: any = {}) {
+  if (!env?.TMUX || !env?.TMUX_PANE) {
+    return {
+      ok: false,
+      error: "not inside tmux (TMUX/TMUX_PANE is not set)",
+    };
+  }
+
+  const result = runCommand("tmux", ["display-message", "-p", "-t", String(env.TMUX_PANE), "#S:#I"], { allowFailure: true, env });
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      error: tmuxFailureMessage(result, "tmux display-message could not resolve the current window target"),
+    };
+  }
+
+  const target = result.stdout.trim().split("\n")[0]?.trim();
+  if (!target) {
+    return {
+      ok: false,
+      error: "tmux display-message did not return a current window target",
+    };
+  }
+
+  return { ok: true, target };
+}
+
+export function killCurrentWindow({ env = process.env }: any = {}) {
+  const resolved = resolveCurrentWindowTarget({ env });
+  if (!resolved.ok) {
+    return {
+      killed: false,
+      target: "",
+      error: resolved.error,
+    };
+  }
+
+  const result = runCommand("tmux", ["kill-window", "-t", resolved.target], { allowFailure: true, env });
+  if (result.status !== 0) {
+    return {
+      killed: false,
+      target: resolved.target,
+      error: tmuxFailureMessage(result, `tmux kill-window failed for ${resolved.target}`),
+    };
+  }
+
+  return { killed: true, target: resolved.target };
+}
+
+function tmuxFailureMessage(result, fallback) {
+  if (result.error?.message) return result.error.message;
+  const stderr = result.stderr?.trim();
+  if (stderr) return stderr;
+  return fallback;
+}
+
 export function selectLayout(target, layout = "tiled") {
   runCommand("tmux", ["select-layout", "-t", target, layout], { allowFailure: true });
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -35,3 +35,19 @@ test("parseArgv supports global flags before the command", () => {
     config: "relaymux.json",
   });
 });
+
+test("parseArgv recognizes notify --suicide as a boolean flag", () => {
+  const parsed = parseArgv([
+    "notify",
+    "--suicide",
+    "--reply-mode",
+    "imessage",
+    "--message",
+    "done",
+  ]);
+
+  assert.equal(parsed.command, "notify");
+  assert.equal(parsed.flags.suicide, true);
+  assert.equal(parsed.flags.replyMode, "imessage");
+  assert.equal(parsed.flags.message, "done");
+});

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { handleNotify } from "../src/notify.js";
+
+function makeIo(env: Record<string, string> = {}) {
+  let stdout = "";
+  let stderr = "";
+  return {
+    io: {
+      env: { ...process.env, ...env },
+      stdout: { write: (chunk) => { stdout += String(chunk); } },
+      stderr: { write: (chunk) => { stderr += String(chunk); } },
+    },
+    get stdout() { return stdout; },
+    get stderr() { return stderr; },
+  };
+}
+
+function tempStateDir(name: string) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `relaymux-${name}-`));
+}
+
+test("notify --suicide kills the current tmux window after notify succeeds", async () => {
+  const harness = makeIo();
+  const stateDir = tempStateDir("notify-suicide-success");
+  const killedTargets: string[] = [];
+
+  await handleNotify({
+    flags: { runId: "run-1", message: "done", suicide: true },
+    positionals: [],
+    config: {},
+    stateDir,
+    io: harness.io,
+    tmux: {
+      killCurrentWindow: () => {
+        killedTargets.push("agents:3");
+        return { killed: true, target: "agents:3" };
+      },
+    },
+  });
+
+  assert.deepEqual(killedTargets, ["agents:3"]);
+  assert.match(harness.stdout, /"runId":"run-1"/);
+  assert.equal(harness.stderr, "");
+  assert.match(fs.readFileSync(path.join(stateDir, "events.jsonl"), "utf8"), /"message":"done"/);
+});
+
+test("notify failure does not kill the current tmux window", async () => {
+  const harness = makeIo();
+  let killCalls = 0;
+
+  await assert.rejects(
+    () => handleNotify({
+      flags: { replyMode: "bogus", message: "done", suicide: true },
+      positionals: [],
+      config: {},
+      stateDir: tempStateDir("notify-suicide-failure"),
+      io: harness.io,
+      tmux: {
+        killCurrentWindow: () => {
+          killCalls += 1;
+          return { killed: true, target: "agents:3" };
+        },
+      },
+    }),
+    /--reply-mode/,
+  );
+
+  assert.equal(killCalls, 0);
+});
+
+test("notify without --suicide does not touch tmux", async () => {
+  const harness = makeIo();
+
+  await handleNotify({
+    flags: { runId: "run-2", message: "done" },
+    positionals: [],
+    config: {},
+    stateDir: tempStateDir("notify-no-suicide"),
+    io: harness.io,
+    tmux: {
+      killCurrentWindow: () => {
+        throw new Error("tmux should not be called");
+      },
+    },
+  });
+
+  assert.match(harness.stdout, /"runId":"run-2"/);
+  assert.equal(harness.stderr, "");
+});
+
+test("notify --suicide warns when the current tmux window cannot be resolved", async () => {
+  const harness = makeIo();
+
+  await handleNotify({
+    flags: { runId: "run-3", message: "done", suicide: true },
+    positionals: [],
+    config: {},
+    stateDir: tempStateDir("notify-suicide-warning"),
+    io: harness.io,
+    tmux: {
+      killCurrentWindow: () => ({ killed: false, target: "", error: "not inside tmux" }),
+    },
+  });
+
+  assert.match(harness.stdout, /"runId":"run-3"/);
+  assert.match(harness.stderr, /--suicide requested/);
+  assert.match(harness.stderr, /not inside tmux/);
+  assert.match(harness.stderr, /leaving window open/);
+});

--- a/test/tmux.test.ts
+++ b/test/tmux.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { killCurrentWindow } from "../src/tmux.js";
+
+function makeFakeTmux(dir: string, body: string) {
+  const file = path.join(dir, "tmux");
+  fs.writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return file;
+}
+
+test("killCurrentWindow does not resolve or kill without a tmux environment", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-tmux-outside-"));
+  const log = path.join(dir, "tmux.log");
+  makeFakeTmux(dir, `echo "$*" >> ${JSON.stringify(log)}; exit 0`);
+
+  const result = killCurrentWindow({ env: { PATH: dir } });
+
+  assert.equal(result.killed, false);
+  assert.match(result.error, /not inside tmux/);
+  assert.equal(fs.existsSync(log), false);
+});
+
+test("killCurrentWindow resolves the window from the current tmux pane before killing", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-tmux-current-"));
+  const log = path.join(dir, "tmux.log");
+  makeFakeTmux(dir, `
+echo "$*" >> ${JSON.stringify(log)}
+if [ "$1" = "display-message" ]; then
+  printf 'agents:3\n'
+  exit 0
+fi
+exit 0
+`);
+
+  const result = killCurrentWindow({
+    env: {
+      PATH: dir,
+      TMUX: "/tmp/tmux-test/default,1,0",
+      TMUX_PANE: "%9",
+    },
+  });
+
+  assert.deepEqual(result, { killed: true, target: "agents:3" });
+  assert.deepEqual(fs.readFileSync(log, "utf8").trim().split("\n"), [
+    "display-message -p -t %9 #S:#I",
+    "kill-window -t agents:3",
+  ]);
+});


### PR DESCRIPTION
## Summary
Add `relaymux notify --suicide` for disposable tmux worker tabs: it sends/queues the notification first, then closes only the current tmux window after success.

- Normal `relaymux notify` behavior is unchanged without the flag.
- Failed notifications and non-tmux contexts leave windows alone.

## Design
### Notify flow
- `src/args.ts` — registers `--suicide` as a boolean CLI flag so `relaymux notify --suicide` parses without changing positional handling.
- `src/notify.ts` — splits existing notify work into a first-step `performNotify`, then conditionally runs suicide cleanup only after that promise resolves. Cleanup failures write a warning and leave the already-successful notification result intact.
- `src/cli.ts` — documents `--suicide` in the top-level help and notify option list.

### Current-window tmux cleanup
- `src/tmux.ts` — adds `resolveCurrentWindowTarget` and `killCurrentWindow`. The resolver requires tmux environment, asks tmux for the current pane's `#S:#I` target via `display-message -p -t $TMUX_PANE`, and kills only that resolved window target.
- `src/notify.ts` — injects the tmux cleanup dependency for tests and flushes stdout/stderr before attempting to kill the window.

### Tests and docs
- `test/args.test.ts` — covers parsing `notify --suicide` as a boolean.
- `test/notify.test.ts` — covers success-triggered cleanup, failure skipping cleanup, normal notify regression, and warning when cleanup cannot resolve a target.
- `test/tmux.test.ts` — covers outside-tmux no-op behavior and the exact current-pane tmux command sequence used before killing.
- `README.md` and `docs/integrations.md` — explain the disposable-worker use case and safety boundary.

## Validation
- `npm run validate` passed: TypeScript lint, full test suite (`137` tests), and build.
- Live tmux smoke test passed: created a disposable tmux window running local `dist/bin/relaymux.js notify --run-id <smoke> --message ... --suicide`; the window existed before notify, the event was recorded under a temp `RELAYMUX_HOME`, and the window was gone after notify.
