### PR TITLE
Keep relaymux home layout state-focused

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,18 +2,15 @@
 
 `relaymux init` writes a core config with no message adapters at `~/.relaymux/config.json`. The file is private by default and relaymux refuses to overwrite it unless you pass `--force`.
 
-relaymux stores private config, run records, prompts, logs, and local API token state under `~/.relaymux` by default:
+relaymux stores private config, the first-party SQLite database, runtime files, logs, and local API token state under `~/.relaymux` by default:
 
 ```text
 ~/.relaymux/
   AGENTS.md       # primary local orchestrator instructions when present
   config.json     # private config, written mode 0600
   relaymux.sqlite3 # first-party relaymux SQLite database
-  state/          # run records, prompts, scripts, schedules, daemon state, local API token
+  state/          # runtime files: prompts, scripts, schedules, daemon state, local API token
   logs/           # background service stdout/stderr logs
-  tasks/          # optional task scratch space
-  reports/        # optional reports
-  research/       # optional research notes
 ```
 
 ## SQLite Store
@@ -30,6 +27,8 @@ The first-party schema is managed by relaymux migrations and uses the `relaymux_
 | `relaymux_events` | Generic run/event records for first-party local state. |
 
 Use `relaymux db path`, `relaymux db init`, `relaymux db status`, and `relaymux db schema` to inspect or initialize the database. These commands use the system `sqlite3` CLI; relaymux does not install a native SQLite npm dependency.
+
+New durable first-party state should be added here with migrations, not as new top-level home directories. Temporary file artifacts belong under `state/`.
 
 Local extension or domain-specific tables can live in the same database, but relaymux only owns and migrates the `relaymux_` tables. Use a distinct table prefix for extension data.
 
@@ -82,7 +81,7 @@ An agent is a command template in `~/.relaymux/config.json`. If you configure `p
 
 The orchestrator is also a command, but it has a different job from an agent. The orchestrator handles inbound requests from `relaymux ask` or optional message adapters. Agents do delegated work launched with `relaymux launch`. The orchestrator receives incoming text plus relaymux instructions and prints a reply on stdout.
 
-relaymux includes a small built-in orchestration baseline by default: stay local-first, be concise, delegate work that may take more than about 10 seconds with `relaymux launch`, use the configured shared tmux session, prefer prompt files for longer delegated tasks, ask subagents to call `relaymux notify` with idempotency keys, keep quiet updates on `--reply-mode none`, use `relaymux schedule` for recurring prompts, inspect real tmux/repo/test state before claiming completion, and never put secrets in prompts, logs, PRs, or replies.
+relaymux includes a small built-in orchestration baseline by default: stay local-first, be concise, delegate work that may take more than about 10 seconds with `relaymux launch`, use the configured shared tmux session, prefer prompt files for longer delegated tasks, ask subagents to call `relaymux notify` with idempotency keys, keep quiet updates on `--reply-mode none`, use `relaymux schedule` for recurring prompts, keep durable relaymux records in SQLite and unavoidable file artifacts under `state/`, inspect real tmux/repo/test state before claiming completion, and never put secrets in prompts, logs, PRs, or replies.
 
 Inline handling is meant only for truly tiny replies, lightweight read-only inspection, or explicit user requests to stay inline. Repo code changes, PR fixes, debugging/deploy work, deep research, CI loops, docs rewrites, long validation, and multi-file edits should normally become visible relaymux subagent runs.
 

--- a/skills/relaymux/SKILL.md
+++ b/skills/relaymux/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: relaymux
+description: Use relaymux directly or as a base layer for skills that launch, monitor, notify, schedule, or steer local CLI agents in tmux. Lightweight reference for relaymux's mental model and core commands.
+---
+
+# relaymux
+
+Use this skill when working with relaymux itself or when another skill needs to delegate work through relaymux.
+
+## Mental Model
+
+relaymux coordinates local CLI agents in tmux windows. It does not use tmux panes. A background daemon/local API can run outside tmux when installed, while launched agents stay visible in tmux so a human can attach, inspect, interrupt, or recover them.
+
+By default, relaymux uses one shared tmux session. Pass `--session` only when you intentionally want a separate or named tmux session. Managed config, state, logs, prompts, scratch files, reports, research files, and the SQLite database live under `~/.relaymux` by default.
+
+`relaymux status` is the source of truth for relaymux-launched runs.
+
+## Core Commands
+
+Run setup and health checks with:
+
+```bash
+relaymux setup
+relaymux status
+relaymux doctor
+relaymux status-launch-agent --json
+```
+
+Launch an agent in a repository:
+
+```bash
+relaymux launch \
+  --repo <repo-path> \
+  --agent <pi|codex|claude|other> \
+  --name <short-window-name> \
+  --prompt '<specific task, constraints, validation, reporting instructions>'
+```
+
+For long or high-stakes prompts, write the prompt to a file and pass it with `--prompt-file`:
+
+```bash
+relaymux launch \
+  --repo <repo-path> \
+  --agent <agent> \
+  --name <short-window-name> \
+  --prompt-file /tmp/<task>-prompt.md
+```
+
+Launch in a git worktree when work should be isolated:
+
+```bash
+relaymux launch \
+  --repo <source-repo> \
+  --worktree <worktree-path> \
+  --create-worktree \
+  --worktree-branch <branch-name> \
+  --worktree-from origin/main \
+  --agent <agent> \
+  --name <short-window-name> \
+  --prompt-file /tmp/<task>-prompt.md
+```
+
+Send a one-off request to the relaymux daemon:
+
+```bash
+relaymux ask '<request>' --reply-mode none
+relaymux ask '<request>' --no-wait --reply-mode imessage
+```
+
+Report completion or status from a subagent:
+
+```bash
+relaymux notify \
+  --from <subagent-name> \
+  --reply-mode imessage \
+  --idempotency-key '<stable-task-key>-done' \
+  --message 'Done: summary. Validation: commands/results. Blockers: none or list.'
+```
+
+Use `--reply-mode none` for quiet context-only updates. Use `--suicide` only when the current tmux window is disposable and the task policy permits closing it.
+
+Schedule recurring relaymux requests:
+
+```bash
+relaymux schedule add \
+  --name <name> \
+  --prompt '<prompt>' \
+  --cron '*/15 * * * *' \
+  --reply-mode none
+
+relaymux schedule list
+relaymux schedule remove --name <name>
+```
+
+## Delegated Prompt Shape
+
+Make delegated prompts self-contained. Include the repo or worktree path, exact scope, non-goals, files or areas to inspect first when known, instructions to read local repo guidance before editing, validation commands, and the expected final `relaymux notify` command.
+
+Prefer prompt files for multi-line instructions so shell quoting does not corrupt the task.
+
+## Steering Existing Runs
+
+If a follow-up belongs to an existing relaymux run, steer that run instead of launching a duplicate. Do not paste multi-line steering text directly into interactive TUIs that split input by newline. Write the instruction to a temp file and send one single-line steering message such as:
+
+```text
+Read and apply /tmp/<task>-followup.md
+```
+
+If a run is already confused by fragmented steering, stop and restart only when the task policy allows it.
+
+## Safety Rules
+
+Do not overwrite, revert, or race another agent's work. Do not close or kill relaymux/tmux code-task windows unless the user explicitly asks or the project policy says the work is safe to clean up.
+
+For long-running delegated work, keep a lightweight status check running when useful. Remove scheduled status checks when no active jobs or blockers remain.
+
+Report status concisely: what is running, what is blocked, and what needs human input.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -324,7 +324,6 @@ function handleMigrateHome(flags, configInfo, io) {
     legacyConfigPath: flags.legacyConfig,
     legacyStateDir: flags.legacyStateDir,
     orchestratorImessageDir: flags.orchestratorImessageDir,
-    researchDir: flags.researchDir,
     agentmuxConfigPath: flags.agentmuxConfig,
     agentmuxStateDir: flags.agentmuxStateDir,
     configPath: configInfo.exists ? configInfo.path : undefined,
@@ -986,7 +985,7 @@ Useful commands:
   tmux attach -t <session>       attach to the shared or named agent session
   tmux kill-session -t <session> kill only that tmux session; background daemon/adapters keep running
 
-Default home layout: ~/.relaymux/{config.json,relaymux.sqlite3,state,logs,tasks,reports,research}.
+Default home layout: ~/.relaymux/{config.json,relaymux.sqlite3,state,logs}.
 Config defaults to ${defaultConfigPath()} (legacy ~/.config/relaymux/config.json is still read if the new config does not exist).
 `;
 }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { defaultConfigPath, legacyDefaultConfigPath, legacyDefaultStateDir } from "./config.js";
 import { defaultRelaymuxHome, expandPath, ensureDirectory } from "./paths.js";
 
-const HOME_SUBDIRS = ["state", "logs", "tasks", "reports", "research"];
+const HOME_SUBDIRS = ["state", "logs"];
 const STATE_RELAYMUX_NAMES = new Set([
   "daemon-state.json",
   "events.jsonl",
@@ -109,22 +109,6 @@ export function buildHomeMigrationInventory(options: any = {}, env = process.env
     addOrchestratorImessageDir({ root: orchestratorImessageDir, stateDir, logsDir, addItem });
   }
 
-  const researchDir = expandPath(options.researchDir || path.join(os.homedir(), "research"));
-  if (dirExists(researchDir) && !isInside(researchDir, homeDir)) {
-    for (const entry of fs.readdirSync(researchDir, { withFileTypes: true })) {
-      if (!/^orchestrator-prompts-/.test(entry.name)) continue;
-      const source = path.join(researchDir, entry.name);
-      addItem({
-        operation: "copy",
-        kind: entry.isDirectory() ? "dir" : "file",
-        source,
-        destination: path.join(homeDir, "research", entry.name),
-        reason: "relaymux/orchestrator prompt scratch under ~/research",
-        secret: false,
-      });
-    }
-  }
-
   const agentmuxConfig = expandPath(options.agentmuxConfigPath || path.join(os.homedir(), ".config", "agentmux", "config.json"));
   if (fileExists(agentmuxConfig) && !samePath(agentmuxConfig, targetConfigPath) && isRelaymuxConfigFile(agentmuxConfig)) {
     addItem({
@@ -161,7 +145,7 @@ export function formatHomeMigrationInventory(inventory, { applying = false, forc
   lines.push(`relaymux home: ${inventory.homeDir}`);
   lines.push(`target config: ${inventory.configPath}`);
   lines.push(`mode: ${applying ? "apply" : "dry-run/inventory"}${force ? "; force overwrite" : ""}${symlink ? "; replace migrated sources with symlinks" : ""}`);
-  lines.push("managed layout: config.json, state/, logs/, tasks/, reports/, research/");
+  lines.push("managed layout: config.json, relaymux.sqlite3, state/, logs/");
 
   if (!inventory.items.length) {
     lines.push("No relaymux-owned legacy files found in known locations.");

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -16,8 +16,8 @@ Delegating with relaymux:
 - If the user asks for a separate/new/named tmux session, add --session <name>.
 - If the user asks for per-worktree sessions, add --session-mode per-worktree.
 - Prefer a focused prompt file for multi-line delegated instructions.
-- Put relaymux-generated prompt files, task scratch, research notes, and reports under the relaymux managed home shown in runtime context unless the user provides an explicit path.
-- Do not move or rewrite existing personal canonical files just because they look related; inventory and ask before migrating them.
+- Keep durable relaymux records in the relaymux SQLite DB. When a file artifact is unavoidable, put it under the state directory shown in runtime context unless the user provides an explicit path.
+- Do not create top-level non-state directories under the relaymux managed home. Do not move or rewrite existing user-owned canonical files just because they look related; inventory and ask before migrating them.
 - Give each subagent exact scope, files or areas to inspect first when known, acceptance criteria, and validation commands.
 - Ask subagents to report meaningful completion or blockers with relaymux notify.
 - After launching a subagent, inspect relaymux status and the tmux window/pane output before claiming that it started.
@@ -50,7 +50,7 @@ export function buildRuntimePromptContext({ configPath, homeDir, stateDir, sessi
     : "creates a tab/window in a per-worktree session because this config explicitly opts into per-worktree mode";
   return `Runtime context:
 - relaymux config: ${configPath}
-- relaymux managed home: ${homeDir} (state ${stateDir}; logs ${homeDir}/logs; task scratch ${homeDir}/tasks; research ${homeDir}/research; reports ${homeDir}/reports)
+- relaymux managed home: ${homeDir} (db ${homeDir}/relaymux.sqlite3; state ${stateDir}; logs ${homeDir}/logs; file artifacts and implementation notes belong under state/)
 - background service: direct/background process outside tmux when installed
 - tmux model: ${grouping}; agents appear as tabs/windows, never panes/splits
 - local completion webhook: ${webhookUrl}

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { applyHomeMigration, buildHomeMigrationInventory, migrateConfigObject } from "../src/migration.js";
+import { applyHomeMigration, buildHomeMigrationInventory, ensureRelaymuxHomeLayout, migrateConfigObject } from "../src/migration.js";
 
 function makeLayout() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-migrate-"));
@@ -14,7 +14,6 @@ function makeLayout() {
     legacyConfigPath: path.join(root, "xdg", "relaymux", "config.json"),
     legacyStateDir: path.join(root, "state", "relaymux"),
     orchestratorImessageDir: path.join(root, "orchestrator-imessage"),
-    researchDir: path.join(root, "research"),
     agentmuxConfigPath: path.join(root, "agentmux", "config.json"),
     agentmuxStateDir: path.join(root, "agentmux-state"),
   };
@@ -38,31 +37,37 @@ test("migrateConfigObject rewrites only managed legacy relaymux paths", () => {
   assert.deepEqual(migrated.orchestrator.command, ["pi", "--session-dir", "/tmp/relaymux-home/state/sessions", "{prompt}"]);
 });
 
-test("migration inventory finds only relaymux-owned legacy state and scratch", () => {
+test("migration inventory finds only relaymux-owned legacy state", () => {
   const layout = makeLayout();
   fs.mkdirSync(path.dirname(layout.legacyConfigPath), { recursive: true });
   fs.writeFileSync(layout.legacyConfigPath, JSON.stringify({ stateDir: "~/.local/state/relaymux", imessage: {}, daemon: {} }));
   fs.mkdirSync(layout.legacyStateDir, { recursive: true });
   fs.writeFileSync(path.join(layout.legacyStateDir, "runs.jsonl"), "{}\n");
   fs.writeFileSync(path.join(layout.legacyStateDir, "webhook-token"), "do-not-print\n", { mode: 0o644 });
-  fs.mkdirSync(layout.researchDir, { recursive: true });
-  fs.writeFileSync(path.join(layout.researchDir, "personal-notes.md"), "leave me alone\n");
-  fs.mkdirSync(path.join(layout.researchDir, "orchestrator-prompts-abc"));
 
   const inventory = buildHomeMigrationInventory({
     homeDir: layout.home,
     legacyConfigPath: layout.legacyConfigPath,
     legacyStateDir: layout.legacyStateDir,
     orchestratorImessageDir: layout.orchestratorImessageDir,
-    researchDir: layout.researchDir,
     agentmuxConfigPath: layout.agentmuxConfigPath,
     agentmuxStateDir: layout.agentmuxStateDir,
   }, { RELAYMUX_HOME: layout.home });
 
   assert.ok(inventory.items.some((item) => item.operation === "migrate-config" && item.source === layout.legacyConfigPath));
   assert.ok(inventory.items.some((item) => item.source.endsWith("webhook-token") && item.secret));
-  assert.ok(inventory.items.some((item) => item.source.endsWith("orchestrator-prompts-abc")));
-  assert.ok(!inventory.items.some((item) => item.source.endsWith("personal-notes.md")));
+});
+
+test("ensureRelaymuxHomeLayout creates only state and logs directories", () => {
+  const layout = makeLayout();
+
+  ensureRelaymuxHomeLayout(layout.home);
+
+  assert.equal(fs.statSync(path.join(layout.home, "state")).isDirectory(), true);
+  assert.equal(fs.statSync(path.join(layout.home, "logs")).isDirectory(), true);
+  for (const name of ["tasks", "reports", "research", "personal", "implementation-notes"]) {
+    assert.equal(fs.existsSync(path.join(layout.home, name)), false, name);
+  }
 });
 
 test("applyHomeMigration copies config, state, logs, and keeps tokens private", () => {
@@ -86,7 +91,6 @@ test("applyHomeMigration copies config, state, logs, and keeps tokens private", 
     legacyConfigPath: layout.legacyConfigPath,
     legacyStateDir: layout.legacyStateDir,
     orchestratorImessageDir: layout.orchestratorImessageDir,
-    researchDir: layout.researchDir,
     agentmuxConfigPath: layout.agentmuxConfigPath,
     agentmuxStateDir: layout.agentmuxStateDir,
   }, env);

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -32,6 +32,8 @@ test("orchestrator requests include repo-managed best practices by default", () 
   assert.match(prompt, /Delegate by default when the work may take more than about 10 seconds/);
   assert.match(prompt, /repo code changes, PR fixes, deploy\/debugging work, deep research, CI loops, docs rewrites, long validation, and multi-file edits/);
   assert.match(prompt, /Do truly tiny replies and lightweight read-only inspection inline/);
+  assert.match(prompt, /durable relaymux records in the relaymux SQLite DB/);
+  assert.match(prompt, /file artifacts and implementation notes belong under state\//);
   assert.match(prompt, /Do not add --session or --session-mode/);
   assert.match(prompt, /inspect relaymux status and the tmux window\/pane output before claiming that it started/);
   assert.match(prompt, /belongs to an existing active subagent\/tab, send the instruction to that tab instead of launching a duplicate run/);


### PR DESCRIPTION
## Summary
Keep the relaymux managed home focused on SQLite plus state/log artifacts instead of creating or migrating top-level scratch/research/report directories.

- Updates orchestrator guidance to store durable records in SQLite and unavoidable files under state.
- Adds a checked-in relaymux skill reference for delegation, status, notify, and scheduling workflows.

## Design
### Managed home layout and migration
- `src/migration.ts` — reduces the default home subdirectories to `state/` and `logs/`, updates migration inventory text to include `relaymux.sqlite3`, and stops scanning `~/research/orchestrator-prompts-*` as relaymux-owned migration input.
- `src/cli.ts` — removes the unused `researchDir` migration option wiring and updates the CLI help text so the advertised default layout matches the new managed-home boundary.
- `test/migration.test.ts` — updates migration inventory coverage and adds `ensureRelaymuxHomeLayout` coverage to assert it does not create `tasks/`, `reports/`, `research/`, or other top-level non-state directories.

### Orchestrator and docs guidance
- `src/prompt.ts` — changes the default orchestrator instructions/runtime context to prefer the relaymux SQLite DB for durable records and direct unavoidable file artifacts or implementation notes to the state directory.
- `test/orchestrator.test.ts` — verifies the default orchestrator prompt includes the new SQLite/state guidance.
- `docs/configuration.md` — aligns the configuration docs with the narrower home layout and mentions durable relaymux records in SQLite/state instead of broader scratch directories.

### Agent skill reference
- `skills/relaymux/SKILL.md` — adds a lightweight relaymux skill covering the tmux-window mental model, launch/status/notify/schedule commands, delegated prompt shape, steering existing runs, and safety rules.

## Validation
- `npm run validate` — passed: lint (`tsc --noEmit`), tests (138 passed), and build completed successfully.
