### PR TITLE
Reuse one persistent tmux window per scheduled job

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A relaymux run is an ordinary agent process in its own tmux **window**—the tab
 - keep multiple agents visible in one shared session;
 - reconnect after closing a terminal or losing an SSH connection.
 
-relaymux creates the `agents` session by default. If you reuse a name within a session, relaymux closes the previous window with that name before creating the new one. It never launches agents in hidden panes or a remote cloud worker.
+relaymux creates the `agents` session by default. A directly launched agent gets its own tmux window. Scheduled (recurring) launches reuse one persistent window per schedule: each tick replaces the previous run in the same schedule-named tab instead of accumulating a new tab, and superseded runs are marked reaped. Pass `--no-reuse-window` to opt out for a scheduled launch. relaymux never launches agents in hidden panes or a remote cloud worker.
 
 ## Add a local orchestrator
 
@@ -154,6 +154,8 @@ relaymux schedule remove --name weekday-status
 ```
 
 The expression uses five cron fields (minute, hour, day-of-month, month, day-of-week) in the system timezone. Pass `--scheduler launchd` or `--scheduler cron` to choose the backend explicitly; `auto` uses launchd on macOS and cron on Linux. Missed runs, overlapping runs, and machine-sleep gaps are not replayed.
+
+When a scheduled prompt delegates work via `relaymux launch`, that launch reuses one persistent tmux window per schedule (named after the schedule) instead of opening a new tab every tick. The previous tick's window is replaced and its run record is marked reaped, so `relaymux status` shows one current run per schedule. One-off `relaymux launch` calls keep unique-tab behavior. Pass `--no-reuse-window` to opt out for a single scheduled launch, or `--schedule-name <name>` to force persistent-reuse on an ad-hoc launch.
 
 ## Configuration and operations
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -75,6 +75,15 @@ relaymux schedule remove --name weekday-checkin
 
 `--reply-mode none` keeps the request local and quiet. `--reply-mode imessage` or `--reply-mode telegram` sends the orchestrator's final reply through that configured adapter. Cron expressions use five fields: minute, hour, day of month, month, and day of week. When a schedule uses launchd, avoid expressions that constrain both day of month and day of week because launchd matches those fields differently from cron.
 
+### Persistent scheduled windows
+
+When a scheduled prompt delegates work via `relaymux launch`, the launch reuses one persistent tmux window per schedule (named after the schedule) instead of opening a new tab every tick. The daemon exposes the schedule name to the orchestrator through the `RELAYMUX_SCHEDULE_NAME` environment variable, which propagates to `relaymux launch` calls made while handling that tick. The previous tick's window is replaced and its run record is marked reaped, so `relaymux status` shows one current run per schedule rather than a growing pile of tabs.
+
+One-off `relaymux launch` calls keep unique-tab behavior. Control persistent reuse with:
+
+- `--schedule-name <name>` — force persistent-reuse on an ad-hoc launch keyed to this schedule name
+- `--reuse-window` / `--no-reuse-window` — explicitly enable or disable reuse for a launch (reuse is on by default when a schedule name is present)
+
 ## Direct HTTP
 
 For foreground debugging instead of the installed background service, run `relaymux daemon`. If you cannot use the CLI helper, you can call the local API directly:

--- a/src/args.ts
+++ b/src/args.ts
@@ -18,6 +18,7 @@ const BOOLEAN_FLAGS = new Set([
   "once",
   "print-command",
   "restart",
+  "reuse-window",
   "suicide",
   "symlink",
   "telegram",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { createCommandWindow, killWindowByName, listAgentWindows, setWindowMetad
 import { createWorktree, resolveRepoAndWorkdir } from "./worktree.js";
 import { isReplyMode, replyModesText } from "./reply-modes.js";
 import { resolveAgentConfig } from "./launch/agents.js";
-import { makeRunId, sanitizeLaunchName } from "./launch/names.js";
+import { makeRunId, sanitizeLaunchName, sanitizeScheduleName } from "./launch/names.js";
 import { resolveLaunchNotification } from "./launch/notifications.js";
 import { launchTmuxAgent } from "./launch/tmux.js";
 import { handleStatus } from "./status.js";
@@ -458,6 +458,9 @@ function handleLaunch(flags, configInfo, stateDir, io) {
   const holdOnExit = flags.hold ?? config.holdOnExit ?? false;
   const launchNotification = resolveLaunchNotification(flags, config);
 
+  const scheduleName = resolveScheduleName(flags, io.env);
+  const reuseWindow = flags.reuseWindow;
+
   if (!flags.dryRun && worktreeAddArgs) {
     createWorktree(worktreeAddArgs);
   }
@@ -478,6 +481,8 @@ function handleLaunch(flags, configInfo, stateDir, io) {
     quoteArgv,
     repo,
     runId,
+    scheduleName,
+    reuseWindow,
     session: sessionInfo.session,
     sessionInfo,
     stateDir,
@@ -813,6 +818,21 @@ function resolveRequestText(flags, positionals) {
   throw new Error("Missing request text. Use `relaymux ask <text>` or --message <text>.");
 }
 
+function resolveScheduleName(flags, env = process.env) {
+  if (flags.scheduleName !== undefined) {
+    return sanitizeScheduleName(flags.scheduleName);
+  }
+  const fromEnv = String(env.RELAYMUX_SCHEDULE_NAME || "").trim();
+  if (fromEnv) {
+    try {
+      return sanitizeScheduleName(fromEnv);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
 function parseMetadataJson(raw) {
   try {
     const parsed = JSON.parse(String(raw));
@@ -951,6 +971,9 @@ Launch options:
   --notify-reply-mode <mode> imessage/telegram sends adapter updates; none records quiet completion context
   --notify-tail-lines <n>    Recent tmux output lines to include for nonzero auto notifications
   --notify-tail-bytes <n>    Max bytes of recent tmux output in nonzero auto notifications
+  --schedule-name <name>     Reuse one persistent tmux window for this schedule (scheduled launches default to reuse via RELAYMUX_SCHEDULE_NAME)
+  --reuse-window             Force persistent-window reuse for this launch (default on when --schedule-name/RELAYMUX_SCHEDULE_NAME is set)
+  --no-reuse-window          Opt out of persistent-window reuse for a scheduled launch
 
 Background service options:
   --no-load                  Write the service file without loading/starting it

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -15,7 +15,7 @@ import {
   timedStage,
 } from "./daemon-jobs.js";
 import { createCompletionWebhookServer } from "./webhook.js";
-import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorPrompt, runOrchestrator } from "./orchestrator.js";
+import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorPrompt, runOrchestrator, scheduleNameFromSource } from "./orchestrator.js";
 import { formatIncomingForPrompt, isImessageReceiveEnabled, isIncomingUserMessage, receiveMessages, sendMessage } from "./message-io.js";
 import { isTelegramReceiveEnabled, receiveTelegramMessages, sendTelegramMessage } from "./telegram.js";
 import { ensureDirectory } from "./paths.js";
@@ -165,7 +165,8 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     let status = "ok";
     try {
       const prompt = buildTerminalOrchestratorPrompt({ config, configPath: configInfo.path, job });
-      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
+      const scheduleName = scheduleNameFromSource(job.source);
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId, scheduleName }));
       if (job.replyMode === "none") {
         log(`processed terminal request ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
       } else {

--- a/src/db.ts
+++ b/src/db.ts
@@ -52,6 +52,15 @@ export const RELAYMUX_DB_MIGRATIONS = [
       "CREATE INDEX IF NOT EXISTS relaymux_events_time_idx ON relaymux_events(time)",
     ],
   },
+  {
+    version: 3,
+    name: "runs_schedule",
+    statements: [
+      "ALTER TABLE relaymux_runs ADD COLUMN schedule_name TEXT",
+      "CREATE INDEX IF NOT EXISTS relaymux_runs_schedule_name_idx ON relaymux_runs(schedule_name)",
+      "ALTER TABLE relaymux_events ADD COLUMN schedule_name TEXT",
+    ],
+  },
 ];
 
 export function relaymuxDbPath(env = process.env) {
@@ -249,6 +258,133 @@ function expectedVersion() {
 
 function escapeSql(value) {
   return String(value).replace(/'/g, "''");
+}
+
+function sqlValue(value) {
+  return value === undefined || value === null ? "NULL" : `'${escapeSql(String(value))}'`;
+}
+
+function sqlJson(value) {
+  return sqlValue(JSON.stringify(value ?? {}));
+}
+
+// Resolve a usable sqlite runner + path for state mirroring. Returns null when
+// sqlite3 is missing or the DB has not been initialized, so callers can no-op
+// gracefully without failing launch/status.
+export function resolveStateDb({ dbPath, env = process.env, sqlitePath, runCommand: runner }: { dbPath?: string; env?: any; sqlitePath?: string; runCommand?: any } = {}) {
+  const resolvedDb = dbPath || relaymuxDbPath(env);
+  const resolvedSqlite = sqlitePath || findSqliteCli(env);
+  if (!resolvedSqlite || !fs.existsSync(resolvedDb)) return null;
+  const status = relaymuxDbStatus({ dbPath: resolvedDb, sqlitePath: resolvedSqlite, runCommand: runner, env });
+  if (!status.initialized || status.pending.length > 0) return null;
+  return { dbPath: resolvedDb, sqlitePath: resolvedSqlite, runner: runner || runCommand };
+}
+
+export function upsertRunInDb(handle, run) {
+  if (!handle) return false;
+  const payload = { ...run };
+  delete payload.runId;
+  const sql = [
+    ".bail on",
+    "BEGIN IMMEDIATE;",
+    `INSERT INTO relaymux_runs (
+  run_id, started_at, agent, name, session, session_mode, session_source,
+  target, window_target, repo, workdir, prompt_file, script_file, command,
+  schedule_name, payload_json
+) VALUES (
+  ${sqlValue(run.runId)},
+  ${sqlValue(run.time)},
+  ${sqlValue(run.agent)},
+  ${sqlValue(run.name)},
+  ${sqlValue(run.session)},
+  ${sqlValue(run.sessionMode)},
+  ${sqlValue(run.sessionSource)},
+  ${sqlValue(run.target)},
+  ${sqlValue(run.windowTarget)},
+  ${sqlValue(run.repo)},
+  ${sqlValue(run.workdir)},
+  ${sqlValue(run.promptFile)},
+  ${sqlValue(run.scriptFile)},
+  ${sqlValue(run.command)},
+  ${sqlValue(run.scheduleName)},
+  ${sqlJson(payload)}
+)
+ON CONFLICT(run_id) DO UPDATE SET
+  started_at = excluded.started_at,
+  agent = excluded.agent,
+  name = excluded.name,
+  session = excluded.session,
+  session_mode = excluded.session_mode,
+  session_source = excluded.session_source,
+  target = excluded.target,
+  window_target = excluded.window_target,
+  repo = excluded.repo,
+  workdir = excluded.workdir,
+  prompt_file = excluded.prompt_file,
+  script_file = excluded.script_file,
+  command = excluded.command,
+  schedule_name = excluded.schedule_name,
+  payload_json = excluded.payload_json;`,
+    "COMMIT;",
+  ].join("\n");
+  runSqlite(handle.sqlitePath, handle.dbPath, sql, { runner: handle.runner, env: process.env });
+  return true;
+}
+
+export function insertEventInDb(handle, event) {
+  if (!handle) return false;
+  const payload = { ...event };
+  delete payload.runId;
+  delete payload.event;
+  delete payload.time;
+  delete payload.message;
+  delete payload.exitCode;
+  delete payload.scheduleName;
+  const sql = [
+    ".bail on",
+    "BEGIN IMMEDIATE;",
+    `INSERT INTO relaymux_events (
+  run_id, time, event, message, exit_code, schedule_name, payload_json
+) VALUES (
+  ${sqlValue(event.runId)},
+  ${sqlValue(event.time)},
+  ${sqlValue(event.event)},
+  ${sqlValue(event.message)},
+  ${event.exitCode === undefined ? "NULL" : Number(event.exitCode)},
+  ${sqlValue(event.scheduleName)},
+  ${sqlJson(payload)}
+);`,
+    "COMMIT;",
+  ].join("\n");
+  runSqlite(handle.sqlitePath, handle.dbPath, sql, { runner: handle.runner, env: process.env });
+  return true;
+}
+
+// Reap prior schedule runs directly in SQLite when the DB is available. Returns
+// the reaped run ids so the caller can also mirror them into JSONL.
+export function reapScheduleRunsInDb(handle, scheduleName, { exceptRunId, time = new Date().toISOString() }: { exceptRunId?: string; time?: string } = {}) {
+  if (!handle || !scheduleName) return [];
+  const prior = query(handle.sqlitePath, handle.dbPath, [
+    ".mode tabs",
+    `SELECT run_id FROM relaymux_runs WHERE schedule_name = '${escapeSql(scheduleName)}'`,
+    exceptRunId ? ` AND run_id <> '${escapeSql(exceptRunId)}'` : "",
+    ";",
+  ].join(""), { runner: handle.runner, env: process.env });
+  const runIds = prior.split("\n").map((line) => line.trim()).filter(Boolean);
+  const reaped = [];
+  for (const runId of runIds) {
+    const event = {
+      time,
+      runId,
+      event: "reaped",
+      message: "superseded by schedule relaunch",
+      reason: "schedule-reuse",
+      scheduleName,
+    };
+    insertEventInDb(handle, event);
+    reaped.push(event);
+  }
+  return reaped;
 }
 
 function findExecutable(command, env) {

--- a/src/launch/lock.ts
+++ b/src/launch/lock.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ensureDirectory } from "../paths.js";
+
+// Best-effort critical-section lock so two simultaneous schedule ticks (or a
+// tick racing a manual relaunch) cannot both create a tmux window for the same
+// schedule. Uses atomic mkdir as the lock primitive with a short bounded retry.
+//
+// This is local single-machine coordination only; it is not a distributed lock.
+// A stale lock directory older than the TTL is reclaimed so a crashed process
+// does not wedge the schedule forever.
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_POLL_MS = 25;
+const DEFAULT_STALE_TTL_MS = 60_000;
+
+export function withScheduleLock({ stateDir, scheduleName, windowName, timeoutMs = DEFAULT_TIMEOUT_MS, pollMs = DEFAULT_POLL_MS, staleTtlMs = DEFAULT_STALE_TTL_MS, now = Date.now }, fn) {
+  if (!scheduleName) return fn();
+  const lockDir = scheduleLockPath(stateDir, scheduleName, windowName);
+  ensureDirectory(path.dirname(lockDir));
+  const deadline = now() + timeoutMs;
+  let acquired = false;
+  try {
+    while (now() < deadline) {
+      if (tryAcquireLock(lockDir, staleTtlMs, now)) {
+        acquired = true;
+        break;
+      }
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, pollMs);
+    }
+    if (!acquired) {
+      // Last resort: proceed without the lock rather than dropping the launch.
+      // The window-replacement logic still targets the stable schedule window,
+      // so a rare race can at worst produce a transient duplicate that the next
+      // tick reaps.
+    }
+    return fn();
+  } finally {
+    if (acquired) releaseLock(lockDir);
+  }
+}
+
+export function scheduleLockPath(stateDir, scheduleName, windowName) {
+  const safe = String(windowName || scheduleName)
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "schedule";
+  return path.join(stateDir, "locks", `schedule-${safe}.lock`);
+}
+
+function tryAcquireLock(lockDir, staleTtlMs, now) {
+  try {
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "owner"), String(process.pid));
+    return true;
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+    // Reclaim stale locks from crashed processes.
+    try {
+      const stat = fs.statSync(lockDir);
+      if (now() - stat.mtimeMs > staleTtlMs) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+        try {
+          fs.mkdirSync(lockDir);
+          fs.writeFileSync(path.join(lockDir, "owner"), String(process.pid));
+          return true;
+        } catch {
+          return false;
+        }
+      }
+    } catch {}
+    return false;
+  }
+}
+
+function releaseLock(lockDir) {
+  try {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  } catch {}
+}

--- a/src/launch/names.ts
+++ b/src/launch/names.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 
 export function sanitizeLaunchName(value) {
   return String(value)
@@ -10,5 +11,34 @@ export function sanitizeLaunchName(value) {
 
 export function makeRunId() {
   return `run-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+}
+
+// tmux window names live in the `session:name` target namespace, where a `.` or
+// `:` in the name would be parsed as a pane/index separator. Schedule names are
+// valid identifiers but may contain `.`, so map the schedule name to a safe
+// stable tmux window name while keeping it recognizable. When sanitization
+// changes the name (information loss, e.g. dots collapsed to dashes), append a
+// short hash so two distinct schedules cannot collapse onto the same window.
+export function scheduleWindowName(scheduleName) {
+  const original = String(scheduleName || "").trim();
+  const sanitized = original
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 72)
+    .replace(/^-+|-+$/g, "") || "schedule";
+  if (sanitized === original || !original) return sanitized;
+  const hash = createHash("sha1").update(original).digest("hex").slice(0, 6);
+  return `${sanitized.slice(0, 64)}-${hash}`;
+}
+
+export function sanitizeScheduleName(value) {
+  const name = String(value || "").trim();
+  if (!name) {
+    throw new Error("Missing schedule name");
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(name)) {
+    throw new Error(`Invalid schedule name "${name}". Use letters, numbers, dots, underscores, and dashes, starting with a letter or number.`);
+  }
+  return name;
 }
 

--- a/src/launch/tmux.ts
+++ b/src/launch/tmux.ts
@@ -1,7 +1,9 @@
-import { createCommandWindow, setWindowMetadata } from "../tmux.js";
-import { recordRun } from "../state.js";
+import { createCommandWindow, killWindowByTarget, listAgentWindows, setWindowMetadata } from "../tmux.js";
+import { recordRun, reapScheduleRuns } from "../state.js";
 
 import { prepareLaunchArtifacts } from "./artifacts.js";
+import { scheduleWindowName } from "./names.js";
+import { withScheduleLock } from "./lock.js";
 
 export function launchTmuxAgent(request) {
   const sessionInfo = request.sessionInfo;
@@ -9,10 +11,16 @@ export function launchTmuxAgent(request) {
     throw new Error("tmux launch requires a resolved session");
   }
 
-  const artifacts = prepareLaunchArtifacts(request, { writeFiles: !request.dryRun });
+  const reuse = resolveScheduleReuse(request);
+  const launchName = reuse ? reuse.windowName : request.name;
+  const artifactsRequest = reuse ? { ...request, name: launchName } : request;
+  const artifacts = prepareLaunchArtifacts(artifactsRequest, { writeFiles: !request.dryRun });
 
   if (request.dryRun) {
     request.io.stdout.write(`# tmux session: ${sessionInfo.session} (${sessionInfo.mode}; ${sessionInfo.source})\n`);
+    if (reuse) {
+      request.io.stdout.write(`# schedule: ${reuse.scheduleName} (reusing persistent window ${reuse.windowName})\n`);
+    }
     if (request.worktreeAddArgs) {
       request.io.stdout.write(`worktree: ${request.quoteArgv(["git", ...request.worktreeAddArgs])}\n`);
     }
@@ -26,45 +34,82 @@ export function launchTmuxAgent(request) {
     request.io.stdout.write(`${artifacts.shellCommand}\n`);
   }
 
-  const target = createCommandWindow({
-    session: sessionInfo.session,
-    name: request.name,
-    cwd: request.workdir,
-    shellCommand: artifacts.shellCommand,
-  });
+  const placeWindow = () => {
+    if (reuse) {
+      const priorWindows = listAgentWindows({ session: sessionInfo.session })
+        .filter((window) => window.scheduleName === reuse.scheduleName || window.windowName === reuse.windowName);
+      for (const window of priorWindows) {
+        killWindowByTarget(window.target);
+      }
+      reapScheduleRuns(request.stateDir, reuse.scheduleName, { exceptRunId: request.runId });
+    }
 
-  const started = new Date().toISOString();
-  setWindowMetadata(target.windowTarget, {
-    relaymux: "1",
-    relaymux_agent: request.agentName,
-    relaymux_name: request.name,
-    relaymux_repo: request.repo,
-    relaymux_run_id: request.runId,
-    relaymux_session: sessionInfo.session,
-    relaymux_session_mode: sessionInfo.mode,
-    relaymux_started: started,
-  });
-  recordRun(request.stateDir, {
-    time: started,
-    runId: request.runId,
-    session: sessionInfo.session,
-    sessionMode: sessionInfo.mode,
-    sessionSource: sessionInfo.source,
-    target: target.target,
-    windowTarget: target.windowTarget,
-    name: request.name,
-    agent: request.agentName,
-    repo: request.repo,
-    workdir: request.workdir,
-    promptFile: artifacts.promptFile,
-    scriptFile: artifacts.scriptFile,
-    command: artifacts.shellCommand,
-  });
+    const target = createCommandWindow({
+      session: sessionInfo.session,
+      name: launchName,
+      cwd: request.workdir,
+      shellCommand: artifacts.shellCommand,
+    });
 
-  request.io.stdout.write(`Started ${request.name} in tmux session ${sessionInfo.session} tab ${target.windowTarget} (target ${target.target})\n`);
-  request.io.stdout.write(`Run ID: ${request.runId}\n`);
-  if (request.attach) {
-    request.io.stdout.write(`Attach with: tmux attach -t ${sessionInfo.session}\n`);
+    const started = new Date().toISOString();
+    setWindowMetadata(target.windowTarget, {
+      relaymux: "1",
+      relaymux_agent: request.agentName,
+      relaymux_name: launchName,
+      relaymux_repo: request.repo,
+      relaymux_run_id: request.runId,
+      relaymux_session: sessionInfo.session,
+      relaymux_session_mode: sessionInfo.mode,
+      relaymux_started: started,
+      ...(reuse ? { relaymux_schedule: reuse.scheduleName } : {}),
+    });
+    recordRun(request.stateDir, {
+      time: started,
+      runId: request.runId,
+      session: sessionInfo.session,
+      sessionMode: sessionInfo.mode,
+      sessionSource: sessionInfo.source,
+      target: target.target,
+      windowTarget: target.windowTarget,
+      name: launchName,
+      agent: request.agentName,
+      repo: request.repo,
+      workdir: request.workdir,
+      promptFile: artifacts.promptFile,
+      scriptFile: artifacts.scriptFile,
+      command: artifacts.shellCommand,
+      ...(reuse ? { scheduleName: reuse.scheduleName } : {}),
+    });
+
+    if (reuse) {
+      request.io.stdout.write(`Reused schedule ${reuse.scheduleName} window ${reuse.windowName} for ${request.runId}\n`);
+    }
+    request.io.stdout.write(`Started ${launchName} in tmux session ${sessionInfo.session} tab ${target.windowTarget} (target ${target.target})\n`);
+    request.io.stdout.write(`Run ID: ${request.runId}\n`);
+    if (request.attach) {
+      request.io.stdout.write(`Attach with: tmux attach -t ${sessionInfo.session}\n`);
+    }
+    return { target, ...artifacts };
+  };
+
+  if (reuse) {
+    return withScheduleLock(
+      { stateDir: request.stateDir, scheduleName: reuse.scheduleName, windowName: reuse.windowName },
+      placeWindow,
+    );
   }
-  return { target, ...artifacts };
+  return placeWindow();
+}
+
+// Scheduled (recurring, named) launches reuse one persistent tmux window per
+// schedule instead of accumulating a new tab every tick. Reuse is active when a
+// schedule name is available (from --schedule-name or the RELAYMUX_SCHEDULE_NAME
+// env the daemon sets for scheduled orchestrator runs) and the caller has not
+// disabled it with --no-reuse-window. One-off `relaymux launch` calls keep the
+// current per-launch tab behavior.
+function resolveScheduleReuse(request) {
+  const scheduleName = request.scheduleName || "";
+  if (!scheduleName) return null;
+  if (request.reuseWindow === false) return null;
+  return { scheduleName, windowName: scheduleWindowName(scheduleName) };
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -8,6 +8,13 @@ import { resolveStateDir, resolveTokenFile } from "./config.js";
 import { defaultRelaymuxHome, expandPath, ensureDirectory, pathExists, readTextFile } from "./paths.js";
 import { runCommandAsync } from "./async-process.js";
 
+export function scheduleNameFromSource(source) {
+  const value = String(source || "").trim();
+  if (!value.startsWith("schedule:")) return "";
+  const name = value.slice("schedule:".length).trim();
+  return /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(name) ? name : "";
+}
+
 export function buildIncomingOrchestratorPrompt({ config, configPath, incomingText }) {
   return buildFullPrompt({
     config,
@@ -78,7 +85,7 @@ export function buildFullPrompt({ config, configPath, title, body }) {
   ].filter((part) => String(part || "").trim()).join("\n\n");
 }
 
-export async function runOrchestrator(config, { prompt, stateDir, configPath, requestId }) {
+export async function runOrchestrator(config, { prompt, stateDir, configPath, requestId, scheduleName = "" }) {
   const orchestrator = config.orchestrator || {};
   const promptFile = writeOrchestratorPrompt(stateDir, requestId || makeRequestId(), prompt);
   const cwd = expandPath(orchestrator.cwd || "~");
@@ -105,6 +112,13 @@ export async function runOrchestrator(config, { prompt, stateDir, configPath, re
   };
   if (config.tmux?.sessionMode === "shared") {
     env.RELAYMUX_SESSION = config.session || "agents";
+  }
+  // When a scheduled prompt triggers this orchestrator run, expose the stable
+  // schedule name so any `relaymux launch` invoked by the orchestrator can reuse
+  // one persistent tmux window per schedule instead of piling up a new tab per
+  // tick. The env inherits into the orchestrator's child processes.
+  if (scheduleName) {
+    env.RELAYMUX_SCHEDULE_NAME = scheduleName;
   }
 
   const result = await runCommandAsync(invocation.argv[0], invocation.argv.slice(1), {

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,6 +2,18 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { ensureDirectory } from "./paths.js";
+import { insertEventInDb, resolveStateDb, upsertRunInDb, reapScheduleRunsInDb } from "./db.js";
+
+function dbHandleFromStateDir(stateDir) {
+  if (!stateDir) return null;
+  const home = path.dirname(stateDir);
+  const dbPath = path.join(home, "relaymux.sqlite3");
+  try {
+    return resolveStateDb({ dbPath });
+  } catch {
+    return null;
+  }
+}
 
 export function writePromptFile(stateDir, runId, prompt) {
   const dir = path.join(stateDir, "prompts");
@@ -21,10 +33,20 @@ export function writeScriptFile(stateDir, runId, script) {
 
 export function recordRun(stateDir, run) {
   appendJsonl(path.join(stateDir, "runs.jsonl"), run);
+  try {
+    upsertRunInDb(dbHandleFromStateDir(stateDir), run);
+  } catch {
+    // SQLite mirroring is best-effort; JSONL remains the compatibility source.
+  }
 }
 
 export function recordEvent(stateDir, event) {
   appendJsonl(path.join(stateDir, "events.jsonl"), event);
+  try {
+    insertEventInDb(dbHandleFromStateDir(stateDir), event);
+  } catch {
+    // SQLite mirroring is best-effort; JSONL remains the compatibility source.
+  }
 }
 
 export function readRuns(stateDir) {
@@ -41,6 +63,58 @@ export function latestEventsByRun(stateDir) {
     latest.set(event.runId, event);
   }
   return latest;
+}
+
+// Mark every prior run record for a schedule as reaped so `relaymux status`
+// stops showing zombie rows for superseded ticks. Only runs without an existing
+// terminal event (completed/reaped) are touched, and the current runId is kept.
+export function reapScheduleRuns(stateDir, scheduleName, { exceptRunId, time = new Date().toISOString() }: { exceptRunId?: string; time?: string } = {}) {
+  if (!scheduleName) return [];
+  const handle = dbHandleFromStateDir(stateDir);
+  // Prefer reaping in SQLite (canonical) when available, and mirror the same
+  // events into JSONL for status/compatibility. Fall back to JSONL-only reaping.
+  let dbReaped: any[] = [];
+  if (handle) {
+    try {
+      dbReaped = reapScheduleRunsInDb(handle, scheduleName, { exceptRunId, time });
+    } catch {
+      dbReaped = [];
+    }
+  }
+
+  const events = readEvents(stateDir);
+  const terminal = new Set(
+    events
+      .filter((event) => event.event === "completed" || event.event === "reaped")
+      .map((event) => event.runId),
+  );
+  const reaped = [];
+  for (const event of dbReaped) {
+    if (terminal.has(event.runId)) continue;
+    appendJsonl(path.join(stateDir, "events.jsonl"), event);
+    reaped.push(event);
+  }
+
+  for (const run of readRuns(stateDir)) {
+    if (run.scheduleName !== scheduleName) continue;
+    if (exceptRunId && run.runId === exceptRunId) continue;
+    if (terminal.has(run.runId)) continue;
+    if (reaped.some((event) => event.runId === run.runId)) continue;
+    const event = {
+      time,
+      runId: run.runId,
+      event: "reaped",
+      message: "superseded by schedule relaunch",
+      reason: "schedule-reuse",
+      scheduleName,
+    };
+    appendJsonl(path.join(stateDir, "events.jsonl"), event);
+    try {
+      insertEventInDb(handle, event);
+    } catch {}
+    reaped.push(event);
+  }
+  return reaped;
 }
 
 function appendJsonl(file, value) {

--- a/src/status.ts
+++ b/src/status.ts
@@ -110,11 +110,14 @@ function daemonStatus(config, configPath, env = process.env, platform = process.
 
 function statusRow(run: StatusRun, window: StatusRun | undefined, latestEvent: StatusEvent | undefined) {
   const completed = latestEvent?.event === "completed";
+  const reaped = latestEvent?.event === "reaped";
   const state = completed
     ? `completed:${latestEvent.exitCode ?? ""}`
-    : window
-      ? "running"
-      : "window-missing";
+    : reaped
+      ? "reaped"
+      : window
+        ? "running"
+        : "window-missing";
   const target = window?.target || run.windowTarget || run.target || "";
 
   return {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -14,6 +14,7 @@ const WINDOW_FORMAT = [
   "#{@relaymux_repo}",
   "#{@relaymux_name}",
   "#{@relaymux_started}",
+  "#{@relaymux_schedule}",
 ].join(WINDOW_FIELD_SEPARATOR);
 
 export function validateSessionName(session) {
@@ -69,7 +70,11 @@ function createWindow({ session, name, cwd, shellCommand = undefined }) {
 
 export function killWindowByName({ session, name }) {
   validateSessionName(session);
-  const result = runCommand("tmux", ["kill-window", "-t", `${session}:${name}`], { allowFailure: true });
+  return killWindowByTarget(`${session}:${name}`);
+}
+
+export function killWindowByTarget(target) {
+  const result = runCommand("tmux", ["kill-window", "-t", String(target)], { allowFailure: true });
   return result.status === 0;
 }
 
@@ -169,6 +174,7 @@ function parseWindowLine(line) {
     repo,
     name,
     started,
+    scheduleName,
   ] = line.split(WINDOW_FIELD_SEPARATOR);
 
   return {
@@ -184,6 +190,7 @@ function parseWindowLine(line) {
     repo,
     name,
     started,
+    scheduleName,
     target: `${session}:${windowIndex}`,
   };
 }

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -81,13 +81,14 @@ test("SQLite migrations are idempotent through the sqlite runner boundary", () =
   const first = initRelaymuxDb({ dbPath, sqlitePath: "/fake/sqlite3", runCommand: runner, env: { PATH: "" } });
   const second = initRelaymuxDb({ dbPath, sqlitePath: "/fake/sqlite3", runCommand: runner, env: { PATH: "" } });
 
-  assert.deepEqual(first.applied.map((migration) => migration.name), ["core_metadata", "runs_events"]);
+  assert.deepEqual(first.applied.map((migration) => migration.name), ["core_metadata", "runs_events", "runs_schedule"]);
   assert.deepEqual(second.applied, []);
-  assert.equal(first.currentVersion, 2);
-  assert.equal(second.currentVersion, 2);
+  assert.equal(first.currentVersion, 3);
+  assert.equal(second.currentVersion, 3);
   assert.ok(calls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS relaymux_metadata")));
   assert.ok(calls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS relaymux_runs")));
   assert.ok(calls.some((sql) => sql.includes("CREATE TABLE IF NOT EXISTS relaymux_events")));
+  assert.ok(calls.some((sql) => sql.includes("ALTER TABLE relaymux_runs ADD COLUMN schedule_name")));
   assert.ok(stdios.every((stdio) => Array.isArray(stdio) && stdio[0] === "pipe"));
 });
 
@@ -101,7 +102,7 @@ test("DB status reports pending migrations for an existing uninitialized DB", ()
 
   assert.equal(status.exists, true);
   assert.equal(status.initialized, false);
-  assert.deepEqual(status.pending.map((migration) => migration.name), ["core_metadata", "runs_events"]);
+  assert.deepEqual(status.pending.map((migration) => migration.name), ["core_metadata", "runs_events", "runs_schedule"]);
 });
 
 test("expected schema includes first-party relaymux tables", () => {

--- a/test/launch-lock.test.ts
+++ b/test/launch-lock.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { withScheduleLock, scheduleLockPath } from "../src/launch/lock.js";
+
+test("scheduleLockPath derives a safe lock directory from the schedule/window name", () => {
+  const stateDir = "/tmp/state";
+  assert.equal(
+    scheduleLockPath(stateDir, "personal-digest-hourly", "personal-digest-hourly"),
+    path.join(stateDir, "locks", "schedule-personal-digest-hourly.lock"),
+  );
+  // unsafe characters are collapsed
+  assert.equal(
+    scheduleLockPath(stateDir, "nightly.build", "nightly-build-e2ee6b"),
+    path.join(stateDir, "locks", "schedule-nightly-build-e2ee6b.lock"),
+  );
+});
+
+test("withScheduleLock runs the critical section and releases the lock", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-lock-basic-"));
+  const stateDir = path.join(root, "state");
+  let ran = false;
+  const result = withScheduleLock(
+    { stateDir, scheduleName: "daily", windowName: "daily" },
+    () => {
+      ran = true;
+      assert.equal(fs.existsSync(scheduleLockPath(stateDir, "daily", "daily")), true);
+      return "done";
+    },
+  );
+  assert.equal(ran, true);
+  assert.equal(result, "done");
+  assert.equal(fs.existsSync(scheduleLockPath(stateDir, "daily", "daily")), false);
+});
+
+test("withScheduleLock without a schedule name does not lock", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-lock-none-"));
+  const stateDir = path.join(root, "state");
+  let ran = false;
+  withScheduleLock({ stateDir, scheduleName: "", windowName: "" }, () => { ran = true; });
+  assert.equal(ran, true);
+  assert.equal(fs.existsSync(path.join(stateDir, "locks")), false);
+});
+
+test("withScheduleLock reclaims a stale lock older than the TTL", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-lock-stale-"));
+  const stateDir = path.join(root, "state");
+  const lockDir = scheduleLockPath(stateDir, "daily", "daily");
+  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+  fs.mkdirSync(lockDir);
+  fs.writeFileSync(path.join(lockDir, "owner"), "999999");
+
+  // Backdate the lock directory so it is older than the TTL.
+  const stale = new Date(Date.now() - 120_000);
+  fs.utimesSync(lockDir, stale, stale);
+
+  let ran = false;
+  withScheduleLock(
+    { stateDir, scheduleName: "daily", windowName: "daily", timeoutMs: 200, staleTtlMs: 60_000 },
+    () => { ran = true; },
+  );
+  assert.equal(ran, true);
+  assert.equal(fs.existsSync(lockDir), false);
+});
+
+test("withScheduleLock serializes overlapping critical sections", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-lock-serial-"));
+  const stateDir = path.join(root, "state");
+  const lockDir = scheduleLockPath(stateDir, "daily", "daily");
+  const order: string[] = [];
+
+  // Simulate two "processes" by using setTimeout-based critical sections and
+  // awaiting both. The second must wait until the first releases.
+  const run = (label: string, holdMs: number) => new Promise<void>((resolve) => {
+    withScheduleLock({ stateDir, scheduleName: "daily", windowName: "daily", timeoutMs: 2000, pollMs: 10 }, () => {
+      order.push(`${label}:enter`);
+      // Busy-wait synchronously to hold the lock; use a synchronous spin so the
+      // mkdir lock stays held across this tick.
+      const end = Date.now() + holdMs;
+      while (Date.now() < end) { /* hold */ }
+      order.push(`${label}:exit`);
+    });
+    // withScheduleLock is synchronous; resolve on next tick.
+    setImmediate(resolve);
+  });
+
+  const p1 = run("a", 60);
+  const p2 = run("b", 10);
+  await Promise.all([p1, p2]);
+
+  // Both entered and exited, and b did not enter while a held the lock.
+  assert.deepEqual(order, ["a:enter", "a:exit", "b:enter", "b:exit"]);
+  assert.equal(fs.existsSync(lockDir), false);
+});

--- a/test/schedule-reuse.test.ts
+++ b/test/schedule-reuse.test.ts
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { quoteArgv } from "../src/command.js";
+import { launchTmuxAgent } from "../src/launch/tmux.js";
+import { scheduleWindowName, sanitizeScheduleName } from "../src/launch/names.js";
+import { reapScheduleRuns, readRuns, readEvents, latestEventsByRun } from "../src/state.js";
+import { scheduleNameFromSource } from "../src/orchestrator.js";
+
+// Build a fake `tmux` executable on PATH that logs every invocation and returns
+// a stable window target for new-window/new-session so launchTmuxAgent can run
+// end-to-end without a real tmux server.
+function makeFakeTmux(root: string) {
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir);
+  const logFile = path.join(root, "tmux.log");
+  const windowState = path.join(root, "window.exists");
+  fs.writeFileSync(
+    path.join(binDir, "tmux"),
+    `#!/bin/sh
+{
+  printf 'CALL\\n'
+  for arg in "$@"; do printf 'ARG:%s\\n' "$arg"; done
+  printf 'END\\n'
+} >> ${JSON.stringify(logFile)}
+if [ "$1" = "list-windows" ]; then
+  if [ -f ${JSON.stringify(windowState)} ]; then
+    printf 'agents<|relaymux|>2<|relaymux|>personal-digest-hourly<|relaymux|>0<|relaymux|>1<|relaymux|>/tmp<|relaymux|>1<|relaymux|>run-old<|relaymux|>custom<|relaymux|>/tmp<|relaymux|>personal-digest-hourly<|relaymux|>2025-01-01T00:00:00Z<|relaymux|>personal-digest-hourly\\n'
+  fi
+  exit 0
+fi
+if [ "$1" = "has-session" ]; then exit 0; fi
+if [ "$1" = "new-window" ] || [ "$1" = "new-session" ]; then
+  touch ${JSON.stringify(windowState)}
+  printf 'agents:2.0\\n'
+  exit 0
+fi
+if [ "$1" = "kill-window" ]; then
+  rm -f ${JSON.stringify(windowState)}
+  exit 0
+fi
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  return { binDir, logFile };
+}
+
+function makeLaunchRequest({ root, stateDir, name, runId, scheduleName, reuseWindow }: {
+  root: string;
+  stateDir: string;
+  name: string;
+  runId: string;
+  scheduleName?: string;
+  reuseWindow?: boolean;
+}) {
+  let stdout = "";
+  return {
+    request: {
+      agentConfig: { command: ["/usr/bin/true"], promptMode: "none" },
+      agentName: "custom",
+      attach: false,
+      cliPath: "/usr/local/bin/relaymux.js",
+      configPath: path.join(root, "config.json"),
+      dryRun: false,
+      holdOnExit: false,
+      io: { stdout: { write: (chunk: string) => { stdout += String(chunk); } } },
+      launchNotification: undefined,
+      name,
+      printCommand: false,
+      prompt: "noop",
+      quoteArgv,
+      repo: root,
+      runId,
+      scheduleName,
+      reuseWindow,
+      session: "agents",
+      sessionInfo: { session: "agents", mode: "shared", source: "config.session" },
+      stateDir,
+      workdir: root,
+      worktreeAddArgs: undefined,
+    },
+    get stdout() { return stdout; },
+  };
+}
+
+function withFakeTmux<T>(fn: (logFile: string) => T): T {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reuse-"));
+  const { binDir, logFile } = makeFakeTmux(root);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${originalPath || ""}`;
+  try {
+    return fn(logFile);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+}
+
+test("scheduleWindowName maps a schedule name to a stable tmux-safe window name", () => {
+  assert.equal(scheduleWindowName("personal-digest-hourly"), "personal-digest-hourly");
+  // dots are collapsed to dashes so they cannot be parsed as pane separators;
+  // when sanitization changes the name, a short hash keeps distinct schedules
+  // from collapsing onto the same window.
+  assert.equal(scheduleWindowName("nightly.build"), "nightly-build-e2ee6b");
+  assert.equal(scheduleWindowName("  "), "schedule");
+});
+
+test("sanitizeScheduleName validates schedule identifiers", () => {
+  assert.equal(sanitizeScheduleName("daily-check"), "daily-check");
+  assert.throws(() => sanitizeScheduleName("daily check"), /Invalid schedule name/);
+  assert.throws(() => sanitizeScheduleName(""), /Missing schedule name/);
+});
+
+test("scheduleNameFromSource extracts schedule names from schedule: sources", () => {
+  assert.equal(scheduleNameFromSource("schedule:personal-digest-hourly"), "personal-digest-hourly");
+  assert.equal(scheduleNameFromSource("terminal"), "");
+  assert.equal(scheduleNameFromSource("schedule:"), "");
+  assert.equal(scheduleNameFromSource("schedule:bad name"), "");
+});
+
+test("scheduled launch reuses one persistent window name instead of the per-tick name", () => {
+  withFakeTmux((logFile) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reuse-run-"));
+    const stateDir = path.join(root, "state");
+    const harness = makeLaunchRequest({
+      root,
+      stateDir,
+      name: "personal-digest-20250115-0800",
+      runId: "run-tick-1",
+      scheduleName: "personal-digest-hourly",
+    });
+
+    launchTmuxAgent(harness.request);
+
+    const calls = fs.readFileSync(logFile, "utf8");
+    // The created window must be named after the schedule, not the per-tick name.
+    assert.match(calls, /ARG:new-window/);
+    assert.match(calls, /ARG:-n\nARG:personal-digest-hourly/);
+    assert.doesNotMatch(calls, /ARG:personal-digest-20250115-0800/);
+    // The first tick has no prior window to kill.
+    assert.doesNotMatch(calls, /ARG:kill-window/);
+    assert.match(harness.stdout, /Reused schedule personal-digest-hourly window personal-digest-hourly/);
+  });
+});
+
+test("two consecutive schedule ticks leave exactly one kill + one create, and the second reaps the first", () => {
+  withFakeTmux((logFile) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reuse-two-"));
+    const stateDir = path.join(root, "state");
+
+    const tick1 = makeLaunchRequest({
+      root,
+      stateDir,
+      name: "personal-digest-20250115-0800",
+      runId: "run-tick-1",
+      scheduleName: "personal-digest-hourly",
+    });
+    launchTmuxAgent(tick1.request);
+
+    const tick2 = makeLaunchRequest({
+      root,
+      stateDir,
+      name: "personal-digest-20250115-0900",
+      runId: "run-tick-2",
+      scheduleName: "personal-digest-hourly",
+    });
+    launchTmuxAgent(tick2.request);
+
+    const calls = fs.readFileSync(logFile, "utf8");
+    // Exactly one kill-window (the second tick superseding the first) and two
+    // new-window calls (one per tick), both targeting the stable schedule name.
+    const killCount = (calls.match(/ARG:kill-window\nARG:-t\nARG:agents:2/g) || []).length;
+    const createCount = (calls.match(/ARG:new-window/g) || []).length;
+    assert.equal(killCount, 1);
+    assert.equal(createCount, 2);
+
+    // Run records: two runs, both keyed to the schedule, stable name.
+    const runs = readRuns(stateDir);
+    assert.equal(runs.length, 2);
+    assert.equal(runs[0].scheduleName, "personal-digest-hourly");
+    assert.equal(runs[0].name, "personal-digest-hourly");
+    assert.equal(runs[1].scheduleName, "personal-digest-hourly");
+    assert.equal(runs[1].name, "personal-digest-hourly");
+
+    // The first run is reaped by the second tick; the current run is not.
+    const latest = latestEventsByRun(stateDir);
+    assert.equal(latest.get("run-tick-1")?.event, "reaped");
+    assert.equal(latest.get("run-tick-2"), undefined);
+  });
+});
+
+test("one-off launches without a schedule name keep unique-tab behavior and never kill or reap", () => {
+  withFakeTmux((logFile) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reuse-oneoff-"));
+    const stateDir = path.join(root, "state");
+    const harness = makeLaunchRequest({
+      root,
+      stateDir,
+      name: "ad-hoc-task",
+      runId: "run-adhoc",
+    });
+
+    launchTmuxAgent(harness.request);
+
+    const calls = fs.readFileSync(logFile, "utf8");
+    assert.match(calls, /ARG:new-window/);
+    assert.match(calls, /ARG:-n\nARG:ad-hoc-task/);
+    assert.doesNotMatch(calls, /ARG:kill-window/);
+    assert.doesNotMatch(harness.stdout, /Reused schedule/);
+
+    const runs = readRuns(stateDir);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].scheduleName, undefined);
+    assert.equal(runs[0].name, "ad-hoc-task");
+  });
+});
+
+test("--no-reuse-window opts out of persistent reuse even with a schedule name", () => {
+  withFakeTmux((logFile) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reuse-optout-"));
+    const stateDir = path.join(root, "state");
+    const harness = makeLaunchRequest({
+      root,
+      stateDir,
+      name: "personal-digest-20250115-0800",
+      runId: "run-optout",
+      scheduleName: "personal-digest-hourly",
+      reuseWindow: false,
+    });
+
+    launchTmuxAgent(harness.request);
+
+    const calls = fs.readFileSync(logFile, "utf8");
+    assert.match(calls, /ARG:-n\nARG:personal-digest-20250115-0800/);
+    assert.doesNotMatch(calls, /ARG:kill-window/);
+    assert.doesNotMatch(harness.stdout, /Reused schedule/);
+    const runs = readRuns(stateDir);
+    assert.equal(runs[0].scheduleName, undefined);
+  });
+});
+
+test("reapScheduleRuns only reaps prior runs of the same schedule and skips terminal ones", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reap-"));
+  const stateDir = path.join(root, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  // Two prior runs for the same schedule, one already completed.
+  const runs = [
+    { runId: "r1", scheduleName: "daily", name: "daily", time: "2025-01-01T08:00:00Z" },
+    { runId: "r2", scheduleName: "daily", name: "daily", time: "2025-01-01T09:00:00Z" },
+    { runId: "r3", scheduleName: "other", name: "other", time: "2025-01-01T09:00:00Z" },
+  ];
+  for (const run of runs) {
+    fs.appendFileSync(path.join(stateDir, "runs.jsonl"), `${JSON.stringify(run)}\n`);
+  }
+  // r1 already has a completed event.
+  fs.appendFileSync(path.join(stateDir, "events.jsonl"), `${JSON.stringify({ runId: "r1", event: "completed", time: "2025-01-01T08:05:00Z" })}\n`);
+
+  const reaped = reapScheduleRuns(stateDir, "daily", { exceptRunId: "r-current" });
+
+  // Only r2 is reaped (r1 already completed, r3 is a different schedule).
+  assert.equal(reaped.length, 1);
+  assert.equal(reaped[0].runId, "r2");
+  assert.equal(reaped[0].event, "reaped");
+
+  const latest = latestEventsByRun(stateDir);
+  assert.equal(latest.get("r1")?.event, "completed");
+  assert.equal(latest.get("r2")?.event, "reaped");
+  assert.equal(latest.get("r3"), undefined);
+});
+
+test("scheduled launch dry-run reports the persistent window without touching tmux", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-reuse-dry-"));
+  const stateDir = path.join(root, "state");
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir);
+  const tmuxPath = path.join(binDir, "tmux");
+  fs.writeFileSync(tmuxPath, `#!/bin/sh\necho "should-not-run" >> ${JSON.stringify(path.join(root, "tmux.log"))}\nexit 0\n`, { mode: 0o755 });
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${originalPath || ""}`;
+  try {
+    let stdout = "";
+    launchTmuxAgent({
+      agentConfig: { command: ["/usr/bin/true"], promptMode: "none" },
+      agentName: "custom",
+      attach: false,
+      cliPath: "/usr/local/bin/relaymux.js",
+      configPath: path.join(root, "config.json"),
+      dryRun: true,
+      holdOnExit: false,
+      io: { stdout: { write: (chunk: string) => { stdout += String(chunk); } } },
+      launchNotification: undefined,
+      name: "personal-digest-20250115-0800",
+      printCommand: false,
+      prompt: "noop",
+      quoteArgv,
+      repo: root,
+      runId: "run-dry",
+      scheduleName: "personal-digest-hourly",
+      reuseWindow: true,
+      session: "agents",
+      sessionInfo: { session: "agents", mode: "shared", source: "config.session" },
+      stateDir,
+      workdir: root,
+      worktreeAddArgs: undefined,
+    } as any);
+
+    assert.match(stdout, /# schedule: personal-digest-hourly \(reusing persistent window personal-digest-hourly\)/);
+    assert.equal(fs.existsSync(path.join(root, "tmux.log")), false);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});

--- a/test/state-db.test.ts
+++ b/test/state-db.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+
+import { initRelaymuxDb, relaymuxDbStatus } from "../src/db.js";
+import { recordRun, recordEvent, reapScheduleRuns, readRuns, readEvents } from "../src/state.js";
+
+const SQLITE_AVAILABLE = (() => {
+  try {
+    return spawnSync("sqlite3", ["--version"]).status === 0;
+  } catch {
+    return false;
+  }
+})();
+
+function setupRealDb(root: string) {
+  const home = path.join(root, "home");
+  const dbPath = path.join(home, "relaymux.sqlite3");
+  const stateDir = path.join(home, "state");
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+  initRelaymuxDb({ dbPath, env: { PATH: process.env.PATH || "" } });
+  return { home, dbPath, stateDir };
+}
+
+function queryDb(dbPath: string, sql: string): string {
+  const result = spawnSync("sqlite3", ["-batch", dbPath], {
+    input: sql,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`sqlite3 query failed: ${String(result.stderr || result.stdout)}`);
+  }
+  return String(result.stdout || "");
+}
+
+test("DB status reports the new runs_schedule migration after init", { skip: !SQLITE_AVAILABLE }, () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-statedb-status-"));
+  const { dbPath } = setupRealDb(root);
+  const status = relaymuxDbStatus({ dbPath, env: { PATH: process.env.PATH || "" } });
+  assert.equal(status.initialized, true);
+  assert.equal(status.currentVersion, 3);
+  assert.deepEqual(status.pending, []);
+});
+
+test("recordRun and recordEvent mirror into the SQLite store when available", { skip: !SQLITE_AVAILABLE }, () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-statedb-mirror-"));
+  const { dbPath, stateDir } = setupRealDb(root);
+
+  recordRun(stateDir, {
+    time: "2026-01-01T00:00:00Z",
+    runId: "run-1",
+    session: "agents",
+    name: "personal-digest-hourly",
+    agent: "custom",
+    scheduleName: "personal-digest-hourly",
+  });
+  recordEvent(stateDir, { time: "2026-01-01T00:00:01Z", runId: "run-1", event: "started" });
+
+  const runRow = queryDb(dbPath, "SELECT run_id, schedule_name FROM relaymux_runs WHERE run_id = 'run-1';").trim();
+  assert.match(runRow, /run-1\|personal-digest-hourly/);
+  const eventCount = Number(queryDb(dbPath, "SELECT COUNT(*) FROM relaymux_events WHERE run_id = 'run-1';").trim());
+  assert.ok(eventCount >= 1);
+  // JSONL compatibility files are still written.
+  assert.equal(readRuns(stateDir).length, 1);
+  assert.equal(readEvents(stateDir).length, 1);
+});
+
+test("reapScheduleRuns mirrors reaped events into SQLite and JSONL", { skip: !SQLITE_AVAILABLE }, () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-statedb-reap-"));
+  const { dbPath, stateDir } = setupRealDb(root);
+
+  recordRun(stateDir, { time: "t1", runId: "r1", name: "s", scheduleName: "daily" });
+  recordRun(stateDir, { time: "t2", runId: "r2", name: "s", scheduleName: "daily" });
+
+  const reaped = reapScheduleRuns(stateDir, "daily", { exceptRunId: "r-current" });
+
+  assert.equal(reaped.length, 2);
+  assert.ok(reaped.every((e) => e.event === "reaped"));
+  const reapedCount = Number(queryDb(dbPath, "SELECT COUNT(*) FROM relaymux_events WHERE event = 'reaped';").trim());
+  assert.ok(reapedCount >= 2);
+  const jsonlReaped = readEvents(stateDir).filter((e) => e.event === "reaped");
+  assert.equal(jsonlReaped.length, 2);
+});
+
+test("state mirroring is best-effort and never throws when sqlite3 is absent", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-statedb-noop-"));
+  const stateDir = path.join(root, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const originalPath = process.env.PATH;
+  process.env.PATH = "";
+  try {
+    assert.doesNotThrow(() => recordRun(stateDir, { time: "t", runId: "r", name: "n" }));
+    assert.doesNotThrow(() => recordEvent(stateDir, { time: "t", runId: "r", event: "started" }));
+    assert.doesNotThrow(() => reapScheduleRuns(stateDir, "daily", { exceptRunId: "r" }));
+    assert.equal(readRuns(stateDir).length, 1);
+    assert.equal(readEvents(stateDir).length, 1);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});


### PR DESCRIPTION
## Summary
Recurring scheduled launches now reuse one persistent tmux window per schedule instead of accumulating a new tab every tick. Each tick replaces the previous run in the same schedule-named tab and marks the superseded run record reaped, so `relaymux status` shows one current run per schedule rather than a growing pile of `personal-digest-YYYYMMDD-HHMM` zombies.

- Scheduled launches default to persistent reuse; one-off `relaymux launch` calls keep unique-tab behavior.
- Superseded runs are reaped in both the JSONL compatibility store and the canonical SQLite run/event tables.

## Design
### Schedule identity propagation
- `src/orchestrator.ts` — `scheduleNameFromSource()` extracts the schedule name from a `schedule:<name>` source. `runOrchestrator()` now accepts `scheduleName` and sets `RELAYMUX_SCHEDULE_NAME` in the orchestrator subprocess env, which inherits into the orchestrator's `relaymux launch` children.
- `src/daemon.ts` — `processTerminalRequestJob` derives the schedule name from `job.source` and passes it to `runOrchestrator`, so scheduled `ask --no-wait` runs surface the schedule identity to delegated launches.

### Persistent window reuse
- `src/launch/tmux.ts` — `launchTmuxAgent()` resolves schedule reuse (`resolveScheduleReuse`): when a schedule name is present and reuse is not disabled, it derives a stable window name, replaces any existing window matching `@relaymux_schedule` metadata or the stable name, sets `@relaymux_schedule`, and records the run with `scheduleName`. The kill+create+record critical section runs under a per-schedule lock.
- `src/launch/names.ts` — `scheduleWindowName()` maps a schedule name to a tmux-safe stable window name (collapses `.`/`:` to dashes, appends a short hash when sanitization loses information). `sanitizeScheduleName()` validates the identifier.
- `src/launch/lock.ts` — `withScheduleLock()` uses atomic `mkdir` as a local critical-section lock with stale-lock reclamation so two simultaneous ticks cannot both create a window for the same schedule.
- `src/cli.ts` — `handleLaunch` reads `--schedule-name` / `RELAYMUX_SCHEDULE_NAME` and `--reuse-window` / `--no-reuse-window` and passes them through. Help text documents the new flags.

### Run record persistence (SQLite + JSONL)
- `src/db.ts` — migration v3 `runs_schedule` adds `schedule_name` to `relaymux_runs`/`relaymux_events`. `resolveStateDb()`, `upsertRunInDb()`, `insertEventInDb()`, and `reapScheduleRunsInDb()` mirror run/event records into the canonical SQLite store, no-oping gracefully when sqlite3/DB is unavailable.
- `src/state.ts` — `recordRun`/`recordEvent`/`reapScheduleRuns` now mirror into SQLite when available while keeping JSONL as the compatibility source. `reapScheduleRuns` marks prior same-schedule runs with a terminal `reaped` event.
- `src/status.ts` — `reaped` is treated as a terminal state so reaped runs no longer show as `running`/`window-missing`.

### tmux window metadata
- `src/tmux.ts` — `WINDOW_FORMAT` and `parseWindowLine` carry `@relaymux_schedule`. `killWindowByTarget()` is extracted for exact-target replacement.

### Tests
- `test/schedule-reuse.test.ts` — stable window naming, per-tick name override, two consecutive ticks leave one kill + one create with the first reaped, one-off launches never kill/reap, `--no-reuse-window` opt-out, dry-run reporting, `reapScheduleRuns` skip semantics.
- `test/launch-lock.test.ts` — lock path derivation, basic acquire/release, no-lock passthrough, stale-lock reclamation, serialized overlapping critical sections.
- `test/state-db.test.ts` — SQLite mirror of runs/events, reap mirroring, migration v3 status, and best-effort no-op when sqlite3 is absent.
- `test/db.test.ts` — updated for the v3 migration.

## Validation
- `npm run validate` (tsc --noEmit + `tsx --test test/*.test.ts` + build): green. 157/157 tests pass, lint clean, build succeeds.
- No existing tmux tabs/windows were killed during this work; leftover digest tabs remain a separate cleanup per the task boundaries.
- The live CLI/LaunchAgent was not reinstalled or restarted.
