### PR TITLE
Split orchestrator system prompt from user turn, inject --system-prompt automatically

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -15,7 +15,7 @@ import {
   timedStage,
 } from "./daemon-jobs.js";
 import { createCompletionWebhookServer } from "./webhook.js";
-import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorPrompt, runOrchestrator } from "./orchestrator.js";
+import { buildIncomingOrchestratorParts, buildIncomingOrchestratorPrompt, buildTerminalOrchestratorParts, buildTerminalOrchestratorPrompt, buildWebhookOrchestratorParts, buildWebhookOrchestratorPrompt, joinPromptParts, runOrchestrator } from "./orchestrator.js";
 import { formatIncomingForPrompt, isImessageReceiveEnabled, isIncomingUserMessage, receiveMessages, sendMessage } from "./message-io.js";
 import { isTelegramReceiveEnabled, receiveTelegramMessages, sendTelegramMessage } from "./telegram.js";
 import { ensureDirectory } from "./paths.js";
@@ -105,12 +105,13 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     };
 
     try {
-      const prompt = buildIncomingOrchestratorPrompt({
+      const parts = buildIncomingOrchestratorParts({
         config,
         configPath: configInfo.path,
         incomingText: formatIncomingForPrompt(job.messages, job.adapter),
       });
-      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
+      const prompt = joinPromptParts(parts);
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, promptParts: parts, stateDir, configPath: configInfo.path, requestId: job.requestId }));
       await timedStage(metrics, "adapterSendMs", () => sendReply(config, job.replyMode || "imessage", reply, io));
       markSeen();
       log(`replied to ${job.ids.join(",")} via ${job.replyMode || "imessage"}`);
@@ -135,8 +136,9 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     log(formatLatencyLogLine("job_start", startLatencyFields(metrics)));
     let status = "ok";
     try {
-      const prompt = buildWebhookOrchestratorPrompt({ config, configPath: configInfo.path, job });
-      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
+      const parts = buildWebhookOrchestratorParts({ config, configPath: configInfo.path, job });
+      const prompt = joinPromptParts(parts);
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, promptParts: parts, stateDir, configPath: configInfo.path, requestId: job.requestId }));
       if (job.replyMode === "none") {
         log(`processed quiet completion ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
       } else {
@@ -164,8 +166,9 @@ export async function runDaemon({ flags, configInfo, stateDir, io = defaultIo() 
     log(formatLatencyLogLine("job_start", startLatencyFields(metrics)));
     let status = "ok";
     try {
-      const prompt = buildTerminalOrchestratorPrompt({ config, configPath: configInfo.path, job });
-      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, stateDir, configPath: configInfo.path, requestId: job.requestId }));
+      const parts = buildTerminalOrchestratorParts({ config, configPath: configInfo.path, job });
+      const prompt = joinPromptParts(parts);
+      const reply = await timedStage(metrics, "orchestratorMs", () => runOrchestrator(config, { prompt, promptParts: parts, stateDir, configPath: configInfo.path, requestId: job.requestId }));
       if (job.replyMode === "none") {
         log(`processed terminal request ${job.requestId}: ${oneLine(reply).slice(0, 240)}`);
       } else {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -9,7 +9,13 @@ import { defaultRelaymuxHome, expandPath, ensureDirectory, pathExists, readTextF
 import { runCommandAsync } from "./async-process.js";
 
 export function buildIncomingOrchestratorPrompt({ config, configPath, incomingText }) {
-  return buildFullPrompt({
+  return joinPromptParts(
+    buildIncomingOrchestratorParts({ config, configPath, incomingText }),
+  );
+}
+
+export function buildIncomingOrchestratorParts({ config, configPath, incomingText }) {
+  return buildPromptParts({
     config,
     configPath,
     title: "Incoming iMessage/SMS adapter turn",
@@ -18,6 +24,10 @@ export function buildIncomingOrchestratorPrompt({ config, configPath, incomingTe
 }
 
 export function buildWebhookOrchestratorPrompt({ config, configPath, job }) {
+  return joinPromptParts(buildWebhookOrchestratorParts({ config, configPath, job }));
+}
+
+export function buildWebhookOrchestratorParts({ config, configPath, job }) {
   const metadataText = Object.keys(job.metadata || {}).length
     ? `\nMetadata JSON:\n${JSON.stringify(job.metadata, null, 2)}`
     : "";
@@ -26,7 +36,7 @@ export function buildWebhookOrchestratorPrompt({ config, configPath, job }) {
     ? "Reply mode is none: process this local update as context only. The daemon will not send a user-visible adapter message, so return a short internal acknowledgement."
     : `Reply mode is ${job.replyMode}: produce one concise user-visible adapter update. Avoid spam and mention only meaningful completion, failure, or blockers.`;
 
-  return buildFullPrompt({
+  return buildPromptParts({
     config,
     configPath,
     title: "Local subagent completion/update",
@@ -35,6 +45,10 @@ export function buildWebhookOrchestratorPrompt({ config, configPath, job }) {
 }
 
 export function buildTerminalOrchestratorPrompt({ config, configPath, job }) {
+  return joinPromptParts(buildTerminalOrchestratorParts({ config, configPath, job }));
+}
+
+export function buildTerminalOrchestratorParts({ config, configPath, job }) {
   const metadataText = Object.keys(job.metadata || {}).length
     ? `\nMetadata JSON:\n${JSON.stringify(job.metadata, null, 2)}`
     : "";
@@ -42,7 +56,7 @@ export function buildTerminalOrchestratorPrompt({ config, configPath, job }) {
     ? "Reply mode is none: do the requested work and return one concise terminal-visible status. The daemon will not send an adapter message."
     : `Reply mode is ${job.replyMode}: do the requested work, then produce one concise user-visible adapter status. The daemon will also return the same text to the terminal command.`;
 
-  return buildFullPrompt({
+  return buildPromptParts({
     config,
     configPath,
     title: "Terminal request",
@@ -50,7 +64,7 @@ export function buildTerminalOrchestratorPrompt({ config, configPath, job }) {
   });
 }
 
-export function buildFullPrompt({ config, configPath, title, body }) {
+export function buildPromptParts({ config, configPath, title, body }) {
   const daemon = config.daemon || {};
   const homeDir = resolveRelaymuxHome(config);
   const system = [
@@ -71,20 +85,36 @@ export function buildFullPrompt({ config, configPath, title, body }) {
     webhookUrl,
   });
 
-  return [
-    system,
-    runtime,
-    `# ${title}\n\n${body}`,
-  ].filter((part) => String(part || "").trim()).join("\n\n");
+  const systemPrompt = [system, runtime].filter((part) => String(part || "").trim()).join("\n\n");
+  const userPrompt = `# ${title}\n\n${body}`;
+  return { systemPrompt, userPrompt, full: [systemPrompt, userPrompt].filter((part) => String(part || "").trim()).join("\n\n") };
 }
 
-export async function runOrchestrator(config, { prompt, stateDir, configPath, requestId }) {
+export function buildFullPrompt({ config, configPath, title, body }) {
+  return joinPromptParts(buildPromptParts({ config, configPath, title, body }));
+}
+
+export function joinPromptParts({ full }) {
+  return full;
+}
+
+export async function runOrchestrator(config, { prompt, promptParts, stateDir, configPath, requestId }) {
   const orchestrator = config.orchestrator || {};
-  const promptFile = writeOrchestratorPrompt(stateDir, requestId || makeRequestId(), prompt);
+  const parts = promptParts
+    ? { systemPrompt: promptParts.systemPrompt || "", userPrompt: promptParts.userPrompt || prompt }
+    : { systemPrompt: "", userPrompt: prompt };
+  const id = requestId || makeRequestId();
+  const promptFile = writeOrchestratorPrompt(stateDir, id, parts.userPrompt, "");
+  const systemPromptFile = parts.systemPrompt
+    ? writeOrchestratorPrompt(stateDir, id, parts.systemPrompt, ".system")
+    : "";
+  const command = injectSystemPromptIntoCommand(orchestrator.command, systemPromptFile);
   const cwd = expandPath(orchestrator.cwd || "~");
-  const invocation = buildAgentInvocation("orchestrator", orchestrator, {
-    prompt,
+  const invocation = buildAgentInvocation("orchestrator", { ...orchestrator, command }, {
+    prompt: parts.userPrompt,
     promptFile,
+    systemPrompt: parts.systemPrompt,
+    systemPromptFile,
     configPath,
     session: config.session || "agents",
     tokenFile: resolveTokenFile(config),
@@ -93,7 +123,7 @@ export async function runOrchestrator(config, { prompt, stateDir, configPath, re
     repo: cwd,
     workdir: cwd,
     name: "orchestrator",
-    runId: requestId || "orchestrator",
+    runId: id,
   });
 
   const input = invocation.stdinFile ? fs.readFileSync(invocation.stdinFile, "utf8") : undefined;
@@ -122,10 +152,23 @@ export async function runOrchestrator(config, { prompt, stateDir, configPath, re
   return result.stdout.trim() || result.stderr.trim() || "Done.";
 }
 
-function writeOrchestratorPrompt(stateDir, requestId, prompt) {
+function injectSystemPromptIntoCommand(command, systemPromptFile) {
+  if (!systemPromptFile || !Array.isArray(command)) return command;
+  const alreadyHasSystemPrompt = command.some(
+    (part) => String(part).includes("{systemPrompt}") || String(part).includes("{systemPromptFile}"),
+  );
+  if (alreadyHasSystemPrompt) return command;
+  const promptIndex = command.findIndex((part) => String(part).includes("{prompt}"));
+  if (promptIndex === -1) return command;
+  const modified = [...command];
+  modified.splice(promptIndex, 0, "--system-prompt", "{systemPromptFile}");
+  return modified;
+}
+
+function writeOrchestratorPrompt(stateDir, requestId, prompt, suffix) {
   const dir = path.join(stateDir, "prompts");
   ensureDirectory(dir);
-  const file = path.join(dir, `${sanitizeFilePart(requestId)}.orchestrator.txt`);
+  const file = path.join(dir, `${sanitizeFilePart(requestId)}.orchestrator${suffix}.txt`);
   fs.writeFileSync(file, prompt);
   return file;
 }

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -55,6 +55,21 @@ test("buildAgentInvocation supports stdin prompt mode", () => {
   assert.equal(invocation.stdinFile, "/tmp/prompt");
 });
 
+test("buildAgentInvocation renders systemPrompt/systemPromptFile placeholders", () => {
+  const invocation = buildAgentInvocation("orchestrator", {
+    command: ["pi", "--print", "--system-prompt", "{systemPromptFile}", "{prompt}"],
+    promptMode: "arg",
+  }, {
+    prompt: "user turn body",
+    promptFile: "/tmp/prompt",
+    systemPrompt: "system text",
+    systemPromptFile: "/tmp/system",
+  });
+
+  assert.deepEqual(invocation.argv, ["pi", "--print", "--system-prompt", "/tmp/system", "user turn body"]);
+  assert.equal(invocation.stdinFile, null);
+});
+
 test("shellExportBlock rejects invalid env keys", () => {
   assert.throws(() => shellExportBlock({ "BAD-KEY": "value" }), /Invalid environment/);
 });

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { defaultConfig } from "../src/config.js";
-import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorPrompt } from "../src/orchestrator.js";
+import { buildIncomingOrchestratorPrompt, buildTerminalOrchestratorParts, buildTerminalOrchestratorPrompt, joinPromptParts, runOrchestrator } from "../src/orchestrator.js";
 
 function terminalJob(overrides: Record<string, any> = {}) {
   return {
@@ -163,4 +163,91 @@ test("orchestrator default system prompt can be disabled", () => {
   assert.match(prompt, /Only this local prompt/);
   assert.match(prompt, /Runtime context:/);
   assert.match(prompt, /# Terminal request/);
+});
+
+test("buildPromptParts splits system prompt from user turn", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-parts-"));
+  const config = defaultConfig({ RELAYMUX_HOME: path.join(dir, "home") });
+  const parts = buildTerminalOrchestratorParts({
+    config,
+    configPath: path.join(dir, "config.json"),
+    job: terminalJob(),
+  });
+
+  assert.match(parts.systemPrompt, /You are a local relaymux orchestrator/);
+  assert.match(parts.systemPrompt, /Runtime context:/);
+  assert.doesNotMatch(parts.systemPrompt, /# Terminal request/);
+  assert.match(parts.userPrompt, /# Terminal request/);
+  assert.doesNotMatch(parts.userPrompt, /You are a local relaymux orchestrator/);
+  assert.equal(
+    joinPromptParts(parts),
+    buildTerminalOrchestratorPrompt({ config, configPath: path.join(dir, "config.json"), job: terminalJob() }),
+  );
+});
+
+test("runOrchestrator writes a separate system prompt file when command uses {systemPromptFile}", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-run-"));
+  const stateDir = path.join(dir, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const config = defaultConfig({ RELAYMUX_HOME: path.join(dir, "home") });
+  config.orchestrator = {
+    ...config.orchestrator,
+    cwd: dir,
+    command: ["/bin/echo", "--system-prompt", "{systemPromptFile}", "{prompt}"],
+    promptMode: "arg",
+  };
+  const parts = buildTerminalOrchestratorParts({
+    config,
+    configPath: path.join(dir, "config.json"),
+    job: terminalJob(),
+  });
+
+  await runOrchestrator(config, {
+    prompt: joinPromptParts(parts),
+    promptParts: parts,
+    stateDir,
+    configPath: path.join(dir, "config.json"),
+    requestId: "req-split",
+  });
+
+  const promptFiles = fs.readdirSync(path.join(stateDir, "prompts"));
+  assert.ok(promptFiles.includes("req-split.orchestrator.txt"), "user prompt file written");
+  assert.ok(promptFiles.includes("req-split.orchestrator.system.txt"), "system prompt file written");
+  const systemFile = fs.readFileSync(path.join(stateDir, "prompts", "req-split.orchestrator.system.txt"), "utf8");
+  const userFile = fs.readFileSync(path.join(stateDir, "prompts", "req-split.orchestrator.txt"), "utf8");
+  assert.match(systemFile, /You are a local relaymux orchestrator/);
+  assert.match(userFile, /# Terminal request/);
+  assert.doesNotMatch(userFile, /You are a local relaymux orchestrator/);
+});
+
+test("runOrchestrator automatically injects system prompt file into any command with {prompt}", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relaymux-orchestrator-auto-"));
+  const stateDir = path.join(dir, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const config = defaultConfig({ RELAYMUX_HOME: path.join(dir, "home") });
+  config.orchestrator = {
+    ...config.orchestrator,
+    cwd: dir,
+    command: ["/bin/echo", "{prompt}"],
+    promptMode: "arg",
+  };
+  const parts = buildTerminalOrchestratorParts({
+    config,
+    configPath: path.join(dir, "config.json"),
+    job: terminalJob(),
+  });
+
+  await runOrchestrator(config, {
+    prompt: joinPromptParts(parts),
+    promptParts: parts,
+    stateDir,
+    configPath: path.join(dir, "config.json"),
+    requestId: "req-auto",
+  });
+
+  const promptFiles = fs.readdirSync(path.join(stateDir, "prompts"));
+  assert.ok(promptFiles.some((f) => f.includes(".system")), "system prompt file written automatically");
+  const userFile = fs.readFileSync(path.join(stateDir, "prompts", "req-auto.orchestrator.txt"), "utf8");
+  assert.doesNotMatch(userFile, /You are a local relaymux orchestrator/);
+  assert.match(userFile, /# Terminal request/);
 });


### PR DESCRIPTION
## Summary

The orchestrator was baking the full system prompt (~10KB of SOUL.md, default orchestrator instructions, runtime context, and extraSystemPrompt) into every user message on every turn. This demoted relaymux instructions to user-role content, bloated context with repeated text, and broke provider prefix caching.

Now `runOrchestrator` automatically splits the assembled prompt into system and user parts, writes the system portion to a separate file, and injects `--system-prompt <file>` into the orchestrator command argv before `{prompt}`. The `{prompt}` placeholder becomes just the new turn body.

- System instructions get system-role authority instead of being demoted to user content
- No more ~10KB of repeated system text injected into every turn's user message
- Stable provider prefix caching (system message is fixed, only user turn body varies)
- Backward compatible — commands without `{systemPromptFile}` placeholders get automatic injection

## Design

### Orchestrator prompt split

- `src/orchestrator.ts` — `buildFullPrompt` refactored to `buildPromptParts`, returning `{ systemPrompt, userPrompt, full }` instead of a single joined string
- `src/orchestrator.ts` — `runOrchestrator` now:
  1. Splits the assembled prompt using `promptParts` from the daemon
  2. Writes system part to `<requestId>.orchestrator.system.txt` and user part to `<requestId>.orchestrator.txt`
  3. Automatically injects `--system-prompt {systemPromptFile}` into argv before `{prompt}` when the command doesn't already reference system prompt placeholders
- `src/orchestrator.ts` — Added `injectSystemPromptIntoCommand` helper that clones the command array and inserts the `--system-prompt` flag before `{prompt}` if not already present
- `src/daemon.ts` — All three orchestrator call sites (incoming, webhook, terminal) now build prompt parts via `build*Parts()` and pass them alongside the joined prompt string to `runOrchestrator`

### Agent command template support

- `src/command.ts` — `buildAgentInvocation` already renders `{systemPromptFile}` and `{systemPrompt}` via `renderTemplate`. No changes needed; the new context keys are available automatically.

### Backward compatibility

- Configs with explicit `--system-prompt {systemPromptFile}` in the orchestrator command keep working (the auto-injection detects the existing placeholder and skips)
- Configs without the placeholder get automatic injection, so orchestrator commands stay simple

## Validation

- `node --test test/orchestrator.test.ts test/command.test.ts` — 17/17 pass
- `npm run validate` — 143/143 tests pass, lint clean, build clean
- Deployed to daemon: daemon started cleanly with simplified config, polling iMessage normally
