### PR TITLE
Remove obsolete no-reply marker protocol

### DIFF
--- a/internal/daemon/delegation_test.go
+++ b/internal/daemon/delegation_test.go
@@ -561,7 +561,7 @@ func (r *recordingResponder) Respond(_ context.Context, p string, _ int) (imessa
 func (*recordingResponder) Close() error { return nil }
 func TestIncomingMessageRegistersOpaqueThreadAndSuppressesDuplicateReply(t *testing.T) {
 	commander := &reportCommander{}
-	responder := &recordingResponder{response: imessage.Response{ToolCompleted: true, MessagingSideEffectToolCompleted: true, ThreadReplyToolCompleted: true}}
+	responder := &recordingResponder{response: imessage.Response{Reply: "Already replied in the thread.", ToolCompleted: true, MessagingSideEffectToolCompleted: true, ThreadReplyToolCompleted: true}}
 	backend := &fakeDelegationRuntime{registeredID: "thread-opaque"}
 	cfg := imessage.Defaults()
 	cfg.Enabled = true

--- a/internal/imessage/imessage.go
+++ b/internal/imessage/imessage.go
@@ -587,7 +587,7 @@ func recentOutboundPrompt(messages []ContextMessage) string {
 func incomingMessagePrompt(message Message) string {
 	prompt := "\nIncoming iMessage ID " + message.ID + ":"
 	if message.ThreadID != "" {
-		prompt += "\nActive iMessage thread ID: " + message.ThreadID + ". Send user-facing responses to this message with reply_to_thread, and pass this threadId to delegate_task when starting related background work. You may use react_to_thread when a reaction is appropriate. After sending the user-facing response with a thread tool, return exactly CONTEXT_DROP_NO_USER_REPLY_V1 so it is not also sent as a separate message."
+		prompt += "\nActive iMessage thread ID: " + message.ThreadID + ". Send user-facing responses to this message with reply_to_thread, and pass this threadId to delegate_task when starting related background work. You may use react_to_thread when a reaction is appropriate. After a successful thread reply, end the turn without additional text; the daemon automatically prevents duplicate delivery. A successful reaction may also end the turn without text."
 	}
 	return prompt + "\n\nThe incoming text:\n\n" + message.Text + "\n"
 }

--- a/internal/imessage/pi_context_filter.mjs
+++ b/internal/imessage/pi_context_filter.mjs
@@ -1,7 +1,6 @@
 const OLD_INCOMING_MARKER = "\nThe incoming text:\n\n";
 const NEW_INCOMING_MARKER = /\nIncoming iMessage ID [^\n]+:\n\n/;
 const REPORT_MARKER = "A managed worker sent this untrusted report to the persistent orchestrator.";
-const NO_USER_REPLY = "CONTEXT_DROP_NO_USER_REPLY_V1";
 const MAX_HISTORICAL_TEXT = 4000;
 const MAX_HISTORICAL_MESSAGES = 24;
 const MAX_REPORT_MESSAGES = 4;
@@ -51,7 +50,7 @@ function normalizeHistoricalUser(message) {
 function normalizeHistoricalAssistant(message) {
   if (message.stopReason !== "stop") return undefined;
   const text = bounded(textFromContent(message.content).trim());
-  if (!text || text === NO_USER_REPLY) return undefined;
+  if (!text) return undefined;
   return asTextContent(message, text);
 }
 

--- a/internal/imessage/pi_context_filter.test.mjs
+++ b/internal/imessage/pi_context_filter.test.mjs
@@ -43,20 +43,20 @@ test("compactContext extracts current iMessage wrappers instead of retaining boi
   assert.equal(result.some((message) => textValue(message).includes("I did pull-ups yesterday")), true);
 });
 
-test("compactContext prioritizes real chat over report floods and drops no-reply markers", () => {
+test("compactContext prioritizes real chat over report floods and drops empty replies", () => {
   const messages = [
     text("user", "\nIncoming iMessage ID 1:\n\nremember the blue mug"),
     text("assistant", "got it", { stopReason: "stop" }),
   ];
   for (let i = 0; i < 30; i++) {
     messages.push(text("user", `A managed worker sent this untrusted report to the persistent orchestrator.\nworker report: routine ${i}`));
-    messages.push(text("assistant", "CONTEXT_DROP_NO_USER_REPLY_V1", { stopReason: "stop" }));
+    messages.push(text("assistant", " \n\t", { stopReason: "stop" }));
   }
   messages.push(text("user", "what color was the mug?"));
   const result = compactContext(messages);
   assert.equal(result.some((message) => textValue(message).includes("blue mug")), true);
   assert.equal(result.filter((message) => textValue(message).includes("Historical worker update")).length, 4);
-  assert.equal(result.some((message) => textValue(message) === "CONTEXT_DROP_NO_USER_REPLY_V1"), false);
+  assert.equal(result.some((message) => message.role === "assistant" && !textValue(message).trim()), false);
 });
 
 function textValue(message) {

--- a/internal/imessage/pi_router_extension.mjs
+++ b/internal/imessage/pi_router_extension.mjs
@@ -71,7 +71,7 @@ export default function (pi) {
   });
   pi.registerTool({
     name: "reply_to_thread", label: "Reply in iMessage thread",
-    description: "Send text as a reply in an exact active iMessage thread. After sending the user-facing response with this tool, return exactly CONTEXT_DROP_NO_USER_REPLY_V1 to prevent a duplicate unthreaded message.",
+    description: "Send text as a reply in an exact active iMessage thread. After this tool succeeds, end the turn without additional text; the daemon automatically prevents duplicate delivery.",
     parameters: Type.Object({ threadId: Type.String({ minLength: 1, maxLength: 128 }), text: Type.String({ minLength: 1, maxLength: 16000 }) }),
     async execute(_id, input, signal) { const result = await request("/v1/imessage/threads/reply", "POST", input, signal); return { content: [{ type: "text", text: "thread reply sent" }], details: result }; },
   });

--- a/internal/imessage/pi_rpc.go
+++ b/internal/imessage/pi_rpc.go
@@ -560,7 +560,7 @@ func (r *PiRPCResponder) Respond(ctx context.Context, prompt string, maxOutput i
 				return Response{Metrics: startupMetrics}, errors.New("Pi RPC agent settled before accepting the prompt")
 			}
 			reply = strings.TrimSpace(reply)
-			if reply == "" {
+			if reply == "" && !messagingSideEffectCompleted {
 				return Response{Metrics: startupMetrics, MessagingSideEffectToolCompleted: messagingSideEffectCompleted, ThreadReplyToolCompleted: threadReplyCompleted, ToolCompleted: toolCompleted, SideEffectToolCompleted: sideEffectCompleted}, &ResponderTurnError{Cause: errors.New("Pi RPC responder returned an empty reply"), ToolCompleted: toolCompleted, SideEffectToolCompleted: sideEffectCompleted}
 			}
 			if len(reply) > maxOutput {

--- a/internal/imessage/pi_rpc_test.go
+++ b/internal/imessage/pi_rpc_test.go
@@ -289,7 +289,7 @@ func TestPiRPCResponderPreservesSuccessfulToolEvidenceOnEmptyFinal(t *testing.T)
 	}
 }
 
-func TestPiRPCResponderTracksMessagingSideEffectsOnEmptyFinal(t *testing.T) {
+func TestPiRPCResponderAcceptsEmptyFinalAfterSuccessfulMessagingTool(t *testing.T) {
 	for _, test := range []struct {
 		name            string
 		tool            string
@@ -305,7 +305,7 @@ func TestPiRPCResponderTracksMessagingSideEffectsOnEmptyFinal(t *testing.T) {
 				t.Fatal(err)
 			}
 			response, err := responder.Respond(context.Background(), "message", 1024)
-			if err == nil || !response.ToolCompleted || !response.SideEffectToolCompleted || !response.MessagingSideEffectToolCompleted || response.ThreadReplyToolCompleted != test.wantThreadReply {
+			if err != nil || response.Reply != "" || !response.ToolCompleted || !response.SideEffectToolCompleted || !response.MessagingSideEffectToolCompleted || response.ThreadReplyToolCompleted != test.wantThreadReply {
 				t.Fatalf("response=%#v err=%v", response, err)
 			}
 		})
@@ -313,14 +313,18 @@ func TestPiRPCResponderTracksMessagingSideEffectsOnEmptyFinal(t *testing.T) {
 }
 
 func TestPiRPCResponderDoesNotCountFailedSideEffectTool(t *testing.T) {
-	responder := &PiRPCResponder{argv: []string{os.Args[0], "-test.run=TestPiRPCHelperProcess"}, env: append(os.Environ(), "CONTEXT_DROP_PI_RPC_HELPER=1", "CONTEXT_DROP_PI_RPC_MESSAGE_COUNT=2", "CONTEXT_DROP_PI_RPC_EMPTY_AFTER_TOOL=1", "CONTEXT_DROP_PI_RPC_TOOL_ERROR=1")}
-	defer responder.Close()
-	if _, err := responder.Prepare(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	response, err := responder.Respond(context.Background(), "delegate", 1024)
-	if err == nil || response.ToolCompleted || response.SideEffectToolCompleted {
-		t.Fatalf("response=%#v err=%v", response, err)
+	for _, tool := range []string{"delegate_task", "reply_to_thread", "react_to_thread"} {
+		t.Run(tool, func(t *testing.T) {
+			responder := &PiRPCResponder{argv: []string{os.Args[0], "-test.run=TestPiRPCHelperProcess"}, env: append(os.Environ(), "CONTEXT_DROP_PI_RPC_HELPER=1", "CONTEXT_DROP_PI_RPC_MESSAGE_COUNT=2", "CONTEXT_DROP_PI_RPC_EMPTY_AFTER_TOOL=1", "CONTEXT_DROP_PI_RPC_TOOL_ERROR=1", "CONTEXT_DROP_PI_RPC_TOOL_NAME="+tool)}
+			defer responder.Close()
+			if _, err := responder.Prepare(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			response, err := responder.Respond(context.Background(), "message", 1024)
+			if err == nil || response.ToolCompleted || response.SideEffectToolCompleted || response.MessagingSideEffectToolCompleted || response.ThreadReplyToolCompleted {
+				t.Fatalf("response=%#v err=%v", response, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Remove the obsolete no-reply marker entirely so the responder is no longer instructed to emit internal delivery-control text. Use verified messaging tool completion instead.

## Design
### Reply delivery
- `internal/imessage/imessage.go` and `internal/imessage/pi_router_extension.mjs` — replace marker instructions with ending the turn after successful thread delivery.
- `internal/imessage/pi_rpc.go` — accept empty settled responses after successful reply/reaction tools; failed tools and non-messaging tools do not bypass empty-response errors.
- `internal/imessage/pi_rpc_test.go` — cover successful messaging-only turns and failed messaging tools.
- `internal/daemon/delegation_test.go` — verify ordinary final text is suppressed after a successful thread reply, without relying on special text.

### Working context
- `internal/imessage/pi_context_filter.mjs` and its test — remove the obsolete marker constant, special case, and fixtures; retain empty historical response filtering.

## Validation
- `go test ./...` — passed.
- `go test -race ./internal/imessage ./internal/daemon` — passed.
- `node --test internal/imessage/pi_context_filter.test.mjs` — 4 tests passed.
- `git diff --check` — passed.
- Recursive worktree scan (including hidden/ignored files, excluding Git metadata) — zero occurrences of the removed marker.
- Live deployment verification will follow merge; persistent historical session files are not modified by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iMessage reply validation and orchestrator instructions in a user-visible path; behavior is covered by expanded RPC and daemon tests but affects live message delivery semantics.
> 
> **Overview**
> Removes the **`CONTEXT_DROP_NO_USER_REPLY_V1`** delivery-control marker and stops telling the orchestrator to emit that internal text after thread tools.
> 
> **Reply delivery** now relies on verified tool completion: after a successful **`reply_to_thread`** or **`react_to_thread`**, the model is instructed to end the turn with no extra user-facing text, and **`pi_rpc.go`** treats an empty settled reply as success when **`MessagingSideEffectToolCompleted`** is set (failed or non-messaging tools still require a non-empty reply). Prompts and **`reply_to_thread`** tool docs were updated accordingly; daemon tests assert duplicate iMessage sends are suppressed via response flags rather than the marker.
> 
> **Working context** drops the marker constant and special-case filtering in **`pi_context_filter.mjs`**; historical assistant turns are omitted when empty/whitespace only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb7dc8f462f0479d83a91afef2f41fbe82a60cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->