### PR TITLE
Fix scheduled Herdr tab auto-namer

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build && node --test ../internal/imessage/*.test.mjs dist/test/*.test.js",
+    "test": "npm run build && node --test ../internal/imessage/*.test.mjs ../workflows/herdr-tab-namer/*.test.mjs dist/test/*.test.js",
     "validate": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/workflows/herdr-tab-namer/README.md
+++ b/workflows/herdr-tab-namer/README.md
@@ -1,0 +1,19 @@
+# Herdr tab auto-namer
+
+This workflow labels tabs using recent terminal output and a local Ollama-compatible model. It preserves the existing `herdr-tab-auto-namer` schedule's behavior: all workspaces on its configured Herdr socket are eligible.
+
+The script honors `HERDR_BIN`, otherwise prefers `~/.local/bin/herdr`, then falls back to `herdr` on PATH. This avoids launchd selecting an older Homebrew client ahead of the user-installed client. Workspace/tab/pane discovery failures exit nonzero rather than appearing as an empty successful pass.
+
+## Validate
+
+```sh
+node --test workflows/herdr-tab-namer/namer.test.mjs
+```
+
+For a live dry run, use the same environment as the existing schedule and add `--dry-run --once`. The caller must be inside Herdr. Dry runs still query the local model but do not rename tabs or update naming state.
+
+## Install an update
+
+Pause the existing schedule, back up its installed `namer.mjs`, and replace that script with this version. Retain the existing schedule command, socket, model, interval, and state/log directory. Run a live dry run, then resume the schedule and verify a completed pass in `namer.log`.
+
+The installed script currently lives under `~/.context-drop/managed/state/herdr-tab-namer/`; generated logs and naming state must not be committed here.

--- a/workflows/herdr-tab-namer/namer.mjs
+++ b/workflows/herdr-tab-namer/namer.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// Herdr tab auto-namer.
+// Reads every tab across all workspaces, asks a local Ollama model for a
+// short label (or KEEP), and renames tabs whose content has changed.
+//
+// Env:
+//   HERDR_ENV=1
+//   HERDR_SOCKET_PATH=/Users/avyay/.config/herdr/herdr.sock
+//   OLLAMA_HOST=127.0.0.1:11435
+//   OLLAMA_MODEL=qwen3.8:27b-mlx
+//
+// Usage: node namer.mjs [--dry-run] [--once]
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { setInterval as setIntervalFn, setTimeout } from 'node:timers';
+
+const DRY = process.argv.includes('--dry-run');
+const ONCE = process.argv.includes('--once') || !process.env.NAMER_INTERVAL;
+const INTERVAL_MS = 30 * 60 * 1000;
+const OLLAMA_HOST = process.env.OLLAMA_HOST || '127.0.0.1:11435';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen3.8:27b-mlx';
+const READ_LINES = 40;
+const MAX_LABEL_LEN = 30;
+const MAX_WORDS = 5;
+const MIN_WORDS = 1;
+
+const LOG_DIR = dirname(new URL(import.meta.url).pathname);
+const LOG_PATH = join(LOG_DIR, 'namer.log');
+const STATE_PATH = join(LOG_DIR, 'namer-state.json');
+
+// launchd puts Homebrew first on PATH, which may contain an older client.
+const userHerdr = join(homedir(), '.local', 'bin', 'herdr');
+const HERDR_BIN = process.env.HERDR_BIN || (existsSync(userHerdr) ? userHerdr : 'herdr');
+const herdrEnv = {
+  ...process.env,
+  HERDR_ENV: '1',
+  HERDR_SOCKET_PATH: process.env.HERDR_SOCKET_PATH || '/Users/avyay/.config/herdr/herdr.sock',
+};
+
+function herdrOutput(args) {
+  return execFileSync(HERDR_BIN, args, {
+    encoding: 'utf8',
+    env: herdrEnv,
+    timeout: 15000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+function herdr(...args) {
+  const response = JSON.parse(herdrOutput(args));
+  if (response.error) throw new Error(`herdr ${args.join(' ')} failed: ${JSON.stringify(response.error)}`);
+  return response;
+}
+
+function herdrText(...args) {
+  try {
+    return herdrOutput(args);
+  } catch (e) {
+    log(`herdr ${args.join(' ')} failed: ${e.message}`);
+    return '';
+  }
+}
+
+function log(msg) {
+  const ts = new Date().toISOString();
+  const line = `[${ts}] ${msg}`;
+  console.error(line);
+  try {
+    writeFileSync(LOG_PATH, line + '\n', { flag: 'a' });
+  } catch {}
+}
+
+function loadState() {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveState(state) {
+  try {
+    writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+  } catch (e) {
+    log(`saveState failed: ${e.message}`);
+  }
+}
+
+function askOllama(prompt) {
+  const body = JSON.stringify({
+    model: OLLAMA_MODEL,
+    stream: false,
+    think: false,
+    options: { temperature: 0.2, num_predict: 25 },
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You name terminal tabs for a coding agent multiplexer (Herdr). ' +
+          'Given the current tab label, agent status, working directory, and recent terminal output, ' +
+          'reply with EITHER:\n' +
+          '- the single word KEEP (if the current label already describes the work well), or\n' +
+          '- a concise 1-5 word label that describes what the tab is doing.\n' +
+          'Rules: lowercase only, no punctuation, no quotes, no Markdown, no explanation, no trailing period. ' +
+          'Output only the label or KEEP on a single line.',
+      },
+      { role: 'user', content: prompt },
+    ],
+  });
+
+  try {
+    const resp = execFileSync(
+      'curl',
+      [
+        '-sS',
+        '--max-time',
+        '120',
+        `http://${OLLAMA_HOST}/api/chat`,
+        '-H',
+        'Content-Type: application/json',
+        '-d',
+        body,
+      ],
+      { encoding: 'utf8', timeout: 130000, maxBuffer: 4 * 1024 * 1024 },
+    );
+    const parsed = JSON.parse(resp);
+    return (parsed.message?.content || '').trim();
+  } catch (e) {
+    log(`ollama request failed: ${e.message}`);
+    return '';
+  }
+}
+
+function parseLabel(raw) {
+  if (!raw) return null;
+  // Take the first non-empty line.
+  const firstLine = raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)[0];
+  if (!firstLine) return null;
+
+  // KEEP handling: if the response starts with "keep" (case-insensitive) as a
+  // standalone word, treat it as keep.
+  if (/^keep\b/i.test(firstLine)) return 'KEEP';
+
+  // Strip surrounding quotes and stray punctuation.
+  let label = firstLine
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/[.!?,:;]+$/g, '')
+    .trim();
+
+  // Enforce lowercase, allow alphanumeric, spaces, dashes.
+  if (!/^[a-z0-9][a-z0-9 -]*[a-z0-9]$/.test(label) && !/^[a-z0-9]$/.test(label)) return null;
+
+  const words = label.split(/\s+/).filter(Boolean);
+  if (words.length < MIN_WORDS || words.length > MAX_WORDS) return null;
+  if (label.length > MAX_LABEL_LEN) return null;
+
+  return label;
+}
+
+function snapshotTabs() {
+  const wl = herdr('workspace', 'list');
+  const workspaces = wl?.result?.workspaces;
+  if (!Array.isArray(workspaces)) throw new Error('herdr workspace list returned no workspace array');
+  const tabs = [];
+  for (const ws of workspaces) {
+    const tl = herdr('tab', 'list', '--workspace', ws.workspace_id);
+    const pl = herdr('pane', 'list', '--workspace', ws.workspace_id);
+    const tabList = tl?.result?.tabs;
+    const workspacePanes = pl?.result?.panes;
+    if (!Array.isArray(tabList) || !Array.isArray(workspacePanes)) {
+      throw new Error(`herdr tab/pane discovery returned invalid data for ${ws.workspace_id}`);
+    }
+    for (const tab of tabList) {
+      const panes = workspacePanes.filter((p) => p.tab_id === tab.tab_id);
+      // Gather signals from the first pane in the tab.
+      let recentOutput = '';
+      let paneInfo = null;
+      if (panes.length > 0) {
+        paneInfo = panes[0];
+        recentOutput = herdrText(
+          'pane', 'read', paneInfo.pane_id,
+          '--source', 'recent-unwrapped',
+          '--lines', String(READ_LINES),
+          '--format', 'text',
+        );
+      }
+      tabs.push({
+        tab_id: tab.tab_id,
+        workspace_id: ws.workspace_id,
+        workspace_label: ws.label,
+        current_label: tab.label,
+        agent: paneInfo?.agent || null,
+        agent_status: paneInfo?.agent_status || tab.agent_status,
+        cwd: paneInfo?.cwd || null,
+        terminal_title: paneInfo?.terminal_title_stripped || paneInfo?.terminal_title || null,
+        recent_output: recentOutput.slice(-1500),
+      });
+    }
+  }
+  return tabs;
+}
+
+function buildPrompt(tab) {
+  const lines = [];
+  lines.push(`Current label: ${tab.current_label}`);
+  if (tab.agent) lines.push(`Agent: ${tab.agent} (${tab.agent_status})`);
+  else lines.push(`Agent: none (${tab.agent_status})`);
+  if (tab.cwd) lines.push(`Dir: ${tab.cwd}`);
+  if (tab.terminal_title) lines.push(`Terminal: ${tab.terminal_title}`);
+  lines.push('');
+  lines.push('Recent output (last ~40 lines, may be truncated):');
+  const output = tab.recent_output.trim();
+  lines.push(output || '(no output)');
+  lines.push('');
+  lines.push('Reply with KEEP or a 1-5 word label.');
+  return lines.join('\n');
+}
+
+function runPass() {
+  log(`pass start${DRY ? ' (dry-run)' : ''}`);
+  const tabs = snapshotTabs();
+  log(`found ${tabs.length} tabs across workspaces`);
+  const state = loadState();
+  let renamed = 0;
+  let kept = 0;
+  let skipped = 0;
+
+  for (const tab of tabs) {
+    // Skip tabs with no readable output and no agent — nothing to name.
+    if (!tab.recent_output.trim() && !tab.agent) {
+      skipped++;
+      continue;
+    }
+
+    const prompt = buildPrompt(tab);
+    const raw = askOllama(prompt);
+    const parsed = parseLabel(raw);
+
+    if (!parsed) {
+      skipped++;
+      log(`skip (invalid response) tab=${tab.tab_id} label="${tab.current_label}" raw="${raw.slice(0, 60)}"`);
+      continue;
+    }
+
+    if (parsed === 'KEEP') {
+      kept++;
+      log(`keep tab=${tab.tab_id} label="${tab.current_label}"`);
+      continue;
+    }
+
+    // Skip if the model returned the same label we already have.
+    if (parsed === tab.current_label) {
+      kept++;
+      continue;
+    }
+
+    log(`rename tab=${tab.tab_id} "${tab.current_label}" -> "${parsed}"${DRY ? ' (dry-run, not applied)' : ''}`);
+    if (!DRY) {
+      herdr('tab', 'rename', tab.tab_id, parsed);
+      renamed++;
+    } else {
+      renamed++;
+    }
+
+    // Record the new label in state so we can detect churn.
+    state[tab.tab_id] = { label: parsed, ts: new Date().toISOString() };
+  }
+
+  if (!DRY) saveState(state);
+  log(`pass done: renamed=${renamed} kept=${kept} skipped=${skipped}`);
+}
+
+function main() {
+  if (ONCE) {
+    runPass();
+    return;
+  }
+  log(`starting interval mode every ${INTERVAL_MS / 60000}m`);
+  runPass();
+  setIntervalFn(() => {
+    try {
+      runPass();
+    } catch (e) {
+      log(`pass crashed: ${e.message}`);
+    }
+  }, INTERVAL_MS);
+}
+
+try {
+  main();
+} catch (e) {
+  log(`pass failed: ${e.message}`);
+  process.exitCode = 1;
+}

--- a/workflows/herdr-tab-namer/namer.test.mjs
+++ b/workflows/herdr-tab-namer/namer.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, copyFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function runNamer(t, { local, path, override }) {
+  const dir = mkdtempSync(join(tmpdir(), 'herdr-namer-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const script = join(dir, 'namer.mjs');
+  copyFileSync(new URL('./namer.mjs', import.meta.url), script);
+  function client(subdir, body) {
+    const binDir = join(dir, subdir);
+    mkdirSync(binDir, { recursive: true });
+    const bin = join(binDir, 'herdr');
+    writeFileSync(bin, `#!${process.execPath}\n${body}\n`, { mode: 0o755 });
+    return bin;
+  }
+  const env = { ...process.env, HOME: dir, HERDR_ENV: '1' };
+  delete env.HERDR_BIN;
+  delete env.NAMER_INTERVAL;
+  if (local) client('.local/bin', local);
+  if (path) {
+    client('path-bin', path);
+    env.PATH = join(dir, 'path-bin');
+  }
+  if (override) env.HERDR_BIN = client('override-bin', override);
+  return spawnSync(process.execPath, [script, '--once', '--dry-run'], { env, encoding: 'utf8', timeout: 10000 });
+}
+
+const empty = `console.log(JSON.stringify({result:{workspaces:[]}}));`;
+const incompatible = `console.error('client protocol 19 is older than server protocol 22'); process.exit(1);`;
+
+test('prefers the user-installed client over an incompatible PATH client', (t) => {
+  const result = runNamer(t, { local: empty, path: incompatible });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /found 0 tabs/);
+  assert.doesNotMatch(result.stderr, /protocol 19/);
+});
+
+test('respects an explicit HERDR_BIN', (t) => {
+  const result = runNamer(t, { local: incompatible, override: empty });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('falls back to PATH when no user-installed client exists', (t) => {
+  const result = runNamer(t, { path: empty });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const [name, body] of [
+  ['protocol mismatch', incompatible],
+  ['error envelope', `console.log(JSON.stringify({error:{code:'protocol_mismatch'}}));`],
+  ['malformed JSON', `console.log('not JSON');`],
+  ['missing workspaces', `console.log('{}');`],
+  ['invalid tab discovery', `console.log(JSON.stringify(process.argv[2] === 'workspace' ? {result:{workspaces:[{workspace_id:'test-workspace'}]}} : {result:{}}));`],
+]) {
+  test(`${name} fails the process instead of reporting a successful empty pass`, (t) => {
+    const result = runNamer(t, { override: body });
+    assert.equal(result.status, 1, result.stderr);
+    assert.match(result.stderr, /pass failed:/);
+    assert.doesNotMatch(result.stderr, /pass done:|found 0 tabs/);
+  });
+}


### PR DESCRIPTION
## Summary
Fix the scheduled Herdr tab auto-namer selecting an outdated Homebrew client and then silently reporting success when discovery fails. Preserve its existing tab scope, model, and naming behavior.

## Design
### Scheduled workflow
- `workflows/herdr-tab-namer/namer.mjs` — bring the existing external workflow into version control. Honor `HERDR_BIN`, otherwise prefer the user-installed client before PATH. Propagate discovery/rename errors and reject malformed discovery envelopes so failures exit nonzero.
- `workflows/herdr-tab-namer/README.md` — describe testing and updating the existing installed workflow without changing its schedule or socket.
### Regression coverage
- `workflows/herdr-tab-namer/namer.test.mjs` — subprocess tests for binary precedence, explicit override, PATH fallback, protocol mismatch, error envelopes, malformed JSON, and invalid discovery arrays.
- `runtime/package.json` — include workflow regression tests in the existing CI test command.

## Validation
- `node --test workflows/herdr-tab-namer/namer.test.mjs` — 8 passed.
- `cd runtime && npm test` — 108 passed.
- `git diff --check` — passed.
- Live read-only checks: user-installed Herdr reports protocol 22 and successfully discovers configured workspaces; local model endpoint lists the configured model.
- Live dry run and scheduled rename verification pending deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The script renames live Herdr tabs on a schedule and calls a local model; fixes reduce silent failure risk but incorrect renames or Herdr API misuse could still affect multiplexer state.
> 
> **Overview**
> Fixes the scheduled **Herdr tab auto-namer** so launchd no longer picks an outdated Homebrew `herdr` client and then logs a bogus successful empty pass when discovery fails.
> 
> The workflow is added under `workflows/herdr-tab-namer/` as **`namer.mjs`**, matching the existing schedule’s scope (all workspaces on the configured socket, Ollama-based KEEP/rename behavior). **Client resolution** now uses `HERDR_BIN`, then `~/.local/bin/herdr`, then PATH. **Discovery** validates Herdr JSON envelopes and throws on protocol errors, malformed responses, or missing tab/pane arrays so the process exits nonzero instead of reporting `found 0 tabs` / `pass done`.
> 
> **`namer.test.mjs`** covers binary precedence, `HERDR_BIN` override, PATH fallback, and failure modes (protocol mismatch, error envelopes, bad JSON, invalid discovery). **`runtime/package.json`** runs those tests in CI. **`README.md`** documents validation, dry-run, and in-place upgrade of the managed install under `~/.context-drop/managed/state/herdr-tab-namer/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c141def6b6e060c8e94db31e48b8d2bfdfb83e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->